### PR TITLE
Never revert on ovmCREATE*

### DIFF
--- a/packages/ovm/src/contracts/testing-contracts/InvalidOpcodes.sol
+++ b/packages/ovm/src/contracts/testing-contracts/InvalidOpcodes.sol
@@ -1,0 +1,16 @@
+pragma solidity ^0.5.0;
+pragma experimental ABIEncoderV2;
+
+contract InvalidOpcodes {
+    function getCoinbase() public returns (address){
+        return block.coinbase;
+    }
+
+    function getDifficulty() public returns (uint){
+        return block.difficulty;
+    }
+
+    function getBlockNumber() public returns (uint) {
+        return block.number;
+    }
+}

--- a/packages/ovm/test/contracts/execution-manager.call-opcodes.spec.ts
+++ b/packages/ovm/test/contracts/execution-manager.call-opcodes.spec.ts
@@ -25,6 +25,7 @@ import {
   addressToBytes32Address,
   DEFAULT_ETHNODE_GAS_LIMIT,
   didCreateSucceed,
+  gasLimit,
 } from '../helpers'
 import { GAS_LIMIT, OPCODE_WHITELIST_MASK } from '../../src/app'
 import { TransactionReceipt } from 'ethers/providers'
@@ -174,7 +175,7 @@ describe('Execution Manager -- Call opcodes', () => {
       const result = await executionManager.provider.call({
         to: executionManager.address,
         data,
-        gasLimit: 6_700_000,
+        gasLimit,
       })
 
       log.debug(`Result: [${result}]`)
@@ -189,7 +190,7 @@ describe('Execution Manager -- Call opcodes', () => {
       await wallet.sendTransaction({
         to: executionManager.address,
         data,
-        gasLimit: 6_700_000,
+        gasLimit,
       })
 
       const fetchData: string = `${executeCallToCallContractData}${callMethodId}${callContract2Address32}${sloadMethodIdAndParams}`
@@ -197,7 +198,7 @@ describe('Execution Manager -- Call opcodes', () => {
       const result = await executionManager.provider.call({
         to: executionManager.address,
         data: fetchData,
-        gasLimit: 6_700_000,
+        gasLimit,
       })
 
       log.debug(`Result: [${result}]`)
@@ -212,7 +213,7 @@ describe('Execution Manager -- Call opcodes', () => {
       const result = await executionManager.provider.call({
         to: executionManager.address,
         data,
-        gasLimit: 6_700_000,
+        gasLimit,
       })
 
       log.debug(`RESULT: ${result}`)
@@ -231,7 +232,7 @@ describe('Execution Manager -- Call opcodes', () => {
       const result = await executionManager.provider.call({
         to: executionManager.address,
         data,
-        gasLimit: 6_700_000,
+        gasLimit,
       })
 
       log.debug(`RESULT: ${result}`)
@@ -261,7 +262,7 @@ describe('Execution Manager -- Call opcodes', () => {
       await wallet.sendTransaction({
         to: executionManager.address,
         data,
-        gasLimit: 6_700_000,
+        gasLimit,
       })
 
       // Stored in contract 2 via delegate call but accessed via contract 1
@@ -270,7 +271,7 @@ describe('Execution Manager -- Call opcodes', () => {
       const result = await executionManager.provider.call({
         to: executionManager.address,
         data: fetchData,
-        gasLimit: 6_700_000,
+        gasLimit,
       })
 
       log.debug(`Result: [${result}]`)
@@ -284,7 +285,7 @@ describe('Execution Manager -- Call opcodes', () => {
       const contract2Result = await executionManager.provider.call({
         to: executionManager.address,
         data: contract2FetchData,
-        gasLimit: 6_700_000,
+        gasLimit,
       })
 
       log.debug(`Result: [${contract2Result}]`)
@@ -304,14 +305,14 @@ describe('Execution Manager -- Call opcodes', () => {
       await wallet.sendTransaction({
         to: executionManager.address,
         data,
-        gasLimit: 6_700_000,
+        gasLimit,
       })
 
       const contract1FetchData: string = `${executeCallToCallContractData}${callMethodId}${callContractAddress32}${sloadMethodIdAndParams}`
       const contract1Result = await executionManager.provider.call({
         to: executionManager.address,
         data: contract1FetchData,
-        gasLimit: 6_700_000,
+        gasLimit,
       })
 
       log.debug(`Result 1: [${contract1Result}]`)
@@ -326,7 +327,7 @@ describe('Execution Manager -- Call opcodes', () => {
       const contract2Result = await executionManager.provider.call({
         to: executionManager.address,
         data: contract2FetchData,
-        gasLimit: 6_700_000,
+        gasLimit,
       })
 
       log.debug(`Result 2: [${contract2Result}]`)
@@ -341,7 +342,7 @@ describe('Execution Manager -- Call opcodes', () => {
       const contract3Result = await executionManager.provider.call({
         to: executionManager.address,
         data: contract3FetchData,
-        gasLimit: 6_700_000,
+        gasLimit,
       })
 
       log.debug(`Result 3: [${contract3Result}]`)
@@ -365,7 +366,7 @@ describe('Execution Manager -- Call opcodes', () => {
       const result = await executionManager.provider.call({
         to: executionManager.address,
         data,
-        gasLimit: 6_700_000,
+        gasLimit,
       })
 
       log.debug(`Result: [${result}]`)
@@ -379,7 +380,7 @@ describe('Execution Manager -- Call opcodes', () => {
       const result = await executionManager.provider.call({
         to: executionManager.address,
         data,
-        gasLimit: 6_700_000,
+        gasLimit,
       })
 
       log.debug(`Result: [${result}]`)
@@ -394,7 +395,7 @@ describe('Execution Manager -- Call opcodes', () => {
       await executionManager.provider.call({
         to: executionManager.address,
         data,
-        gasLimit: 6_700_000,
+        gasLimit,
       })
     })
 
@@ -405,7 +406,7 @@ describe('Execution Manager -- Call opcodes', () => {
         const res = await executionManager.provider.call({
           to: executionManager.address,
           data,
-          gasLimit: 6_700_000,
+          gasLimit,
         })
       })
     })
@@ -418,43 +419,69 @@ describe('Execution Manager -- Call opcodes', () => {
         await wallet.sendTransaction({
           to: executionManager.address,
           data,
-          gasLimit: 6_700_000,
+          gasLimit,
         })
       })
     })
 
-    it('Fails to create on ovmSTATICCALL to CREATE', async () => {
+    it('Fails to create on ovmSTATICCALL to CREATE -- tx', async () => {
       const data: string = `${executeCallToCallContractData}${staticCallMethodId}${callContract2Address32}${createMethodIdAndData}`
 
       // Note: Send transaction vs call so it is persisted
       const receipt = await wallet.sendTransaction({
         to: executionManager.address,
         data,
-        gasLimit: 6_700_000,
+        gasLimit,
       })
 
-      const creatSucceeded = await didCreateSucceed(
+      const createSucceeded = await didCreateSucceed(
         executionManager,
         receipt.hash
       )
-      creatSucceeded.should.equal(false, 'Create should have failed!')
+      createSucceeded.should.equal(false, 'Create should have failed!')
     })
 
-    it('fails on ovmSTATICCALL to CREATE2', async () => {
+    it('Fails to create on ovmSTATICCALL to CREATE -- call', async () => {
+      const data: string = `${executeCallToCallContractData}${staticCallMethodId}${callContract2Address32}${createMethodIdAndData}`
+
+      const res = await wallet.provider.call({
+        to: executionManager.address,
+        data,
+        gasLimit,
+      })
+
+      const address = remove0x(res)
+      address.should.equal('00'.repeat(32), 'Should be 0 address!')
+    })
+
+    it('fails on ovmSTATICCALL to CREATE2 -- tx', async () => {
       const data: string = `${executeCallToCallContractData}${staticCallMethodId}${callContract2Address32}${create2MethodIdAndData}`
 
       // Note: Send transaction vs call so it is persisted
       const receipt = await wallet.sendTransaction({
         to: executionManager.address,
         data,
-        gasLimit: 6_700_000,
+        gasLimit,
       })
 
-      const creatSucceeded = await didCreateSucceed(
+      const createSucceeded = await didCreateSucceed(
         executionManager,
         receipt.hash
       )
-      creatSucceeded.should.equal(false, 'Create should have failed!')
+      createSucceeded.should.equal(false, 'Create should have failed!')
+    })
+
+    it('fails on ovmSTATICCALL to CREATE2 -- call', async () => {
+      const data: string = `${executeCallToCallContractData}${staticCallMethodId}${callContract2Address32}${create2MethodIdAndData}`
+
+      const res = await wallet.provider.call({
+        to: executionManager.address,
+        data,
+        gasLimit,
+      })
+
+      const address = remove0x(res)
+      address.should.equal('00'.repeat(32), 'Should be 0 address!')
     })
   })
 })

--- a/packages/ovm/test/contracts/execution-manager.code-opcodes.spec.ts
+++ b/packages/ovm/test/contracts/execution-manager.code-opcodes.spec.ts
@@ -26,6 +26,7 @@ import {
   manuallyDeployOvmContract,
   getUnsignedTransactionCalldata,
   DEFAULT_ETHNODE_GAS_LIMIT,
+  gasLimit,
 } from '../helpers'
 import { GAS_LIMIT, OPCODE_WHITELIST_MASK } from '../../src/app'
 
@@ -91,7 +92,7 @@ describe('Execution Manager -- Code-related opcodes', () => {
       const result: string = await executionManager.provider.call({
         to: add0x(executionManager.address),
         data,
-        gasLimit: 6_700_000,
+        gasLimit,
       })
       log.debug(`Resulting size: [${result}]`)
 
@@ -116,7 +117,7 @@ describe('Execution Manager -- Code-related opcodes', () => {
       const codeHash: string = await executionManager.provider.call({
         to: add0x(executionManager.address),
         data,
-        gasLimit: 6_700_000,
+        gasLimit,
       })
       log.debug(`Resulting hash: [${codeHash}]`)
 
@@ -144,7 +145,7 @@ describe('Execution Manager -- Code-related opcodes', () => {
       const code: string = await executionManager.provider.call({
         to: executionManager.address,
         data,
-        gasLimit: 6_700_000_000,
+        gasLimit,
       })
       log.debug(`Resulting code: [${code}]`)
 

--- a/packages/ovm/test/contracts/execution-manager.context-opcodes.spec.ts
+++ b/packages/ovm/test/contracts/execution-manager.context-opcodes.spec.ts
@@ -25,6 +25,7 @@ import {
   bytes32AddressToAddress,
   addressToBytes32Address,
   DEFAULT_ETHNODE_GAS_LIMIT,
+  gasLimit,
 } from '../helpers'
 import { GAS_LIMIT, OPCODE_WHITELIST_MASK } from '../../src/app'
 
@@ -119,7 +120,7 @@ describe('Execution Manager -- Context opcodes', () => {
         await executionManager.provider.call({
           to: executionManager.address,
           data,
-          gasLimit: 6_700_000,
+          gasLimit,
         })
       })
     })
@@ -140,7 +141,7 @@ describe('Execution Manager -- Context opcodes', () => {
       const result = await executionManager.provider.call({
         to: executionManager.address,
         data,
-        gasLimit: 6_700_000,
+        gasLimit,
       })
 
       log.debug(`CALLER result: ${result}`)
@@ -164,7 +165,7 @@ describe('Execution Manager -- Context opcodes', () => {
         await executionManager.provider.call({
           to: executionManager.address,
           data,
-          gasLimit: 6_700_000,
+          gasLimit,
         })
       })
     })
@@ -185,7 +186,7 @@ describe('Execution Manager -- Context opcodes', () => {
       const result = await executionManager.provider.call({
         to: executionManager.address,
         data,
-        gasLimit: 6_700_000,
+        gasLimit,
       })
 
       log.debug(`ADDRESS result: ${result}`)
@@ -213,7 +214,7 @@ describe('Execution Manager -- Context opcodes', () => {
         await executionManager.provider.call({
           to: executionManager.address,
           data,
-          gasLimit: 6_700_000,
+          gasLimit,
         })
       })
     })
@@ -237,7 +238,7 @@ describe('Execution Manager -- Context opcodes', () => {
       const result = await executionManager.provider.call({
         to: executionManager.address,
         data,
-        gasLimit: 6_700_000,
+        gasLimit,
       })
 
       log.debug(`TIMESTAMP result: ${result}`)
@@ -264,7 +265,7 @@ describe('Execution Manager -- Context opcodes', () => {
       const result = await executionManager.provider.call({
         to: executionManager.address,
         data,
-        gasLimit: 6_700_000,
+        gasLimit,
       })
 
       log.debug(`GASLIMIT result: ${result}`)
@@ -294,7 +295,7 @@ describe('Execution Manager -- Context opcodes', () => {
       const result = await executionManager.provider.call({
         to: executionManager.address,
         data,
-        gasLimit: 6_700_000,
+        gasLimit,
       })
 
       log.debug(`QUEUE ORIGIN result: ${result}`)
@@ -325,7 +326,7 @@ describe('Execution Manager -- Context opcodes', () => {
       const result = await executionManager.provider.call({
         to: executionManager.address,
         data,
-        gasLimit: 6_700_000,
+        gasLimit,
       })
 
       log.debug(`QUEUE ORIGIN result: ${result}`)

--- a/packages/ovm/test/contracts/execution-manager.create-opcodes.spec.ts
+++ b/packages/ovm/test/contracts/execution-manager.create-opcodes.spec.ts
@@ -15,7 +15,7 @@ const log = getLogger('execution-manager-create', true)
 
 /* Internal Imports */
 import { OPCODE_WHITELIST_MASK, GAS_LIMIT } from '../../src/app'
-import { DEFAULT_ETHNODE_GAS_LIMIT } from '../helpers'
+import { DEFAULT_ETHNODE_GAS_LIMIT, gasLimit } from '../helpers'
 
 /*********
  * TESTS *
@@ -69,7 +69,7 @@ describe('ExecutionManager -- Create opcodes', () => {
       const result = await executionManager.provider.call({
         to: executionManager.address,
         data,
-        gasLimit: 6_700_000,
+        gasLimit,
       })
 
       log.debug(`Result: [${result}]`)
@@ -90,7 +90,7 @@ describe('ExecutionManager -- Create opcodes', () => {
       const result = await executionManager.provider.call({
         to: purityCheckedExecutioManager.address,
         data,
-        gasLimit: 6_700_000,
+        gasLimit,
       })
 
       log.debug(`Result: [${result}]`)
@@ -113,7 +113,7 @@ describe('ExecutionManager -- Create opcodes', () => {
       const result = await executionManager.provider.call({
         to: executionManager.address,
         data,
-        gasLimit: 6_700_000,
+        gasLimit,
       })
 
       log.debug(`Result: [${result}]`)
@@ -136,7 +136,7 @@ describe('ExecutionManager -- Create opcodes', () => {
       const result = await executionManager.provider.call({
         to: purityCheckedExecutioManager.address,
         data,
-        gasLimit: 6_700_000,
+        gasLimit,
       })
 
       log.debug(`Result: [${result}]`)

--- a/packages/ovm/test/contracts/execution-manager.purity-checking.spec.ts
+++ b/packages/ovm/test/contracts/execution-manager.purity-checking.spec.ts
@@ -16,6 +16,7 @@ import {
   manuallyDeployOvmContract,
   DEFAULT_ETHNODE_GAS_LIMIT,
   manuallyDeployOvmContractReturnReceipt,
+  didCreateSucceed,
 } from '../helpers'
 import { TransactionReceipt } from 'ethers/providers'
 
@@ -50,28 +51,31 @@ describe('Execution Manager -- Purity Checking', () => {
         DummyContract,
         []
       )
-      receipt.status.should.equal(
-        0,
+      const createSucceeded = await didCreateSucceed(
+        executionManager,
+        receipt.transactionHash
+      )
+
+      createSucceeded.should.equal(
+        false,
         `DummyContract.sol should not have been considered pure because it uses storage in its constructor`
       )
     })
     it('should successfully deploy a pure contract', async () => {
-      let failed = false
-      try {
-        await manuallyDeployOvmContract(
-          wallet,
-          provider,
-          executionManager,
-          AddThree,
-          []
-        )
-      } catch (e) {
-        if (e.message.indexOf('revert') >= 0) {
-          failed = true
-        }
-      }
-      failed.should.equal(
-        false,
+      const receipt = await manuallyDeployOvmContractReturnReceipt(
+        wallet,
+        provider,
+        executionManager,
+        AddThree,
+        []
+      )
+      const createSucceeded = await didCreateSucceed(
+        executionManager,
+        receipt.transactionHash
+      )
+
+      createSucceeded.should.equal(
+        true,
         `AddThree.sol contract should have been considered pure`
       )
     })

--- a/packages/ovm/test/contracts/execution-manager.storage-opcodes.spec.ts
+++ b/packages/ovm/test/contracts/execution-manager.storage-opcodes.spec.ts
@@ -12,7 +12,7 @@ import * as SimpleStorage from '../../build/contracts/SimpleStorage.json'
 
 /* Internal Imports */
 import { OPCODE_WHITELIST_MASK, GAS_LIMIT } from '../../src/app'
-import { DEFAULT_ETHNODE_GAS_LIMIT } from '../helpers'
+import { DEFAULT_ETHNODE_GAS_LIMIT, gasLimit } from '../helpers'
 
 const log = getLogger('execution-manager-storage', true)
 
@@ -52,7 +52,7 @@ describe('ExecutionManager -- Storage opcodes', () => {
     const tx = await wallet.sendTransaction({
       to: executionManager.address,
       data,
-      gasLimit: 6_700_000,
+      gasLimit,
     })
 
     const reciept = await provider.getTransactionReceipt(tx.hash)
@@ -94,7 +94,7 @@ describe('ExecutionManager -- Storage opcodes', () => {
       const result = await executionManager.provider.call({
         to: executionManager.address,
         data,
-        gasLimit: 6_700_000,
+        gasLimit,
       })
 
       // It should load the value which we just set

--- a/packages/ovm/test/contracts/revert-test.spec.ts
+++ b/packages/ovm/test/contracts/revert-test.spec.ts
@@ -28,7 +28,7 @@ describe('Revert Test', () => {
   })
 
   describe('Test that revert will blow away modified state from successful sub-calls', async () => {
-    it.only('reverts sub-call state', async () => {
+    it('reverts sub-call state', async () => {
       await revertTestContract.entryPoint()
 
       const a = await revertTestContract.getA()

--- a/packages/ovm/test/contracts/simple-storage.spec.ts
+++ b/packages/ovm/test/contracts/simple-storage.spec.ts
@@ -18,6 +18,7 @@ import {
   getUnsignedTransactionCalldata,
   executeUnsignedEOACall,
   DEFAULT_ETHNODE_GAS_LIMIT,
+  gasLimit,
 } from '../helpers'
 import { CHAIN_ID, GAS_LIMIT, OPCODE_WHITELIST_MASK } from '../../src/app'
 
@@ -118,7 +119,7 @@ describe('SimpleStorage', () => {
       const result = await executionManager.provider.call({
         to: executionManager.address,
         data: add0x(callData),
-        gasLimit: 6_700_000,
+        gasLimit,
       })
       result.should.equal(add0x(value))
     })

--- a/packages/ovm/test/helpers.ts
+++ b/packages/ovm/test/helpers.ts
@@ -28,7 +28,7 @@ import {
 type Signature = [string, string, string]
 
 export const DEFAULT_ETHNODE_GAS_LIMIT = 9_000_000
-
+export const gasLimit = 6_700_000
 const log = getLogger('helpers', true)
 
 /**

--- a/packages/ovm/test/helpers.ts
+++ b/packages/ovm/test/helpers.ts
@@ -272,3 +272,24 @@ export const getTransactionResult = async (
   const receipt = await provider.waitForTransaction(tx.hash)
   return abi.decode([returnType], receipt.logs.pop().data)
 }
+
+/**
+ * Returns whether the provided Create transaction succeeded.
+ *
+ * @param executionManager The ExecutionManager contract.
+ * @param createTxHash The transaction hash in question.
+ * @returns True if there was a successful create in this tx, false otherwise.
+ */
+export const didCreateSucceed = async (
+  executionManager: Contract,
+  createTxHash: string
+): Promise<boolean> => {
+  const receipt = await executionManager.provider.waitForTransaction(
+    createTxHash
+  )
+  return (
+    receipt.logs
+      .map((x) => executionManager.interface.parseLog(x))
+      .filter((x) => x.name === 'CreatedContract').length > 0
+  )
+}


### PR DESCRIPTION
## Description
Makes ExecutionManager.sol always return an address from ovmCREATE and ovmCREATE2. It will be the 0 address if the create failed. This is to make it work how the EVM works currently.

## Metadata
### Fixes
- Fixes # [YAS-171](https://optimists.atlassian.net/browse/YAS-171)

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
