### PR TITLE
Add support for custom solc versions

### DIFF
--- a/packages/solc-transpiler/package.json
+++ b/packages/solc-transpiler/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "@eth-optimism/core-utils": "~0.0.1-alpha.7",
     "@eth-optimism/rollup-dev-tools": "~0.0.1-alpha.7",
+    "require-from-string": "^2.0.2",
     "solc": "^0.5.12"
   },
   "devDependencies": {

--- a/packages/solc-transpiler/src/compiler.ts
+++ b/packages/solc-transpiler/src/compiler.ts
@@ -114,14 +114,12 @@ export const compile = (configJsonString: string, callbacks?: any): string => {
 }
 
 /**
- * Gets the requested version of the solc module.
- * 
- * solc-js provides downloadable versions of itself which can be downloaded and
- * used to compile contracts that require different compiler versions. This
- * function must be synchronous so it can be used in the compilation process
- * which is also synchronous. To achieve this we construct a string of
- * JavaScript which downloads the latest version of solc and run that code using
- * `execSync`
+ * Gets the requested version of the solc module. solc-js provides downloadable
+ * versions of itself which can be downloaded and used to compile contracts that
+ * require different compiler versions. This function must be synchronous so it
+ * can be used in the compilation process which is also synchronous. To achieve
+ * this we construct a string of JavaScript which downloads the latest version
+ * of solc and run that code using `execSync`
  *
  * @param versionString The requested version of solc
  * @returns The requested version of the `solc` module or the latest version

--- a/yarn.lock
+++ b/yarn.lock
@@ -8906,7 +8906,7 @@ require-directory@^2.1.1:
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha1-jGStX9MNqxyXbiNE/+f3kqam30I=
 
-require-from-string@^2.0.0:
+require-from-string@^2.0.0, require-from-string@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
   integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==


### PR DESCRIPTION
## Description

If the required version of solc isn't currently in use solc will [download the required version of itself][1]. Normally you can pass "version" in the the truffle config to trigger this behavior but our truffle version field is already filled with a path to our custom solc compiler. Instead we pass the environment variable `SOLC_VERSION` which triggers it.

Truffle expects `compile` to be synchronous so we can't do anything asynchronous in that function. To get around this we use `execSync` which executes synchronously.

[1]: https://github.com/ethereum/solc-js/blob/5c1280ca2c73dfba58bad21849b16eb1fa5618e5/README.md#using-a-legacy-version

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
