### PR TITLE
Add ability to seamlessly start fullnode in Truffle

### DIFF
--- a/packages/core-db/package.json
+++ b/packages/core-db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/core-db",
-  "version": "0.0.1-alpha.10",
+  "version": "0.0.1-alpha.11",
   "description": "Optimism DB Utils",
   "main": "build/index.js",
   "files": [
@@ -29,7 +29,7 @@
     "url": "https://github.com/ethereum-optimism/optimism-monorepo.git"
   },
   "dependencies": {
-    "@eth-optimism/core-utils": "0.0.1-alpha.10",
+    "@eth-optimism/core-utils": "0.0.1-alpha.11",
     "abstract-leveldown": "^6.2.2",
     "async-lock": "^1.2.2",
     "chai": "^4.2.0",

--- a/packages/core-db/package.json
+++ b/packages/core-db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/core-db",
-  "version": "0.0.1-alpha.9",
+  "version": "0.0.1-alpha.10",
   "description": "Optimism DB Utils",
   "main": "build/index.js",
   "files": [
@@ -29,7 +29,7 @@
     "url": "https://github.com/ethereum-optimism/optimism-monorepo.git"
   },
   "dependencies": {
-    "@eth-optimism/core-utils": "0.0.1-alpha.9",
+    "@eth-optimism/core-utils": "0.0.1-alpha.10",
     "abstract-leveldown": "^6.2.2",
     "async-lock": "^1.2.2",
     "chai": "^4.2.0",

--- a/packages/core-utils/package.json
+++ b/packages/core-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/core-utils",
-  "version": "0.0.1-alpha.10",
+  "version": "0.0.1-alpha.11",
   "description": "Optimism Core Utils",
   "main": "build/index.js",
   "files": [

--- a/packages/core-utils/package.json
+++ b/packages/core-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/core-utils",
-  "version": "0.0.1-alpha.9",
+  "version": "0.0.1-alpha.10",
   "description": "Optimism Core Utils",
   "main": "build/index.js",
   "files": [

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@eth-optimism/docs",
   "private": true,
-  "version": "0.0.1-alpha.10",
+  "version": "0.0.1-alpha.11",
   "description": "Optimism docs",
   "author": "Optimism",
   "license": "MIT",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@eth-optimism/docs",
   "private": true,
-  "version": "0.0.1-alpha.9",
+  "version": "0.0.1-alpha.10",
   "description": "Optimism docs",
   "author": "Optimism",
   "license": "MIT",

--- a/packages/docs/src/core/src/integrating-tests.rst
+++ b/packages/docs/src/core/src/integrating-tests.rst
@@ -49,7 +49,8 @@ Using With Truffle
 
 To use the transpiler with Truffle, set truffle's ``compilers.solc.version`` configuration to ``@eth-optimism/solc-transpiler``, and configure the ``EXECUTION_MANAGER_ADDRESS`` environment variable. 
 
-Currently, Truffle does not provide a clean way to use custom chain IDs, so we have created the ``@eth-optimism/ovm-truffle-provider-wrapper`` library to seamlessly wrap your provider of choice to handle this.
+Currently, Truffle does not provide a clean way to use custom chain IDs, so we have created the ``@eth-optimism/ovm-truffle-provider-wrapper`` package to seamlessly wrap your provider of choice to handle this.
+Note: you will also need to include ``@eth-optimism/rollup-full-node`` as a dependency if you would like to run a full node locally (or use ``ProviderWrapper.wrapProviderAndStartLocalNode(...)``).
 
 example truffle-config.json:
 

--- a/packages/docs/src/core/src/integrating-tests.rst
+++ b/packages/docs/src/core/src/integrating-tests.rst
@@ -56,7 +56,7 @@ example truffle-config.json:
 .. code-block:: json
 
   const HDWalletProvider = require('truffle-hdwallet-provider');
-  const wrapProvider = require('@eth-optimism/ovm-truffle-provider-wrapper');
+  const ProviderWrapper = require("@eth-optimism/ovm-truffle-provider-wrapper");
   const mnemonic = 'candy maple cake sugar pudding cream honey rich smooth crumble sweet treat';
 
   // Set this to the desired Execution Manager Address -- required for the transpiler
@@ -64,18 +64,23 @@ example truffle-config.json:
 
   module.exports = {
   /**
-   * Note: this expects the local fullnode to be running:
-   * // TODO: Run `yarn server:fullnode` in rollup-full-node before executing this test
+   * Note: this runs the OVM full node for the duration of the tests at `http://127.0.0.1:8545`
    *
    * To run tests:
    * $ truffle test ./truffle-tests/test-erc20.js --config truffle-config-ovm.js
    */
   networks: {
-    // Note: Requires running the rollup-full-node locally.
     test: {
       network_id: 108,
       provider: function() {
-        return wrapProvider(new HDWalletProvider(mnemonic, "http://127.0.0.1:8545/", 0, 10));
+        return ProviderWrapper.wrapProviderAndStartLocalNode(new HDWalletProvider(mnemonic, "http://127.0.0.1:8545/", 0, 10));
+      },
+      gasPrice: 0,
+      gas: 9000000,
+    },
+    live_example: {
+      provider: function () {
+        return ProviderWrapper.wrapProvider(new HDWalletProvider(mnemonic, "http://127.0.0.1:8545/", 0, 10));
       },
       gasPrice: 0,
       gas: 9000000,

--- a/packages/optimistic-game-semantics/package.json
+++ b/packages/optimistic-game-semantics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/optimistic-game-semantics",
-  "version": "0.0.1-alpha.10",
+  "version": "0.0.1-alpha.11",
   "description": "Optimism Optimistic Game Semantics",
   "main": "build/index.js",
   "files": [
@@ -29,8 +29,8 @@
     "url": "https://github.com/ethereum-optimism/optimism-monorepo.git"
   },
   "dependencies": {
-    "@eth-optimism/core-db": "0.0.1-alpha.10",
-    "@eth-optimism/core-utils": "0.0.1-alpha.10",
+    "@eth-optimism/core-db": "0.0.1-alpha.11",
+    "@eth-optimism/core-utils": "0.0.1-alpha.11",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "debug": "^4.1.1",

--- a/packages/optimistic-game-semantics/package.json
+++ b/packages/optimistic-game-semantics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/optimistic-game-semantics",
-  "version": "0.0.1-alpha.9",
+  "version": "0.0.1-alpha.10",
   "description": "Optimism Optimistic Game Semantics",
   "main": "build/index.js",
   "files": [
@@ -29,8 +29,8 @@
     "url": "https://github.com/ethereum-optimism/optimism-monorepo.git"
   },
   "dependencies": {
-    "@eth-optimism/core-db": "0.0.1-alpha.9",
-    "@eth-optimism/core-utils": "0.0.1-alpha.9",
+    "@eth-optimism/core-db": "0.0.1-alpha.10",
+    "@eth-optimism/core-utils": "0.0.1-alpha.10",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "debug": "^4.1.1",

--- a/packages/ovm-truffle-provider-wrapper/README.md
+++ b/packages/ovm-truffle-provider-wrapper/README.md
@@ -7,15 +7,19 @@ ChainId defaults to 108 but is configurable by setting the `OVM_CHAIN_ID` enviro
 ## Example Usage in truffle-config.js:
 ```$javascript
 const HDWalletProvider = require('truffle-hdwallet-provider');
-const wrapProvider = require('@eth-optimism/ovm-truffle-provider-wrapper');
+const ProviderWrapper = require("@eth-optimism/ovm-truffle-provider-wrapper");
 const mnemonic = 'candy maple cake sugar pudding cream honey rich smooth crumble sweet treat';
 
 module.exports = {
   networks: {
-    // Note: Requires running the rollup-full-node locally.
     test: {
       provider: function () {
-        return wrapProvider(new HDWalletProvider(mnemonic, "http://127.0.0.1:8545/", 0, 10));
+        return ProviderWrapper.wrapProviderAndStartLocalNode(new HDWalletProvider(mnemonic, "http://127.0.0.1:8545/", 0, 10));
+      },
+    },
+    live_example: {
+      provider: function () {
+        return ProviderWrapper.wrapProvider(new HDWalletProvider(mnemonic, "http://127.0.0.1:8545/", 0, 10));
       },
     },
   },

--- a/packages/ovm-truffle-provider-wrapper/README.md
+++ b/packages/ovm-truffle-provider-wrapper/README.md
@@ -3,6 +3,7 @@ The OVM uses a specific `chainId`, which Truffle, at the moment, does not allow 
 
 ## Configuration
 ChainId defaults to 108 but is configurable by setting the `OVM_CHAIN_ID` environment variable.
+Note: you will also need to include `@eth-optimism/rollup-full-node` as a dependency if you would like to run a full node locally (or use ``ProviderWrapper.wrapProviderAndStartLocalNode(...)``).
 
 ## Example Usage in truffle-config.js:
 ```$javascript

--- a/packages/ovm-truffle-provider-wrapper/index.ts
+++ b/packages/ovm-truffle-provider-wrapper/index.ts
@@ -7,7 +7,9 @@ const startLocalNode = () => {
   const runText = `(async function(){ const {runFullnode} = require('@eth-optimism/rollup-full-node');runFullnode();})();`
 
   // Assumes this process was kicked off with node, but that's true for `truffle test` and `yarn ...`
-  const sub = spawn(process.argv[0], [`-e`, `${runText}`])
+  const sub = spawn(process.argv[0], [`-e`, `${runText}`], {
+    stdio: ['ignore', 'ignore', 2],
+  })
 
   sub.on('error', (e) => {
     // tslint:disable-next-line:no-console

--- a/packages/ovm-truffle-provider-wrapper/index.ts
+++ b/packages/ovm-truffle-provider-wrapper/index.ts
@@ -1,4 +1,4 @@
-import {execSync, spawn} from 'child_process'
+import { execSync, spawn } from 'child_process'
 
 /**
  * Starts a local OVM node process for testing. It will be killed when the current process terminates.
@@ -10,13 +10,20 @@ const startLocalNode = () => {
   const sub = spawn(process.argv[0], [`-e`, `${runText}`])
 
   sub.on('error', (e) => {
-    console.error(`Local server could not be started. Error details: ${e.message}, Stack: ${e.stack}`)
+    // tslint:disable-next-line:no-console
+    console.error(
+      `Local server could not be started. Error details: ${e.message}, Stack: ${e.stack}`
+    )
   })
 
   // This reliably stops the local server when the current process exits.
   process.on('exit', () => {
-    try {sub.kill()} catch (e) {/*swallow any errors */}
-  });
+    try {
+      sub.kill()
+    } catch (e) {
+      /*swallow any errors */
+    }
+  })
 
   // TODO: This is hacky. If host / port become configurable, spawn a node process to ping it or something better.
   execSync(`sleep 3`)
@@ -63,5 +70,5 @@ const wrapProviderAndStartLocalNode = (provider: any) => {
 
 module.exports = {
   wrapProvider,
-  wrapProviderAndStartLocalNode
+  wrapProviderAndStartLocalNode,
 }

--- a/packages/ovm-truffle-provider-wrapper/index.ts
+++ b/packages/ovm-truffle-provider-wrapper/index.ts
@@ -1,4 +1,25 @@
-module.exports = (provider: any) => {
+import {execSync, spawn} from 'child_process'
+
+const startLocalNode = () => {
+  const runText = `(async function(){ const {runFullnode} = require('@eth-optimism/rollup-full-node');runFullnode();})();`
+
+  // Assumes this process was kicked off with node, but that's true for `truffle test` and `yarn ...`
+  const sub = spawn(process.argv[0], [`-e`, `${runText}`])
+
+  sub.on('error', (e) => {
+    console.error(`Local server could not be started. Error details: ${e.message}, Stack: ${e.stack}`)
+  })
+
+  // This reliably stops the local server when the current process exits.
+  process.on('exit', () => {
+    try {sub.kill()} catch (e) {/*swallow any errors */}
+  });
+
+  // TODO: This is hacky. If host / port become configurable, spawn a node process to ping it or something better.
+  execSync(`sleep 3`)
+}
+
+const wrapProvider = (provider: any) => {
   if (typeof provider !== 'object' || !provider['sendAsync']) {
     throw Error(
       'Invalid provider. Exepcted provider to conform to Truffle provider interface!'
@@ -16,4 +37,19 @@ module.exports = (provider: any) => {
     sendAsync.apply(this, args)
   }
   return provider
+}
+
+let nodeStarted = false
+const wrapProviderAndStartLocalNode = (provider: any) => {
+  if (!nodeStarted) {
+    nodeStarted = true
+    startLocalNode()
+  }
+
+  return wrapProvider(provider)
+}
+
+module.exports = {
+  wrapProvider,
+  wrapProviderAndStartLocalNode
 }

--- a/packages/ovm-truffle-provider-wrapper/index.ts
+++ b/packages/ovm-truffle-provider-wrapper/index.ts
@@ -1,5 +1,8 @@
 import {execSync, spawn} from 'child_process'
 
+/**
+ * Starts a local OVM node process for testing. It will be killed when the current process terminates.
+ */
 const startLocalNode = () => {
   const runText = `(async function(){ const {runFullnode} = require('@eth-optimism/rollup-full-node');runFullnode();})();`
 
@@ -19,6 +22,10 @@ const startLocalNode = () => {
   execSync(`sleep 3`)
 }
 
+/**
+ * Wraps the provided Truffle provider so it will work with the OVM.
+ * @returns The wrapped provider.
+ */
 const wrapProvider = (provider: any) => {
   if (typeof provider !== 'object' || !provider['sendAsync']) {
     throw Error(
@@ -40,6 +47,11 @@ const wrapProvider = (provider: any) => {
 }
 
 let nodeStarted = false
+/**
+ * Wraps the provided Truffle provider so it will work with the OVM and starts a
+ * local OVM node for the duration of the current process.
+ * @returns The wrapped provider.
+ */
 const wrapProviderAndStartLocalNode = (provider: any) => {
   if (!nodeStarted) {
     nodeStarted = true

--- a/packages/ovm-truffle-provider-wrapper/package.json
+++ b/packages/ovm-truffle-provider-wrapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/ovm-truffle-provider-wrapper",
-  "version": "0.0.1-alpha.10",
+  "version": "0.0.1-alpha.11",
   "description": "Optimism Truffle Provider Wrapper",
   "main": "build/index.js",
   "files": [
@@ -28,7 +28,7 @@
     "url": "https://github.com/ethereum-optimism/optimism-monorepo.git"
   },
   "dependencies": {
-    "@eth-optimism/rollup-full-node": "^0.0.1-alpha.10"
+    "@eth-optimism/rollup-full-node": "0.0.1-alpha.11"
   },
   "devDependencies": {
     "@types/node": "^12.0.7",

--- a/packages/ovm-truffle-provider-wrapper/package.json
+++ b/packages/ovm-truffle-provider-wrapper/package.json
@@ -27,6 +27,9 @@
     "type": "git",
     "url": "https://github.com/ethereum-optimism/optimism-monorepo.git"
   },
+  "dependencies": {
+    "@eth-optimism/rollup-full-node": "^0.0.1-alpha.10"
+  },
   "devDependencies": {
     "@types/node": "^12.0.7",
     "rimraf": "^2.6.3",

--- a/packages/ovm-truffle-provider-wrapper/package.json
+++ b/packages/ovm-truffle-provider-wrapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/ovm-truffle-provider-wrapper",
-  "version": "0.0.1-alpha.9",
+  "version": "0.0.1-alpha.10",
   "description": "Optimism Truffle Provider Wrapper",
   "main": "build/index.js",
   "files": [

--- a/packages/ovm/package.json
+++ b/packages/ovm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/ovm",
-  "version": "0.0.1-alpha.10",
+  "version": "0.0.1-alpha.11",
   "description": "An optimistic execution-compatible EVM",
   "main": "build/index.js",
   "files": [
@@ -49,9 +49,9 @@
     "typescript": "^3.3.3333"
   },
   "dependencies": {
-    "@eth-optimism/core-db": "0.0.1-alpha.10",
-    "@eth-optimism/core-utils": "0.0.1-alpha.10",
-    "@eth-optimism/rollup-core": "0.0.1-alpha.10",
+    "@eth-optimism/core-db": "0.0.1-alpha.11",
+    "@eth-optimism/core-utils": "0.0.1-alpha.11",
+    "@eth-optimism/rollup-core": "0.0.1-alpha.11",
     "@types/sinon-chai": "^3.2.2",
     "chai": "^4.2.0",
     "ethereum-waffle": "2.1.0",

--- a/packages/ovm/package.json
+++ b/packages/ovm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/ovm",
-  "version": "0.0.1-alpha.9",
+  "version": "0.0.1-alpha.10",
   "description": "An optimistic execution-compatible EVM",
   "main": "build/index.js",
   "files": [
@@ -49,9 +49,9 @@
     "typescript": "^3.3.3333"
   },
   "dependencies": {
-    "@eth-optimism/core-db": "0.0.1-alpha.9",
-    "@eth-optimism/core-utils": "0.0.1-alpha.9",
-    "@eth-optimism/rollup-core": "0.0.1-alpha.9",
+    "@eth-optimism/core-db": "0.0.1-alpha.10",
+    "@eth-optimism/core-utils": "0.0.1-alpha.10",
+    "@eth-optimism/rollup-core": "0.0.1-alpha.10",
     "@types/sinon-chai": "^3.2.2",
     "chai": "^4.2.0",
     "ethereum-waffle": "2.1.0",

--- a/packages/ovm/test/contracts/execution-manager.call-opcodes.spec.ts
+++ b/packages/ovm/test/contracts/execution-manager.call-opcodes.spec.ts
@@ -95,7 +95,7 @@ describe('Execution Manager -- Call opcodes', () => {
       gasLimit: DEFAULT_ETHNODE_GAS_LIMIT,
     })
 
-    const deployTx = new ContractFactory(
+    const deployTx: any = new ContractFactory(
       SimpleCall.abi,
       SimpleCall.bytecode
     ).getDeployTransaction(dummyContract.address)

--- a/packages/rollup-contracts/package.json
+++ b/packages/rollup-contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/rollup-contracts",
-  "version": "0.0.1-alpha.9",
+  "version": "0.0.1-alpha.10",
   "description": "Optimistic Rollup smart contracts",
   "main": "build/index.js",
   "files": [
@@ -43,9 +43,9 @@
     "typescript": "^3.3.3333"
   },
   "dependencies": {
-    "@eth-optimism/core-db": "0.0.1-alpha.9",
-    "@eth-optimism/core-utils": "0.0.1-alpha.9",
-    "@eth-optimism/rollup-core": "0.0.1-alpha.9",
+    "@eth-optimism/core-db": "0.0.1-alpha.10",
+    "@eth-optimism/core-utils": "0.0.1-alpha.10",
+    "@eth-optimism/rollup-core": "0.0.1-alpha.10",
     "@types/sinon-chai": "^3.2.2",
     "chai": "^4.2.0",
     "ethereum-waffle": "2.1.0",

--- a/packages/rollup-contracts/package.json
+++ b/packages/rollup-contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/rollup-contracts",
-  "version": "0.0.1-alpha.10",
+  "version": "0.0.1-alpha.11",
   "description": "Optimistic Rollup smart contracts",
   "main": "build/index.js",
   "files": [
@@ -43,9 +43,9 @@
     "typescript": "^3.3.3333"
   },
   "dependencies": {
-    "@eth-optimism/core-db": "0.0.1-alpha.10",
-    "@eth-optimism/core-utils": "0.0.1-alpha.10",
-    "@eth-optimism/rollup-core": "0.0.1-alpha.10",
+    "@eth-optimism/core-db": "0.0.1-alpha.11",
+    "@eth-optimism/core-utils": "0.0.1-alpha.11",
+    "@eth-optimism/rollup-core": "0.0.1-alpha.11",
     "@types/sinon-chai": "^3.2.2",
     "chai": "^4.2.0",
     "ethereum-waffle": "2.1.0",

--- a/packages/rollup-core/package.json
+++ b/packages/rollup-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/rollup-core",
-  "version": "0.0.1-alpha.9",
+  "version": "0.0.1-alpha.10",
   "description": "[Optimism] Optimistic Rollup Core Library",
   "main": "build/index.js",
   "files": [
@@ -29,8 +29,8 @@
     "url": "https://github.com/ethereum-optimism/optimism-monorepo.git"
   },
   "dependencies": {
-    "@eth-optimism/core-db": "0.0.1-alpha.9",
-    "@eth-optimism/core-utils": "0.0.1-alpha.9",
+    "@eth-optimism/core-db": "0.0.1-alpha.10",
+    "@eth-optimism/core-utils": "0.0.1-alpha.10",
     "async-lock": "^1.2.2",
     "ethers": "^4.0.39"
   },

--- a/packages/rollup-core/package.json
+++ b/packages/rollup-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/rollup-core",
-  "version": "0.0.1-alpha.10",
+  "version": "0.0.1-alpha.11",
   "description": "[Optimism] Optimistic Rollup Core Library",
   "main": "build/index.js",
   "files": [
@@ -29,8 +29,8 @@
     "url": "https://github.com/ethereum-optimism/optimism-monorepo.git"
   },
   "dependencies": {
-    "@eth-optimism/core-db": "0.0.1-alpha.10",
-    "@eth-optimism/core-utils": "0.0.1-alpha.10",
+    "@eth-optimism/core-db": "0.0.1-alpha.11",
+    "@eth-optimism/core-utils": "0.0.1-alpha.11",
     "async-lock": "^1.2.2",
     "ethers": "^4.0.39"
   },

--- a/packages/rollup-dev-tools/package.json
+++ b/packages/rollup-dev-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/rollup-dev-tools",
-  "version": "0.0.1-alpha.10",
+  "version": "0.0.1-alpha.11",
   "description": "[Optimism] Optimistic Rollup Dev Tools Library",
   "main": "build/index.js",
   "files": [
@@ -33,8 +33,8 @@
     "url": "https://github.com/ethereum-optimism/optimism-monorepo.git"
   },
   "dependencies": {
-    "@eth-optimism/core-utils": "0.0.1-alpha.10",
-    "@eth-optimism/rollup-core": "0.0.1-alpha.10",
+    "@eth-optimism/core-utils": "0.0.1-alpha.11",
+    "@eth-optimism/rollup-core": "0.0.1-alpha.11",
     "async-lock": "^1.2.2",
     "bn.js": "^5.1.1",
     "dotenv": "^8.2.0",

--- a/packages/rollup-dev-tools/package.json
+++ b/packages/rollup-dev-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/rollup-dev-tools",
-  "version": "0.0.1-alpha.9",
+  "version": "0.0.1-alpha.10",
   "description": "[Optimism] Optimistic Rollup Dev Tools Library",
   "main": "build/index.js",
   "files": [
@@ -33,8 +33,8 @@
     "url": "https://github.com/ethereum-optimism/optimism-monorepo.git"
   },
   "dependencies": {
-    "@eth-optimism/core-utils": "0.0.1-alpha.9",
-    "@eth-optimism/rollup-core": "0.0.1-alpha.9",
+    "@eth-optimism/core-utils": "0.0.1-alpha.10",
+    "@eth-optimism/rollup-core": "0.0.1-alpha.10",
     "async-lock": "^1.2.2",
     "bn.js": "^5.1.1",
     "dotenv": "^8.2.0",

--- a/packages/rollup-full-node/exec/aggregator.js
+++ b/packages/rollup-full-node/exec/aggregator.js
@@ -1,0 +1,3 @@
+const aggregator = require("../build/src/exec/aggregator")
+
+aggregator.runAggregator()

--- a/packages/rollup-full-node/exec/fullnode.js
+++ b/packages/rollup-full-node/exec/fullnode.js
@@ -1,0 +1,3 @@
+const fullnode = require("../build/src/exec/fullnode")
+
+fullnode.runFullnode()

--- a/packages/rollup-full-node/exec/startFullnode.sh
+++ b/packages/rollup-full-node/exec/startFullnode.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+mkdir -p ../log
+SCRIPT_DIR=$(dirname $0)
+yarn --cwd ${SCRIPT_DIR}/.. run server:fullnode 2>&1 | tee ../log/fullnode.$(date '+%Y.%m.%d_%H.%M.%S')_$(uuidgen).log

--- a/packages/rollup-full-node/exec/startFullnode.sh
+++ b/packages/rollup-full-node/exec/startFullnode.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-mkdir -p ../log
-SCRIPT_DIR=$(dirname $0)
-yarn --cwd ${SCRIPT_DIR}/.. run server:fullnode 2>&1 | tee ../log/fullnode.$(date '+%Y.%m.%d_%H.%M.%S')_$(uuidgen).log

--- a/packages/rollup-full-node/exec/stopFullnode.sh
+++ b/packages/rollup-full-node/exec/stopFullnode.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-pkill -f *fullnode.js &> derp.log

--- a/packages/rollup-full-node/exec/stopFullnode.sh
+++ b/packages/rollup-full-node/exec/stopFullnode.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+pkill -f *fullnode.js &> derp.log

--- a/packages/rollup-full-node/index.ts
+++ b/packages/rollup-full-node/index.ts
@@ -1,5 +1,4 @@
 const rootPath = __dirname
 
 export { rootPath }
-export * from './src/app'
-export * from './src/types'
+export * from './src'

--- a/packages/rollup-full-node/package.json
+++ b/packages/rollup-full-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/rollup-full-node",
-  "version": "0.0.1-alpha.9",
+  "version": "0.0.1-alpha.10",
   "description": "[Optimism] Optimistic Rollup Full Node Library",
   "main": "build/index.js",
   "files": [
@@ -32,10 +32,10 @@
     "url": "https://github.com/ethereum-optimism/optimism-monorepo.git"
   },
   "dependencies": {
-    "@eth-optimism/core-db": "0.0.1-alpha.9",
-    "@eth-optimism/core-utils": "0.0.1-alpha.9",
-    "@eth-optimism/ovm": "0.0.1-alpha.9",
-    "@eth-optimism/rollup-core": "0.0.1-alpha.9",
+    "@eth-optimism/core-db": "0.0.1-alpha.10",
+    "@eth-optimism/core-utils": "0.0.1-alpha.10",
+    "@eth-optimism/ovm": "0.0.1-alpha.10",
+    "@eth-optimism/rollup-core": "0.0.1-alpha.10",
     "async-lock": "^1.2.2",
     "axios": "^0.19.0",
     "cors": "^2.8.5",

--- a/packages/rollup-full-node/package.json
+++ b/packages/rollup-full-node/package.json
@@ -13,9 +13,9 @@
     "fix": "prettier --config ../../prettier-config.json --write 'index.ts' '{src,test}/**/*.ts'",
     "lint": "tslint --format stylish --project .",
     "test": "waffle waffle-config.json && mocha --require source-map-support/register --require ts-node/register 'test/**/*.spec.ts' --timeout 8000 --exit",
-    "server:aggregator": "env DEBUG=\"info:*,error:*\" node ./build/src/exec/aggregator.js",
-    "server:fullnode": "env DEBUG=\"info:*,error:*\" node ./build/src/exec/fullnode.js",
-    "server:fullnode:debug": "env DEBUG=\"info:*,error:*,debug:*\" node ./build/src/exec/fullnode.js"
+    "server:aggregator": "env DEBUG=\"info:*,error:*\" node ./exec/aggregator.js",
+    "server:fullnode": "env DEBUG=\"info:*,error:*\" node ./exec/fullnode.js",
+    "server:fullnode:debug": "env DEBUG=\"info:*,error:*,debug:*\" node ./exec/fullnode.js"
   },
   "keywords": [
     "plasma",

--- a/packages/rollup-full-node/package.json
+++ b/packages/rollup-full-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/rollup-full-node",
-  "version": "0.0.1-alpha.10",
+  "version": "0.0.1-alpha.11",
   "description": "[Optimism] Optimistic Rollup Full Node Library",
   "main": "build/index.js",
   "files": [
@@ -32,10 +32,10 @@
     "url": "https://github.com/ethereum-optimism/optimism-monorepo.git"
   },
   "dependencies": {
-    "@eth-optimism/core-db": "0.0.1-alpha.10",
-    "@eth-optimism/core-utils": "0.0.1-alpha.10",
-    "@eth-optimism/ovm": "0.0.1-alpha.10",
-    "@eth-optimism/rollup-core": "0.0.1-alpha.10",
+    "@eth-optimism/core-db": "0.0.1-alpha.11",
+    "@eth-optimism/core-utils": "0.0.1-alpha.11",
+    "@eth-optimism/ovm": "0.0.1-alpha.11",
+    "@eth-optimism/rollup-core": "0.0.1-alpha.11",
     "async-lock": "^1.2.2",
     "axios": "^0.19.0",
     "cors": "^2.8.5",

--- a/packages/rollup-full-node/src/exec/aggregator.ts
+++ b/packages/rollup-full-node/src/exec/aggregator.ts
@@ -90,7 +90,7 @@ const getSupportedMethods = (parsedConfig: {}): Set<string> => {
   return new Set<string>(parsedConfig[supportedMethodsKey])
 }
 
-const runAggregator = async (): Promise<void> => {
+export const runAggregator = async (): Promise<void> => {
   // TODO: Replace with actual Aggregator when wired up.
   const dummyAggregator: Aggregator = new DummyAggregator()
 
@@ -112,5 +112,3 @@ const runAggregator = async (): Promise<void> => {
 
   log.info(`Listening on ${host}:${port}`)
 }
-
-runAggregator()

--- a/packages/rollup-full-node/src/exec/fullnode.ts
+++ b/packages/rollup-full-node/src/exec/fullnode.ts
@@ -19,6 +19,3 @@ export const runFullnode = async (): Promise<void> => {
   const baseUrl = `http://${host}:${port}`
   log.info(`Listening at ${baseUrl}`)
 }
-
-// Start Fullnode
-runFullnode()

--- a/packages/solc-transpiler/package.json
+++ b/packages/solc-transpiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/solc-transpiler",
-  "version": "0.0.1-alpha.9",
+  "version": "0.0.1-alpha.10",
   "description": "Optimism Transpiler Solc Compiler Wrapper",
   "main": "build/index.js",
   "files": [
@@ -29,8 +29,8 @@
     "url": "https://github.com/ethereum-optimism/optimism-monorepo.git"
   },
   "dependencies": {
-    "@eth-optimism/core-utils": "0.0.1-alpha.9",
-    "@eth-optimism/rollup-dev-tools": "0.0.1-alpha.9",
+    "@eth-optimism/core-utils": "0.0.1-alpha.10",
+    "@eth-optimism/rollup-dev-tools": "0.0.1-alpha.10",
     "require-from-string": "^2.0.2",
     "solc": "^0.5.12"
   },

--- a/packages/solc-transpiler/package.json
+++ b/packages/solc-transpiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/solc-transpiler",
-  "version": "0.0.1-alpha.10",
+  "version": "0.0.1-alpha.11",
   "description": "Optimism Transpiler Solc Compiler Wrapper",
   "main": "build/index.js",
   "files": [
@@ -29,8 +29,8 @@
     "url": "https://github.com/ethereum-optimism/optimism-monorepo.git"
   },
   "dependencies": {
-    "@eth-optimism/core-utils": "0.0.1-alpha.10",
-    "@eth-optimism/rollup-dev-tools": "0.0.1-alpha.10",
+    "@eth-optimism/core-utils": "0.0.1-alpha.11",
+    "@eth-optimism/rollup-dev-tools": "0.0.1-alpha.11",
     "require-from-string": "^2.0.2",
     "solc": "^0.5.12"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1254,11 +1254,6 @@ anymatch@^2.0.0:
     micromatch "^3.1.4"
     normalize-path "^2.1.1"
 
-app-module-path@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/app-module-path/-/app-module-path-2.2.0.tgz#641aa55dfb7d6a6f0a8141c4b9c0aa50b6c24dd5"
-  integrity sha1-ZBqlXft9am8KgUHEucCqULbCTdU=
-
 append-buffer@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/append-buffer/-/append-buffer-1.0.2.tgz#d8220cf466081525efea50614f3de6514dfa58f1"
@@ -2137,7 +2132,7 @@ binary-extensions@^1.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.13.1.tgz#598afe54755b2868a5330d2aff9d4ebb53209b65"
   integrity sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==
 
-bindings@^1.2.1, bindings@^1.3.1, bindings@^1.5.0:
+bindings@^1.2.1, bindings@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.5.0.tgz#10353c9e945334bc0511a6d90b38fbc7c9c504df"
   integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
@@ -2873,11 +2868,6 @@ commander@2.11.0:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
   integrity sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==
-
-commander@2.15.1:
-  version "2.15.1"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.15.1.tgz#df46e867d0fc2aec66a34662b406a9ccafff5b0f"
-  integrity sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==
 
 commander@3.0.2:
   version "3.0.2"
@@ -7371,23 +7361,6 @@ mkdirp@0.5.1, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1:
   dependencies:
     minimist "0.0.8"
 
-mocha@5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/mocha/-/mocha-5.2.0.tgz#6d8ae508f59167f940f2b5b3c4a612ae50c90ae6"
-  integrity sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==
-  dependencies:
-    browser-stdout "1.3.1"
-    commander "2.15.1"
-    debug "3.1.0"
-    diff "3.5.0"
-    escape-string-regexp "1.0.5"
-    glob "7.1.2"
-    growl "1.10.5"
-    he "1.1.1"
-    minimatch "3.0.4"
-    mkdirp "0.5.1"
-    supports-color "5.4.0"
-
 mocha@^4.0.1:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/mocha/-/mocha-4.1.0.tgz#7d86cfbcf35cb829e2754c32e17355ec05338794"
@@ -7923,11 +7896,6 @@ ordered-read-streams@^1.0.0:
   integrity sha1-d8DLN8QVJdZBZtmQ/61+xqDhNj4=
   dependencies:
     readable-stream "^2.0.1"
-
-original-require@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/original-require/-/original-require-1.0.1.tgz#0f130471584cd33511c5ec38c8d59213f9ac5e20"
-  integrity sha1-DxMEcVhM0zURxew4yNWSE/msXiA=
 
 os-homedir@^1.0.0:
   version "1.0.2"
@@ -9115,17 +9083,17 @@ scrypt@^6.0.2:
   dependencies:
     nan "^2.0.8"
 
-scryptsy@2.1.0, scryptsy@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/scryptsy/-/scryptsy-2.1.0.tgz#8d1e8d0c025b58fdd25b6fa9a0dc905ee8faa790"
-  integrity sha512-1CdSqHQowJBnMAFyPEBRfqag/YP9OF394FV+4YREIJX4ljD7OxvQRDayyoyyCk+senRjSkP6VnUNQmVQqB6g7w==
-
 scryptsy@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/scryptsy/-/scryptsy-1.2.1.tgz#a3225fa4b2524f802700761e2855bdf3b2d92163"
   integrity sha1-oyJfpLJST4AnAHYeKFW987LZIWM=
   dependencies:
     pbkdf2 "^3.0.3"
+
+scryptsy@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/scryptsy/-/scryptsy-2.1.0.tgz#8d1e8d0c025b58fdd25b6fa9a0dc905ee8faa790"
+  integrity sha512-1CdSqHQowJBnMAFyPEBRfqag/YP9OF394FV+4YREIJX4ljD7OxvQRDayyoyyCk+senRjSkP6VnUNQmVQqB6g7w==
 
 secp256k1@^3.0.1:
   version "3.8.0"
@@ -9174,11 +9142,6 @@ semver-greatest-satisfied-range@^1.1.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
-
-semver@6.2.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-6.2.0.tgz#4d813d9590aaf8a9192693d6c85b9344de5901db"
-  integrity sha512-jdFC1VdUGT/2Scgbimf7FSx9iJLXoqfglSF+gJeuNWVpiE37OIbc1jywR/GJyFdz3mnkz2/id0L0J/cr0izR5A==
 
 semver@^6.0.0, semver@^6.2.0, semver@^6.3.0:
   version "6.3.0"
@@ -9761,13 +9724,6 @@ supports-color@4.4.0:
   dependencies:
     has-flag "^2.0.0"
 
-supports-color@5.4.0:
-  version "5.4.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.4.0.tgz#1c6b337402c2137605efe19f10fec390f6faab54"
-  integrity sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==
-  dependencies:
-    has-flag "^3.0.0"
-
 supports-color@6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-6.0.0.tgz#76cfe742cf1f41bb9b1c29ad03068c05b4c0e40a"
@@ -10101,25 +10057,6 @@ trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
   integrity sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=
-
-truffle-hdwallet-provider@^1.0.17:
-  version "1.0.17"
-  resolved "https://registry.yarnpkg.com/truffle-hdwallet-provider/-/truffle-hdwallet-provider-1.0.17.tgz#fe8edd0d6974eeb31af9959e41525fb19abd74ca"
-  integrity sha512-s6DvSP83jiIAc6TUcpr7Uqnja1+sLGJ8og3X7n41vfyC4OCaKmBtXL5HOHf+SsU3iblOvnbFDgmN6Y1VBL/fsg==
-  dependencies:
-    any-promise "^1.3.0"
-    bindings "^1.3.1"
-    web3 "1.2.1"
-    websocket "^1.0.28"
-
-truffle@^5.1.12:
-  version "5.1.12"
-  resolved "https://registry.yarnpkg.com/truffle/-/truffle-5.1.12.tgz#7d41fe2205b223e5631fcbe5c7faa09899b6ca38"
-  integrity sha512-lw5NC3S4esGqKIbqKXWutOcOMz3G+2LCKvacnrwH/PNh/Wk0qPKia7daiLJqRdqjJkHPtAUpRf8b1aqrcot2Ww==
-  dependencies:
-    app-module-path "^2.2.0"
-    mocha "5.2.0"
-    original-require "1.0.1"
 
 ts-md5@^1.2.4:
   version "1.2.7"
@@ -10621,15 +10558,6 @@ web3-bzz@1.0.0-beta.35:
     swarm-js "0.1.37"
     underscore "1.8.3"
 
-web3-bzz@1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/web3-bzz/-/web3-bzz-1.2.1.tgz#c3bd1e8f0c02a13cd6d4e3c3e9e1713f144f6f0d"
-  integrity sha512-LdOO44TuYbGIPfL4ilkuS89GQovxUpmLz6C1UC7VYVVRILeZS740FVB3j9V4P4FHUk1RenaDfKhcntqgVCHtjw==
-  dependencies:
-    got "9.6.0"
-    swarm-js "0.1.39"
-    underscore "1.9.1"
-
 web3-bzz@1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/web3-bzz/-/web3-bzz-1.2.4.tgz#a4adb7a8cba3d260de649bdb1f14ed359bfb3821"
@@ -10648,15 +10576,6 @@ web3-core-helpers@1.0.0-beta.35:
     underscore "1.8.3"
     web3-eth-iban "1.0.0-beta.35"
     web3-utils "1.0.0-beta.35"
-
-web3-core-helpers@1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/web3-core-helpers/-/web3-core-helpers-1.2.1.tgz#f5f32d71c60a4a3bd14786118e633ce7ca6d5d0d"
-  integrity sha512-Gx3sTEajD5r96bJgfuW377PZVFmXIH4TdqDhgGwd2lZQCcMi+DA4TgxJNJGxn0R3aUVzyyE76j4LBrh412mXrw==
-  dependencies:
-    underscore "1.9.1"
-    web3-eth-iban "1.2.1"
-    web3-utils "1.2.1"
 
 web3-core-helpers@1.2.4:
   version "1.2.4"
@@ -10678,17 +10597,6 @@ web3-core-method@1.0.0-beta.35:
     web3-core-subscriptions "1.0.0-beta.35"
     web3-utils "1.0.0-beta.35"
 
-web3-core-method@1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/web3-core-method/-/web3-core-method-1.2.1.tgz#9df1bafa2cd8be9d9937e01c6a47fc768d15d90a"
-  integrity sha512-Ghg2WS23qi6Xj8Od3VCzaImLHseEA7/usvnOItluiIc5cKs00WYWsNy2YRStzU9a2+z8lwQywPYp0nTzR/QXdQ==
-  dependencies:
-    underscore "1.9.1"
-    web3-core-helpers "1.2.1"
-    web3-core-promievent "1.2.1"
-    web3-core-subscriptions "1.2.1"
-    web3-utils "1.2.1"
-
 web3-core-method@1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/web3-core-method/-/web3-core-method-1.2.4.tgz#a0fbc50b8ff5fd214021435cc2c6d1e115807aed"
@@ -10708,14 +10616,6 @@ web3-core-promievent@1.0.0-beta.35:
     any-promise "1.3.0"
     eventemitter3 "1.1.1"
 
-web3-core-promievent@1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/web3-core-promievent/-/web3-core-promievent-1.2.1.tgz#003e8a3eb82fb27b6164a6d5b9cad04acf733838"
-  integrity sha512-IVUqgpIKoeOYblwpex4Hye6npM0aMR+kU49VP06secPeN0rHMyhGF0ZGveWBrGvf8WDPI7jhqPBFIC6Jf3Q3zw==
-  dependencies:
-    any-promise "1.3.0"
-    eventemitter3 "3.1.2"
-
 web3-core-promievent@1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/web3-core-promievent/-/web3-core-promievent-1.2.4.tgz#75e5c0f2940028722cdd21ba503ebd65272df6cb"
@@ -10734,17 +10634,6 @@ web3-core-requestmanager@1.0.0-beta.35:
     web3-providers-http "1.0.0-beta.35"
     web3-providers-ipc "1.0.0-beta.35"
     web3-providers-ws "1.0.0-beta.35"
-
-web3-core-requestmanager@1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/web3-core-requestmanager/-/web3-core-requestmanager-1.2.1.tgz#fa2e2206c3d738db38db7c8fe9c107006f5c6e3d"
-  integrity sha512-xfknTC69RfYmLKC+83Jz73IC3/sS2ZLhGtX33D4Q5nQ8yc39ElyAolxr9sJQS8kihOcM6u4J+8gyGMqsLcpIBg==
-  dependencies:
-    underscore "1.9.1"
-    web3-core-helpers "1.2.1"
-    web3-providers-http "1.2.1"
-    web3-providers-ipc "1.2.1"
-    web3-providers-ws "1.2.1"
 
 web3-core-requestmanager@1.2.4:
   version "1.2.4"
@@ -10766,15 +10655,6 @@ web3-core-subscriptions@1.0.0-beta.35:
     underscore "1.8.3"
     web3-core-helpers "1.0.0-beta.35"
 
-web3-core-subscriptions@1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/web3-core-subscriptions/-/web3-core-subscriptions-1.2.1.tgz#8c2368a839d4eec1c01a4b5650bbeb82d0e4a099"
-  integrity sha512-nmOwe3NsB8V8UFsY1r+sW6KjdOS68h8nuh7NzlWxBQT/19QSUGiERRTaZXWu5BYvo1EoZRMxCKyCQpSSXLc08g==
-  dependencies:
-    eventemitter3 "3.1.2"
-    underscore "1.9.1"
-    web3-core-helpers "1.2.1"
-
 web3-core-subscriptions@1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/web3-core-subscriptions/-/web3-core-subscriptions-1.2.4.tgz#0dc095b5cfd82baa527a39796e3515a846b21b99"
@@ -10793,16 +10673,6 @@ web3-core@1.0.0-beta.35:
     web3-core-method "1.0.0-beta.35"
     web3-core-requestmanager "1.0.0-beta.35"
     web3-utils "1.0.0-beta.35"
-
-web3-core@1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/web3-core/-/web3-core-1.2.1.tgz#7278b58fb6495065e73a77efbbce781a7fddf1a9"
-  integrity sha512-5ODwIqgl8oIg/0+Ai4jsLxkKFWJYE0uLuE1yUKHNVCL4zL6n3rFjRMpKPokd6id6nJCNgeA64KdWQ4XfpnjdMg==
-  dependencies:
-    web3-core-helpers "1.2.1"
-    web3-core-method "1.2.1"
-    web3-core-requestmanager "1.2.1"
-    web3-utils "1.2.1"
 
 web3-core@1.2.4:
   version "1.2.4"
@@ -10826,15 +10696,6 @@ web3-eth-abi@1.0.0-beta.35:
     underscore "1.8.3"
     web3-core-helpers "1.0.0-beta.35"
     web3-utils "1.0.0-beta.35"
-
-web3-eth-abi@1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/web3-eth-abi/-/web3-eth-abi-1.2.1.tgz#9b915b1c9ebf82f70cca631147035d5419064689"
-  integrity sha512-jI/KhU2a/DQPZXHjo2GW0myEljzfiKOn+h1qxK1+Y9OQfTcBMxrQJyH5AP89O6l6NZ1QvNdq99ThAxBFoy5L+g==
-  dependencies:
-    ethers "4.0.0-beta.3"
-    underscore "1.9.1"
-    web3-utils "1.2.1"
 
 web3-eth-abi@1.2.4:
   version "1.2.4"
@@ -10860,23 +10721,6 @@ web3-eth-accounts@1.0.0-beta.35:
     web3-core-helpers "1.0.0-beta.35"
     web3-core-method "1.0.0-beta.35"
     web3-utils "1.0.0-beta.35"
-
-web3-eth-accounts@1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/web3-eth-accounts/-/web3-eth-accounts-1.2.1.tgz#2741a8ef337a7219d57959ac8bd118b9d68d63cf"
-  integrity sha512-26I4qq42STQ8IeKUyur3MdQ1NzrzCqPsmzqpux0j6X/XBD7EjZ+Cs0lhGNkSKH5dI3V8CJasnQ5T1mNKeWB7nQ==
-  dependencies:
-    any-promise "1.3.0"
-    crypto-browserify "3.12.0"
-    eth-lib "0.2.7"
-    scryptsy "2.1.0"
-    semver "6.2.0"
-    underscore "1.9.1"
-    uuid "3.3.2"
-    web3-core "1.2.1"
-    web3-core-helpers "1.2.1"
-    web3-core-method "1.2.1"
-    web3-utils "1.2.1"
 
 web3-eth-accounts@1.2.4:
   version "1.2.4"
@@ -10910,20 +10754,6 @@ web3-eth-contract@1.0.0-beta.35:
     web3-eth-abi "1.0.0-beta.35"
     web3-utils "1.0.0-beta.35"
 
-web3-eth-contract@1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/web3-eth-contract/-/web3-eth-contract-1.2.1.tgz#3542424f3d341386fd9ff65e78060b85ac0ea8c4"
-  integrity sha512-kYFESbQ3boC9bl2rYVghj7O8UKMiuKaiMkxvRH5cEDHil8V7MGEGZNH0slSdoyeftZVlaWSMqkRP/chfnKND0g==
-  dependencies:
-    underscore "1.9.1"
-    web3-core "1.2.1"
-    web3-core-helpers "1.2.1"
-    web3-core-method "1.2.1"
-    web3-core-promievent "1.2.1"
-    web3-core-subscriptions "1.2.1"
-    web3-eth-abi "1.2.1"
-    web3-utils "1.2.1"
-
 web3-eth-contract@1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/web3-eth-contract/-/web3-eth-contract-1.2.4.tgz#68ef7cc633232779b0a2c506a810fbe903575886"
@@ -10938,20 +10768,6 @@ web3-eth-contract@1.2.4:
     web3-core-subscriptions "1.2.4"
     web3-eth-abi "1.2.4"
     web3-utils "1.2.4"
-
-web3-eth-ens@1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/web3-eth-ens/-/web3-eth-ens-1.2.1.tgz#a0e52eee68c42a8b9865ceb04e5fb022c2d971d5"
-  integrity sha512-lhP1kFhqZr2nnbu3CGIFFrAnNxk2veXpOXBY48Tub37RtobDyHijHgrj+xTh+mFiPokyrapVjpFsbGa+Xzye4Q==
-  dependencies:
-    eth-ens-namehash "2.0.8"
-    underscore "1.9.1"
-    web3-core "1.2.1"
-    web3-core-helpers "1.2.1"
-    web3-core-promievent "1.2.1"
-    web3-eth-abi "1.2.1"
-    web3-eth-contract "1.2.1"
-    web3-utils "1.2.1"
 
 web3-eth-ens@1.2.4:
   version "1.2.4"
@@ -10975,14 +10791,6 @@ web3-eth-iban@1.0.0-beta.35:
     bn.js "4.11.6"
     web3-utils "1.0.0-beta.35"
 
-web3-eth-iban@1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/web3-eth-iban/-/web3-eth-iban-1.2.1.tgz#2c3801718946bea24e9296993a975c80b5acf880"
-  integrity sha512-9gkr4QPl1jCU+wkgmZ8EwODVO3ovVj6d6JKMos52ggdT2YCmlfvFVF6wlGLwi0VvNa/p+0BjJzaqxnnG/JewjQ==
-  dependencies:
-    bn.js "4.11.8"
-    web3-utils "1.2.1"
-
 web3-eth-iban@1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/web3-eth-iban/-/web3-eth-iban-1.2.4.tgz#8e0550fd3fd8e47a39357d87fe27dee9483ee476"
@@ -11001,17 +10809,6 @@ web3-eth-personal@1.0.0-beta.35:
     web3-core-method "1.0.0-beta.35"
     web3-net "1.0.0-beta.35"
     web3-utils "1.0.0-beta.35"
-
-web3-eth-personal@1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/web3-eth-personal/-/web3-eth-personal-1.2.1.tgz#244e9911b7b482dc17c02f23a061a627c6e47faf"
-  integrity sha512-RNDVSiaSoY4aIp8+Hc7z+X72H7lMb3fmAChuSBADoEc7DsJrY/d0R5qQDK9g9t2BO8oxgLrLNyBP/9ub2Hc6Bg==
-  dependencies:
-    web3-core "1.2.1"
-    web3-core-helpers "1.2.1"
-    web3-core-method "1.2.1"
-    web3-net "1.2.1"
-    web3-utils "1.2.1"
 
 web3-eth-personal@1.2.4:
   version "1.2.4"
@@ -11043,25 +10840,6 @@ web3-eth@1.0.0-beta.35:
     web3-net "1.0.0-beta.35"
     web3-utils "1.0.0-beta.35"
 
-web3-eth@1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/web3-eth/-/web3-eth-1.2.1.tgz#b9989e2557c73a9e8ffdc107c6dafbe72c79c1b0"
-  integrity sha512-/2xly4Yry5FW1i+uygPjhfvgUP/MS/Dk+PDqmzp5M88tS86A+j8BzKc23GrlA8sgGs0645cpZK/999LpEF5UdA==
-  dependencies:
-    underscore "1.9.1"
-    web3-core "1.2.1"
-    web3-core-helpers "1.2.1"
-    web3-core-method "1.2.1"
-    web3-core-subscriptions "1.2.1"
-    web3-eth-abi "1.2.1"
-    web3-eth-accounts "1.2.1"
-    web3-eth-contract "1.2.1"
-    web3-eth-ens "1.2.1"
-    web3-eth-iban "1.2.1"
-    web3-eth-personal "1.2.1"
-    web3-net "1.2.1"
-    web3-utils "1.2.1"
-
 web3-eth@1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/web3-eth/-/web3-eth-1.2.4.tgz#24c3b1f1ac79351bbfb808b2ab5c585fa57cdd00"
@@ -11089,15 +10867,6 @@ web3-net@1.0.0-beta.35:
     web3-core "1.0.0-beta.35"
     web3-core-method "1.0.0-beta.35"
     web3-utils "1.0.0-beta.35"
-
-web3-net@1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/web3-net/-/web3-net-1.2.1.tgz#edd249503315dd5ab4fa00220f6509d95bb7ab10"
-  integrity sha512-Yt1Bs7WgnLESPe0rri/ZoPWzSy55ovioaP35w1KZydrNtQ5Yq4WcrAdhBzcOW7vAkIwrsLQsvA+hrOCy7mNauw==
-  dependencies:
-    web3-core "1.2.1"
-    web3-core-method "1.2.1"
-    web3-utils "1.2.1"
 
 web3-net@1.2.4:
   version "1.2.4"
@@ -11168,14 +10937,6 @@ web3-providers-http@1.0.0-beta.35:
     web3-core-helpers "1.0.0-beta.35"
     xhr2-cookies "1.1.0"
 
-web3-providers-http@1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/web3-providers-http/-/web3-providers-http-1.2.1.tgz#c93ea003a42e7b894556f7e19dd3540f947f5013"
-  integrity sha512-BDtVUVolT9b3CAzeGVA/np1hhn7RPUZ6YYGB/sYky+GjeO311Yoq8SRDUSezU92x8yImSC2B+SMReGhd1zL+bQ==
-  dependencies:
-    web3-core-helpers "1.2.1"
-    xhr2-cookies "1.1.0"
-
 web3-providers-http@1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/web3-providers-http/-/web3-providers-http-1.2.4.tgz#514fcad71ae77832c2c15574296282fbbc5f4a67"
@@ -11192,15 +10953,6 @@ web3-providers-ipc@1.0.0-beta.35:
     oboe "2.1.3"
     underscore "1.8.3"
     web3-core-helpers "1.0.0-beta.35"
-
-web3-providers-ipc@1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/web3-providers-ipc/-/web3-providers-ipc-1.2.1.tgz#017bfc687a8fc5398df2241eb98f135e3edd672c"
-  integrity sha512-oPEuOCwxVx8L4CPD0TUdnlOUZwGBSRKScCz/Ws2YHdr9Ium+whm+0NLmOZjkjQp5wovQbyBzNa6zJz1noFRvFA==
-  dependencies:
-    oboe "2.1.4"
-    underscore "1.9.1"
-    web3-core-helpers "1.2.1"
 
 web3-providers-ipc@1.2.4:
   version "1.2.4"
@@ -11220,15 +10972,6 @@ web3-providers-ws@1.0.0-beta.35:
     web3-core-helpers "1.0.0-beta.35"
     websocket "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible"
 
-web3-providers-ws@1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/web3-providers-ws/-/web3-providers-ws-1.2.1.tgz#2d941eaf3d5a8caa3214eff8dc16d96252b842cb"
-  integrity sha512-oqsQXzu+ejJACVHy864WwIyw+oB21nw/pI65/sD95Zi98+/HQzFfNcIFneF1NC4bVF3VNX4YHTNq2I2o97LAiA==
-  dependencies:
-    underscore "1.9.1"
-    web3-core-helpers "1.2.1"
-    websocket "github:web3-js/WebSocket-Node#polyfill/globalThis"
-
 web3-providers-ws@1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/web3-providers-ws/-/web3-providers-ws-1.2.4.tgz#099ee271ee03f6ea4f5df9cfe969e83f4ce0e36f"
@@ -11247,16 +10990,6 @@ web3-shh@1.0.0-beta.35:
     web3-core-method "1.0.0-beta.35"
     web3-core-subscriptions "1.0.0-beta.35"
     web3-net "1.0.0-beta.35"
-
-web3-shh@1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/web3-shh/-/web3-shh-1.2.1.tgz#4460e3c1e07faf73ddec24ccd00da46f89152b0c"
-  integrity sha512-/3Cl04nza5kuFn25bV3FJWa0s3Vafr5BlT933h26xovQ6HIIz61LmvNQlvX1AhFL+SNJOTcQmK1SM59vcyC8bA==
-  dependencies:
-    web3-core "1.2.1"
-    web3-core-method "1.2.1"
-    web3-core-subscriptions "1.2.1"
-    web3-net "1.2.1"
 
 web3-shh@1.2.4:
   version "1.2.4"
@@ -11280,19 +11013,6 @@ web3-utils@1.0.0-beta.35:
     randomhex "0.1.5"
     underscore "1.8.3"
     utf8 "2.1.1"
-
-web3-utils@1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/web3-utils/-/web3-utils-1.2.1.tgz#21466e38291551de0ab34558de21512ac4274534"
-  integrity sha512-Mrcn3l58L+yCKz3zBryM6JZpNruWuT0OCbag8w+reeNROSGVlXzUQkU+gtAwc9JCZ7tKUyg67+2YUGqUjVcyBA==
-  dependencies:
-    bn.js "4.11.8"
-    eth-lib "0.2.7"
-    ethjs-unit "0.1.6"
-    number-to-bn "1.7.0"
-    randomhex "0.1.5"
-    underscore "1.9.1"
-    utf8 "3.0.0"
 
 web3-utils@1.2.4:
   version "1.2.4"
@@ -11320,19 +11040,6 @@ web3@1.0.0-beta.35:
     web3-net "1.0.0-beta.35"
     web3-shh "1.0.0-beta.35"
     web3-utils "1.0.0-beta.35"
-
-web3@1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/web3/-/web3-1.2.1.tgz#5d8158bcca47838ab8c2b784a2dee4c3ceb4179b"
-  integrity sha512-nNMzeCK0agb5i/oTWNdQ1aGtwYfXzHottFP2Dz0oGIzavPMGSKyVlr8ibVb1yK5sJBjrWVnTdGaOC2zKDFuFRw==
-  dependencies:
-    web3-bzz "1.2.1"
-    web3-core "1.2.1"
-    web3-eth "1.2.1"
-    web3-eth-personal "1.2.1"
-    web3-net "1.2.1"
-    web3-shh "1.2.1"
-    web3-utils "1.2.1"
 
 web3@1.2.4:
   version "1.2.4"
@@ -11364,17 +11071,6 @@ websocket@1.0.29:
     typedarray-to-buffer "^3.1.5"
     yaeti "^0.0.6"
 
-websocket@^1.0.28:
-  version "1.0.31"
-  resolved "https://registry.yarnpkg.com/websocket/-/websocket-1.0.31.tgz#e5d0f16c3340ed87670e489ecae6144c79358730"
-  integrity sha512-VAouplvGKPiKFDTeCCO65vYHsyay8DqoBSlzIO3fayrfOgU94lQN5a1uWVnFrMLceTJw/+fQXR5PGbUVRaHshQ==
-  dependencies:
-    debug "^2.2.0"
-    es5-ext "^0.10.50"
-    nan "^2.14.0"
-    typedarray-to-buffer "^3.1.5"
-    yaeti "^0.0.6"
-
 "websocket@git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible":
   version "1.0.26"
   resolved "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2"
@@ -11382,16 +11078,6 @@ websocket@^1.0.28:
     debug "^2.2.0"
     nan "^2.3.3"
     typedarray-to-buffer "^3.1.2"
-    yaeti "^0.0.6"
-
-"websocket@github:web3-js/WebSocket-Node#polyfill/globalThis":
-  version "1.0.29"
-  resolved "https://codeload.github.com/web3-js/WebSocket-Node/tar.gz/905deb4812572b344f5801f8c9ce8bb02799d82e"
-  dependencies:
-    debug "^2.2.0"
-    es5-ext "^0.10.50"
-    nan "^2.14.0"
-    typedarray-to-buffer "^3.1.5"
     yaeti "^0.0.6"
 
 whatwg-fetch@2.0.4:


### PR DESCRIPTION
## Description
* Adding wrapper to `ovm-truffle-provider-wrapper` that kicks off local full-node and stops it after tests
* Separating js to kickoff fullnode and aggregator and js that can be referenced to configure fullnode and aggregator.

## Metadata
### Fixes
- Fixes # [YAS-177](https://optimists.atlassian.net/browse/YAS-177)

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
