### PR TITLE
Add tests for convertInternalLogsToOvmLogs

### DIFF
--- a/packages/ovm/package.json
+++ b/packages/ovm/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "all": "yarn clean && yarn build && yarn test && yarn fix && yarn lint",
     "test:govm": "waffle waffle-config.json && mocha --require source-map-support/register --require ts-node/register 'test/govm/*.spec.ts' --timeout 60000 --exit",
-    "test": "waffle waffle-config.json && mocha --require source-map-support/register --require ts-node/register 'test/contracts/*.spec.ts' --timeout 8000 --exit",
+    "test": "waffle waffle-config.json && mocha --require source-map-support/register --require ts-node/register 'test/contracts/*.spec.ts' 'test/app/*.spec.ts' --timeout 8000 --exit",
     "lint": "tslint --format stylish --project . && solium --no-soliumignore -d src/contracts/",
     "fix": "prettier --config ../../prettier-config.json --write 'index.ts' '{deploy,src,test}/**/*.ts' && solium -d src/contracts --no-soliumignore --fix",
     "build": "mkdir -p ./build && waffle waffle-config.json && tsc -p .",

--- a/packages/ovm/package.json
+++ b/packages/ovm/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "all": "yarn clean && yarn build && yarn test && yarn fix && yarn lint",
     "test:govm": "waffle waffle-config.json && mocha --require source-map-support/register --require ts-node/register 'test/govm/*.spec.ts' --timeout 60000 --exit",
-    "test": "waffle waffle-config.json && mocha --require source-map-support/register --require ts-node/register 'test/contracts/*.spec.ts' 'test/app/*.spec.ts' --timeout 8000 --exit",
+    "test": "waffle waffle-config.json && mocha --require source-map-support/register --require ts-node/register 'test/{contracts,app}/*.spec.ts' --timeout 8000 --exit",
     "lint": "tslint --format stylish --project . && solium --no-soliumignore -d src/contracts/",
     "fix": "prettier --config ../../prettier-config.json --write 'index.ts' '{deploy,src,test}/**/*.ts' && solium -d src/contracts --no-soliumignore --fix",
     "build": "mkdir -p ./build && waffle waffle-config.json && tsc -p .",

--- a/packages/ovm/src/contracts/ExecutionManager.sol
+++ b/packages/ovm/src/contracts/ExecutionManager.sol
@@ -185,11 +185,8 @@ contract ExecutionManager is FullStateManager {
         require(eoaAddress != ZERO_ADDRESS, "Failed to recover signature");
         // Require nonce to be correct
         require(_nonce == getOvmContractNonce(eoaAddress), "Incorrect nonce!");
-<<<<<<< HEAD
         emit CallingWithEOA(eoaAddress);
-=======
         executionContext.ovmTxOrigin = eoaAddress;
->>>>>>> origin/master
         // Make the EOA call for the account
         executeUnsignedEOACall(_timestamp, _queueOrigin, _ovmEntrypoint, _callBytes, eoaAddress);
         executionContext.ovmTxOrigin = ZERO_ADDRESS;

--- a/packages/ovm/src/contracts/ExecutionManager.sol
+++ b/packages/ovm/src/contracts/ExecutionManager.sol
@@ -41,7 +41,9 @@ contract ExecutionManager is FullStateManager {
         address _codeContractAddress,
         bytes32 _codeContractHash
     );
-    event CallingWithEOA();
+    event CallingWithEOA(
+        address _ovmFromAddress
+    );
     event EOACreatedContract(
         address _ovmContractAddress
     );
@@ -183,6 +185,7 @@ contract ExecutionManager is FullStateManager {
         require(eoaAddress != ZERO_ADDRESS, "Failed to recover signature");
         // Require nonce to be correct
         require(_nonce == getOvmContractNonce(eoaAddress), "Incorrect nonce!");
+        emit CallingWithEOA(eoaAddress);
         // Make the EOA call for the account
         executeUnsignedEOACall(_timestamp, _queueOrigin, _ovmEntrypoint, _callBytes, eoaAddress);
     }
@@ -204,7 +207,6 @@ contract ExecutionManager is FullStateManager {
         address _fromAddress
     ) public {
         uint _nonce = getOvmContractNonce(_fromAddress);
-        emit CallingWithEOA();
         // Initialize our context
         initializeContext(_timestamp, _queueOrigin);
 

--- a/packages/ovm/test/app/utils.spec.ts
+++ b/packages/ovm/test/app/utils.spec.ts
@@ -1,0 +1,77 @@
+import { Contract, ethers } from 'ethers'
+import { add0x, ZERO_ADDRESS, TestUtils } from '@eth-optimism/core-utils'
+/* Contract Imports */
+import { getWallets } from 'ethereum-waffle'
+import { TransactionReceipt, JsonRpcProvider, Log } from 'ethers/providers'
+import {
+  convertInternalLogsToOvmLogs,
+  getOvmTransactionMetadata,
+} from '../../src/app'
+import { buildLog } from '../helpers'
+
+const ALICE = '0x0000000000000000000000000000000000000001'
+const BOB = '0x0000000000000000000000000000000000000002'
+const CONTRACT = '0x000000000000000000000000000000000000000C'
+const CODE_CONTRACT = '0x00000000000000000000000000000000000000CC'
+const CODE_CONTRACT_HASH = add0x('00'.repeat(32))
+// We're not actually making any calls to the
+// Execution manager so this can be the zero address
+const EXECUTION_MANAGER_ADDRESS = ZERO_ADDRESS
+
+describe('convertInternalLogsToOvmLogs', () => {
+  it('should replace the address of the event with the address of the last active contract event', async () => {
+    convertInternalLogsToOvmLogs(
+      [
+        [EXECUTION_MANAGER_ADDRESS, 'ActiveContract(address)', [ALICE]],
+        [EXECUTION_MANAGER_ADDRESS, 'EventFromAlice()', []],
+        [EXECUTION_MANAGER_ADDRESS, 'ActiveContract(address)', [BOB]],
+        [EXECUTION_MANAGER_ADDRESS, 'EventFromBob()', []],
+      ].map((args) => buildLog.apply(null, args))
+    ).should.deep.eq(
+      [
+        [ALICE, 'EventFromAlice()', []],
+        [BOB, 'EventFromBob()', []],
+      ].map((args) => buildLog.apply(null, args))
+    )
+  })
+})
+
+describe('getOvmTransactionMetadata', () => {
+  it('should return transaction metadata from calls from externally owned accounts', async () => {
+    const transactionReceipt: TransactionReceipt = {
+      byzantium: true,
+      logs: [
+        [EXECUTION_MANAGER_ADDRESS, 'ActiveContract(address)', [ALICE]],
+        [EXECUTION_MANAGER_ADDRESS, 'CallingWithEOA(address)', [ALICE]],
+        [EXECUTION_MANAGER_ADDRESS, 'ActiveContract(address)', [ALICE]],
+        [EXECUTION_MANAGER_ADDRESS, 'EOACreatedContract(address)', [CONTRACT]],
+        [EXECUTION_MANAGER_ADDRESS, 'ActiveContract(address)', [CONTRACT]],
+        [
+          EXECUTION_MANAGER_ADDRESS,
+          'CreatedContract(address,address,bytes32)',
+          [CONTRACT, CODE_CONTRACT, CODE_CONTRACT_HASH],
+        ],
+      ].map((args) => buildLog.apply(null, args)),
+    }
+
+    getOvmTransactionMetadata(transactionReceipt).should.deep.eq({
+      ovmCreatedContractAddress: CONTRACT,
+      ovmFrom: ALICE,
+      ovmTo: CONTRACT,
+      ovmTxSucceeded: true,
+    })
+  })
+
+  it('should return with ovmTxSucceeded equal to false if the transaction reverted', async () => {
+    const transactionReceipt: TransactionReceipt = {
+      byzantium: true,
+      logs: [[EXECUTION_MANAGER_ADDRESS, 'EOACallRevert()', []]].map((args) =>
+        buildLog.apply(null, args)
+      ),
+    }
+
+    getOvmTransactionMetadata(transactionReceipt).ovmTxSucceeded.should.eq(
+      false
+    )
+  })
+})

--- a/packages/ovm/test/helpers.ts
+++ b/packages/ovm/test/helpers.ts
@@ -6,6 +6,7 @@ import {
   add0x,
   abi,
   keccak256,
+  strToHexStr,
   remove0x,
   hexStrToBuf,
   bufToHexString,
@@ -13,7 +14,12 @@ import {
 } from '@eth-optimism/core-utils'
 import * as ethereumjsAbi from 'ethereumjs-abi'
 import { Contract, ContractFactory, Wallet, ethers } from 'ethers'
-import { Provider, TransactionReceipt, JsonRpcProvider } from 'ethers/providers'
+import {
+  Provider,
+  TransactionReceipt,
+  JsonRpcProvider,
+  Log,
+} from 'ethers/providers'
 import { Transaction } from 'ethers/utils'
 
 /* Contract Imports */
@@ -70,7 +76,7 @@ export const manuallyDeployOvmContractReturnReceipt = async (
     initCode
   )
 
-  return internalTxReceiptToOvmTxReceipt(executionManager, receipt)
+  return internalTxReceiptToOvmTxReceipt(receipt)
 }
 
 /**
@@ -292,4 +298,27 @@ export const didCreateSucceed = async (
       .map((x) => executionManager.interface.parseLog(x))
       .filter((x) => x.name === 'CreatedContract').length > 0
   )
+}
+
+/**
+ * Builds a ethers.js Log object from it's respective parts
+ *
+ * @param address The address the logs was sent from
+ * @param event The event identifier
+ * @param data The event data
+ * @returns an ethers.js Log object
+ */
+export const buildLog = (
+  address: string,
+  event: string,
+  data: string[]
+): Log => {
+  const types = event.match(/\((.+)\)/)
+  const encodedData = types ? abi.encode(types[1].split(','), data) : '0x'
+
+  return {
+    address,
+    topics: [add0x(keccak256(strToHexStr(event)))],
+    data: encodedData,
+  }
 }

--- a/packages/rollup-full-node/src/app/handler.ts
+++ b/packages/rollup-full-node/src/app/handler.ts
@@ -13,7 +13,6 @@ import {
   convertInternalLogsToOvmLogs,
   L2ExecutionManagerContractDefinition,
   OPCODE_WHITELIST_MASK,
-  LogConversionResult,
   internalTxReceiptToOvmTxReceipt,
 } from '@eth-optimism/ovm'
 
@@ -330,7 +329,6 @@ export class DefaultWeb3Handler implements Web3Handler, FullnodeHandler {
 
     // Now let's parse the internal transaction reciept
     const ovmTxReceipt = await internalTxReceiptToOvmTxReceipt(
-      this.executionManager,
       internalTxReceipt
     )
     log.debug(


### PR DESCRIPTION
Other changes:

* Add a separate function for getting ovm transaction metadata
* Move `CallingWithEOA` event into the `CallEOA` function and add an argument to simplify event parsing

## Metadata
### Fixes
- Fixes # [YAS-184 - Add better tests for Event parsing](https://optimists.atlassian.net/jira/software/projects/YAS/boards/2?selectedIssue=YAS-184)

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
