### PR TITLE
Refactor tests and test EXTCODECOPY Failure Behavior

### DIFF
--- a/packages/core-utils/src/app/misc.ts
+++ b/packages/core-utils/src/app/misc.ts
@@ -182,6 +182,15 @@ export const hexStrToBuf = (hexString: string): Buffer => {
 }
 
 /**
+ * Converts a hex string to a javascript Number
+ * @param hexString the hex string to be converted
+ * @returns the hexString as a javascript Number.
+ */
+export const hexStrToNumber = (hexString: string): number => {
+  return parseInt(remove0x(hexString), 16)
+}
+
+/**
  * Converts the provided buffer into a hex string.
  * @param buff The buffer.
  * @param prepend0x Whether or not to prepend '0x' to the resulting string.

--- a/packages/core-utils/src/app/misc.ts
+++ b/packages/core-utils/src/app/misc.ts
@@ -182,9 +182,9 @@ export const hexStrToBuf = (hexString: string): Buffer => {
 }
 
 /**
- * Converts a hex string to a javascript Number
+ * Converts a hex string to a JavaScript Number
  * @param hexString the hex string to be converted
- * @returns the hexString as a javascript Number.
+ * @returns the hexString as a JavaScript Number.
  */
 export const hexStrToNumber = (hexString: string): number => {
   return parseInt(remove0x(hexString), 16)

--- a/packages/ovm/package.json
+++ b/packages/ovm/package.json
@@ -57,6 +57,7 @@
     "ethereum-waffle": "2.1.0",
     "ethers": "^4.0.37",
     "ethlint": "^1.2.5",
+    "lodash": "^4.17.15",
     "mathjs": "^6.6.0",
     "merkletreejs": "^0.1.7",
     "openzeppelin-solidity": "^2.2.0"

--- a/packages/ovm/package.json
+++ b/packages/ovm/package.json
@@ -43,6 +43,7 @@
     "chai": "^4.2.0",
     "chai-bignumber": "^3.0.0",
     "ethereumjs-abi": "^0.6.8",
+    "lodash": "^4.17.15",
     "memdown": "^5.0.0",
     "mocha": "^6.0.2",
     "rimraf": "^2.6.3",
@@ -57,7 +58,6 @@
     "ethereum-waffle": "2.1.0",
     "ethers": "^4.0.37",
     "ethlint": "^1.2.5",
-    "lodash": "^4.17.15",
     "mathjs": "^6.6.0",
     "merkletreejs": "^0.1.7",
     "openzeppelin-solidity": "^2.2.0"

--- a/packages/ovm/src/app/ovm.ts
+++ b/packages/ovm/src/app/ovm.ts
@@ -14,7 +14,6 @@ import {
   StorageElement,
   StorageSlot,
   StorageValue,
-  Transaction,
   TransactionLog,
   TransactionReceipt,
   TransactionResult,

--- a/packages/ovm/src/app/utils.ts
+++ b/packages/ovm/src/app/utils.ts
@@ -1,6 +1,6 @@
 /* External Imports */
 import { getLogger, ZERO_ADDRESS } from '@eth-optimism/core-utils'
-import { Contract, ethers } from 'ethers'
+import { ethers } from 'ethers'
 import { Log, TransactionReceipt } from 'ethers/providers'
 /* Contract Imports */
 

--- a/packages/ovm/src/types/ovm.ts
+++ b/packages/ovm/src/types/ovm.ts
@@ -4,7 +4,6 @@ import {
   Address,
   StorageSlot,
   StorageValue,
-  Transaction,
   TransactionResult,
 } from '@eth-optimism/rollup-core'
 

--- a/packages/ovm/test/app/utils.spec.ts
+++ b/packages/ovm/test/app/utils.spec.ts
@@ -1,8 +1,6 @@
-import { Contract, ethers } from 'ethers'
-import { add0x, ZERO_ADDRESS, TestUtils } from '@eth-optimism/core-utils'
+import { add0x, ZERO_ADDRESS } from '@eth-optimism/core-utils'
 /* Contract Imports */
-import { getWallets } from 'ethereum-waffle'
-import { TransactionReceipt, JsonRpcProvider, Log } from 'ethers/providers'
+import { TransactionReceipt } from 'ethers/providers'
 import {
   convertInternalLogsToOvmLogs,
   getOvmTransactionMetadata,

--- a/packages/ovm/test/contracts/contract-address-generator.spec.ts
+++ b/packages/ovm/test/contracts/contract-address-generator.spec.ts
@@ -3,7 +3,6 @@ import '../setup'
 /* External Imports */
 import { createMockProvider, deployContract, getWallets } from 'ethereum-waffle'
 import { getLogger } from '@eth-optimism/core-utils'
-import { Address } from '@eth-optimism/rollup-core'
 import { utils } from 'ethers'
 
 /* Contract Imports */

--- a/packages/ovm/test/contracts/execution-manager.call-opcodes.spec.ts
+++ b/packages/ovm/test/contracts/execution-manager.call-opcodes.spec.ts
@@ -31,7 +31,7 @@ import {
 } from '../helpers'
 import { GAS_LIMIT, OPCODE_WHITELIST_MASK } from '../../src/app'
 import { TransactionReceipt } from 'ethers/providers'
-import { fromPairs } from "lodash";
+import { fromPairs } from 'lodash'
 
 export const abi = new ethers.utils.AbiCoder()
 
@@ -41,19 +41,19 @@ const log = getLogger('execution-manager-calls', true)
  * TESTS *
  *********/
 
-const methodIds = fromPairs([
-  'executeCall',
-  'makeCall',
-  'makeStaticCall',
-  'makeStaticCallThenCall',
-  'staticFriendlySLOAD',
-  'notStaticFriendlySSTORE',
-  'notStaticFriendlyCREATE',
-  'notStaticFriendlyCREATE2',
-  'staticFriendlySLOAD',
-  'makeDelegateCall'
-].map((methodId) =>
-  [methodId, encodeMethodId(methodId)])
+const methodIds = fromPairs(
+  [
+    'executeCall',
+    'makeCall',
+    'makeStaticCall',
+    'makeStaticCallThenCall',
+    'staticFriendlySLOAD',
+    'notStaticFriendlySSTORE',
+    'notStaticFriendlyCREATE',
+    'notStaticFriendlyCREATE2',
+    'staticFriendlySLOAD',
+    'makeDelegateCall',
+  ].map((methodId) => [methodId, encodeMethodId(methodId)])
 )
 
 const sloadKey: string = '11'.repeat(32)

--- a/packages/ovm/test/contracts/execution-manager.call-opcodes.spec.ts
+++ b/packages/ovm/test/contracts/execution-manager.call-opcodes.spec.ts
@@ -26,6 +26,9 @@ import {
   DEFAULT_ETHNODE_GAS_LIMIT,
   didCreateSucceed,
   gasLimit,
+  executeOVMCall,
+  encodeMethodId,
+  encodeRawArguments,
 } from '../helpers'
 import { GAS_LIMIT, OPCODE_WHITELIST_MASK } from '../../src/app'
 import { TransactionReceipt } from 'ethers/providers'
@@ -169,15 +172,22 @@ describe('Execution Manager -- Call opcodes', () => {
       .methodID('makeCall', [])
       .toString('hex')
 
-    it('properly executes ovmCALL to SLOAD', async () => {
-      const data: string = `${executeCallToCallContractData}${callMethodId}${callContract2Address32}${sloadMethodIdAndParams}`
-
-      const result = await executionManager.provider.call({
-        to: executionManager.address,
-        data,
-        gasLimit,
-      })
-
+    it.only('properly executes ovmCALL to SLOAD', async () => {
+      const result: string = await executeOVMCall(
+        executionManager,
+        "executeCall",
+        [
+          encodeRawArguments([
+            0,
+            0,
+            addressToBytes32Address(callContractAddress),
+            encodeMethodId("makeCall"),
+            addressToBytes32Address(callContract2Address),
+            encodeMethodId("staticFriendlySLOAD"),
+            sloadKey,
+          ])
+        ]
+      )
       log.debug(`Result: [${result}]`)
 
       remove0x(result).should.equal(unpopultedSLOADResult, 'Result mismatch!')

--- a/packages/ovm/test/contracts/execution-manager.call-opcodes.spec.ts
+++ b/packages/ovm/test/contracts/execution-manager.call-opcodes.spec.ts
@@ -62,7 +62,6 @@ describe('Execution Manager -- Call opcodes', () => {
   let callContractAddress: Address
   let callContract2Address: Address
   let callContract3Address: Address
-  const callContractAddress32: string
   let deployTx: any
 
   /* Link libraries before tests */

--- a/packages/ovm/test/contracts/execution-manager.call-opcodes.spec.ts
+++ b/packages/ovm/test/contracts/execution-manager.call-opcodes.spec.ts
@@ -2,13 +2,7 @@ import '../setup'
 
 /* External Imports */
 import { Address } from '@eth-optimism/rollup-core'
-import {
-  getLogger,
-  BigNumber,
-  remove0x,
-  add0x,
-  TestUtils,
-} from '@eth-optimism/core-utils'
+import { getLogger, remove0x, add0x, TestUtils } from '@eth-optimism/core-utils'
 
 import { Contract, ContractFactory, ethers } from 'ethers'
 import { createMockProvider, deployContract, getWallets } from 'ethereum-waffle'
@@ -30,7 +24,6 @@ import {
   encodeRawArguments,
 } from '../helpers'
 import { GAS_LIMIT, OPCODE_WHITELIST_MASK } from '../../src/app'
-import { TransactionReceipt } from 'ethers/providers'
 import { fromPairs } from 'lodash'
 
 export const abi = new ethers.utils.AbiCoder()
@@ -66,13 +59,10 @@ describe('Execution Manager -- Call opcodes', () => {
   // Create pointers to our execution manager & simple copier contract
   let executionManager: Contract
   let dummyContract: Contract
-  let callContract: ContractFactory
   let callContractAddress: Address
   let callContract2Address: Address
   let callContract3Address: Address
-  let callContractAddress32: string
-  let callContract2Address32: string
-  let callContract3Address32: string
+  const callContractAddress32: string
   let deployTx: any
 
   /* Link libraries before tests */
@@ -125,22 +115,6 @@ describe('Execution Manager -- Call opcodes', () => {
     )
 
     log.debug(`Contract address: [${callContractAddress}]`)
-
-    // Also set our simple copier Ethers contract so we can generate unsigned transactions
-    callContract = new ContractFactory(
-      SimpleCall.abi as any,
-      SimpleCall.bytecode
-    )
-
-    callContractAddress32 = remove0x(
-      addressToBytes32Address(callContractAddress)
-    )
-    callContract2Address32 = remove0x(
-      addressToBytes32Address(callContract2Address)
-    )
-    callContract3Address32 = remove0x(
-      addressToBytes32Address(callContract2Address)
-    )
   })
 
   describe('ovmCALL', async () => {
@@ -411,7 +385,7 @@ describe('Execution Manager -- Call opcodes', () => {
         ])
 
       await TestUtils.assertThrowsAsync(async () => {
-        const res = await executionManager.provider.call({
+        await executionManager.provider.call({
           to: executionManager.address,
           data,
           gasLimit,

--- a/packages/ovm/test/contracts/execution-manager.code-opcodes.spec.ts
+++ b/packages/ovm/test/contracts/execution-manager.code-opcodes.spec.ts
@@ -4,18 +4,14 @@ import '../setup'
 import { Address } from '@eth-optimism/rollup-core'
 import {
   getLogger,
-  add0x,
   BigNumber,
   hexStrToBuf,
   remove0x,
   keccak256,
-  bufferUtils,
-  bufToHexString,
 } from '@eth-optimism/core-utils'
 
 import { Contract, ContractFactory, ethers } from 'ethers'
 import { createMockProvider, deployContract, getWallets } from 'ethereum-waffle'
-import * as ethereumjsAbi from 'ethereumjs-abi'
 
 /* Contract Imports */
 import * as ExecutionManager from '../../build/contracts/ExecutionManager.json'
@@ -24,14 +20,11 @@ import * as DummyContract from '../../build/contracts/DummyContract.json'
 /* Internal Imports */
 import {
   manuallyDeployOvmContract,
-  getUnsignedTransactionCalldata,
   DEFAULT_ETHNODE_GAS_LIMIT,
-  gasLimit,
   executeOVMCall,
   addressToBytes32Address,
 } from '../helpers'
 import { GAS_LIMIT, OPCODE_WHITELIST_MASK } from '../../src/app'
-import { fromPairs } from 'lodash'
 
 export const abi = new ethers.utils.AbiCoder()
 

--- a/packages/ovm/test/contracts/execution-manager.code-opcodes.spec.ts
+++ b/packages/ovm/test/contracts/execution-manager.code-opcodes.spec.ts
@@ -31,6 +31,7 @@ import {
   addressToBytes32Address,
 } from '../helpers'
 import { GAS_LIMIT, OPCODE_WHITELIST_MASK } from '../../src/app'
+import { fromPairs } from "lodash";
 
 export const abi = new ethers.utils.AbiCoder()
 
@@ -85,10 +86,8 @@ describe('Execution Manager -- Code-related opcodes', () => {
     it('properly gets contract code size for the contract we expect', async () => {
       const result: string = await executeOVMCall(
         executionManager,
-        "ovmEXTCODESIZE",
-        [
-          addressToBytes32Address(dummyContractAddress),
-        ]
+        'ovmEXTCODESIZE',
+        [addressToBytes32Address(dummyContractAddress)]
       )
       log.debug(`Resulting size: [${result}]`)
 
@@ -104,10 +103,8 @@ describe('Execution Manager -- Code-related opcodes', () => {
     it('properly gets contract code hash for the contract we expect', async () => {
       const codeHash: string = await executeOVMCall(
         executionManager,
-        "ovmEXTCODEHASH",
-        [
-          addressToBytes32Address(dummyContractAddress),
-        ]
+        'ovmEXTCODEHASH',
+        [addressToBytes32Address(dummyContractAddress)]
       )
       log.debug(`Resulting hash: [${codeHash}]`)
 
@@ -121,7 +118,7 @@ describe('Execution Manager -- Code-related opcodes', () => {
     it('properly gets all contract code via EXTCODECOPY', async () => {
       const code: string = await executeOVMCall(
         executionManager,
-        "ovmEXTCODECOPY",
+        'ovmEXTCODECOPY',
         [
           addressToBytes32Address(dummyContractAddress),
           0,
@@ -137,7 +134,7 @@ describe('Execution Manager -- Code-related opcodes', () => {
     it('returns zeroed bytes if the range is out of bounds', async () => {
       const code: string = await executeOVMCall(
         executionManager,
-        "ovmEXTCODECOPY",
+        'ovmEXTCODECOPY',
         [
           addressToBytes32Address(dummyContractAddress),
           0,
@@ -147,10 +144,11 @@ describe('Execution Manager -- Code-related opcodes', () => {
       log.debug(`Resulting code: [${code}]`)
 
       const codeBuff: Buffer = hexStrToBuf(code)
-      const bytecodeWithZeroedBytes = Buffer.concat([dummyContractBytecode, Buffer.alloc(3)])
+      const bytecodeWithZeroedBytes = Buffer.concat([
+        dummyContractBytecode,
+        Buffer.alloc(3),
+      ])
       codeBuff.should.eql(bytecodeWithZeroedBytes, 'Incorrect code!')
     })
   })
 })
-
-

--- a/packages/ovm/test/contracts/execution-manager.code-opcodes.spec.ts
+++ b/packages/ovm/test/contracts/execution-manager.code-opcodes.spec.ts
@@ -82,11 +82,10 @@ describe('Execution Manager -- Code-related opcodes', () => {
   })
 
   describe('getContractCodeSize', async () => {
-    it.only('properly gets contract code size for the contract we expect', async () => {
+    it('properly gets contract code size for the contract we expect', async () => {
       const result: string = await executeOVMCall(
         executionManager,
-        wallet,
-        "EXTCODESIZE",
+        "ovmEXTCODESIZE",
         [
           addressToBytes32Address(dummyContractAddress),
         ]
@@ -105,8 +104,7 @@ describe('Execution Manager -- Code-related opcodes', () => {
     it('properly gets contract code hash for the contract we expect', async () => {
       const codeHash: string = await executeOVMCall(
         executionManager,
-        wallet,
-        "EXTCODEHASH",
+        "ovmEXTCODEHASH",
         [
           addressToBytes32Address(dummyContractAddress),
         ]
@@ -123,8 +121,7 @@ describe('Execution Manager -- Code-related opcodes', () => {
     it('properly gets all contract code via EXTCODECOPY', async () => {
       const code: string = await executeOVMCall(
         executionManager,
-        wallet,
-        "EXTCODECOPY",
+        "ovmEXTCODECOPY",
         [
           addressToBytes32Address(dummyContractAddress),
           0,
@@ -140,8 +137,7 @@ describe('Execution Manager -- Code-related opcodes', () => {
     it('returns zeroed bytes if the range is out of bounds', async () => {
       const code: string = await executeOVMCall(
         executionManager,
-        wallet,
-        "EXTCODECOPY",
+        "ovmEXTCODECOPY",
         [
           addressToBytes32Address(dummyContractAddress),
           0,

--- a/packages/ovm/test/contracts/execution-manager.code-opcodes.spec.ts
+++ b/packages/ovm/test/contracts/execution-manager.code-opcodes.spec.ts
@@ -150,11 +150,7 @@ describe('Execution Manager -- Code-related opcodes', () => {
       const code: string = await executeOVMCall(
         executionManager,
         'ovmEXTCODECOPY',
-        [
-          addressToBytes32Address('11'.repeat(20)),
-          0,
-          length,
-        ]
+        [addressToBytes32Address('11'.repeat(20)), 0, length]
       )
       log.debug(`Resulting code: [${code}]`)
 

--- a/packages/ovm/test/contracts/execution-manager.code-opcodes.spec.ts
+++ b/packages/ovm/test/contracts/execution-manager.code-opcodes.spec.ts
@@ -31,7 +31,7 @@ import {
   addressToBytes32Address,
 } from '../helpers'
 import { GAS_LIMIT, OPCODE_WHITELIST_MASK } from '../../src/app'
-import { fromPairs } from "lodash";
+import { fromPairs } from 'lodash'
 
 export const abi = new ethers.utils.AbiCoder()
 

--- a/packages/ovm/test/contracts/execution-manager.code-opcodes.spec.ts
+++ b/packages/ovm/test/contracts/execution-manager.code-opcodes.spec.ts
@@ -143,5 +143,23 @@ describe('Execution Manager -- Code-related opcodes', () => {
       ])
       codeBuff.should.eql(bytecodeWithZeroedBytes, 'Incorrect code!')
     })
+
+    it('returns zeroed bytes if the provided address is invalid', async () => {
+      const offset = 0
+      const length = 99
+      const code: string = await executeOVMCall(
+        executionManager,
+        'ovmEXTCODECOPY',
+        [
+          addressToBytes32Address('11'.repeat(20)),
+          0,
+          length,
+        ]
+      )
+      log.debug(`Resulting code: [${code}]`)
+
+      const codeBuff: Buffer = hexStrToBuf(code)
+      codeBuff.should.eql(Buffer.alloc(length), 'Incorrect code!')
+    })
   })
 })

--- a/packages/ovm/test/contracts/execution-manager.context-opcodes.spec.ts
+++ b/packages/ovm/test/contracts/execution-manager.context-opcodes.spec.ts
@@ -3,8 +3,6 @@ import { should } from '../setup'
 /* External Imports */
 import { Address } from '@eth-optimism/rollup-core'
 import {
-  bufferUtils,
-  bufToHexString,
   getLogger,
   hexStrToNumber,
   remove0x,
@@ -13,7 +11,6 @@ import {
 
 import { Contract, ContractFactory, ethers } from 'ethers'
 import { createMockProvider, deployContract, getWallets } from 'ethereum-waffle'
-import * as ethereumjsAbi from 'ethereumjs-abi'
 
 /* Contract Imports */
 import * as ExecutionManager from '../../build/contracts/ExecutionManager.json'
@@ -22,11 +19,8 @@ import * as ContextContract from '../../build/contracts/ContextContract.json'
 /* Internal Imports */
 import {
   manuallyDeployOvmContract,
-  getUnsignedTransactionCalldata,
-  bytes32AddressToAddress,
   addressToBytes32Address,
   DEFAULT_ETHNODE_GAS_LIMIT,
-  gasLimit,
   executeOVMCall,
   encodeRawArguments,
   encodeMethodId,
@@ -56,12 +50,9 @@ const methodIds = fromPairs(
 describe('Execution Manager -- Context opcodes', () => {
   const provider = createMockProvider({ gasLimit: DEFAULT_ETHNODE_GAS_LIMIT })
   const [wallet] = getWallets(provider)
-  const defaultTimestampAndQueueOrigin: string = '00'.repeat(64)
 
   // Create pointers to our execution manager & simple copier contract
   let executionManager: Contract
-  let contract: ContractFactory
-  let contract2: ContractFactory
   let contractAddress: Address
   let contract2Address: Address
   let contractAddress32: string
@@ -88,7 +79,7 @@ describe('Execution Manager -- Context opcodes', () => {
     log.debug(`Contract address: [${contractAddress}]`)
 
     // Also set our simple copier Ethers contract so we can generate unsigned transactions
-    contract = new ContractFactory(
+    const contract = new ContractFactory(
       ContextContract.abi as any,
       ContextContract.bytecode
     )
@@ -105,7 +96,7 @@ describe('Execution Manager -- Context opcodes', () => {
     log.debug(`Contract address: [${contractAddress}]`)
 
     // Also set our simple copier Ethers contract so we can generate unsigned transactions
-    contract2 = new ContractFactory(
+    const contract2 = new ContractFactory(
       ContextContract.abi as any,
       ContextContract.bytecode
     )

--- a/packages/ovm/test/contracts/execution-manager.context-opcodes.spec.ts
+++ b/packages/ovm/test/contracts/execution-manager.context-opcodes.spec.ts
@@ -34,10 +34,13 @@ const log = getLogger('execution-manager-context', true)
 
 const methodIds = fromPairs(
   [
-    'getTIMESTAMP',
     'callThroughExecutionManager',
     'executeCall',
+    'getADDRESS',
     'getCALLER',
+    'getGASLIMIT',
+    'getQueueOrigin',
+    'getTIMESTAMP',
     'ovmADDRESS',
     'ovmCALLER',
   ].map((methodId) => [methodId, encodeMethodId(methodId)])
@@ -108,16 +111,16 @@ describe('Execution Manager -- Context opcodes', () => {
   describe('ovmCALLER', async () => {
     it('reverts when CALLER is not set', async () => {
       await TestUtils.assertThrowsAsync(async () => {
-        await executeCall([contractAddress32, encodeMethodId('ovmCALLER')])
+        await executeCall([contractAddress32, methodIds.ovmCALLER])
       })
     })
 
     it('properly retrieves CALLER when caller is set', async () => {
       const result = await executeCall([
         contractAddress32,
-        encodeMethodId('callThroughExecutionManager'),
+        methodIds.callThroughExecutionManager,
         contract2Address32,
-        encodeMethodId('getCALLER'),
+        methodIds.getCALLER,
       ])
       log.debug(`CALLER result: ${result}`)
 
@@ -129,16 +132,16 @@ describe('Execution Manager -- Context opcodes', () => {
   describe('ovmADDRESS', async () => {
     it('reverts when ADDRESS is not set', async () => {
       await TestUtils.assertThrowsAsync(async () => {
-        await executeCall([contractAddress32, encodeMethodId('ovmADDRESS')])
+        await executeCall([contractAddress32, methodIds.ovmADDRESS])
       })
     })
 
     it('properly retrieves ADDRESS when address is set', async () => {
       const result = await executeCall([
         contractAddress32,
-        encodeMethodId('callThroughExecutionManager'),
+        methodIds.callThroughExecutionManager,
         contract2Address32,
-        encodeMethodId('getADDRESS'),
+        methodIds.getADDRESS,
       ])
 
       log.debug(`ADDRESS result: ${result}`)
@@ -153,9 +156,9 @@ describe('Execution Manager -- Context opcodes', () => {
       await TestUtils.assertThrowsAsync(async () => {
         await executeCall([
           contractAddress32,
-          encodeMethodId('callThroughExecutionManager'),
+          methodIds.callThroughExecutionManager,
           contract2Address32,
-          encodeMethodId('getTIMESTAMP'),
+          methodIds.getTIMESTAMP,
         ])
       })
     })
@@ -166,9 +169,9 @@ describe('Execution Manager -- Context opcodes', () => {
         timestamp,
         0,
         contractAddress32,
-        encodeMethodId('callThroughExecutionManager'),
+        methodIds.callThroughExecutionManager,
         contract2Address32,
-        encodeMethodId('getTIMESTAMP'),
+        methodIds.getTIMESTAMP,
       ])
 
       log.debug(`TIMESTAMP result: ${result}`)
@@ -182,9 +185,9 @@ describe('Execution Manager -- Context opcodes', () => {
     it('properly retrieves GASLIMIT', async () => {
       const result = await executeCall([
         contractAddress32,
-        encodeMethodId('callThroughExecutionManager'),
+        methodIds.callThroughExecutionManager,
         contract2Address32,
-        encodeMethodId('getGASLIMIT'),
+        methodIds.getGASLIMIT,
       ])
 
       log.debug(`GASLIMIT result: ${result}`)
@@ -201,9 +204,9 @@ describe('Execution Manager -- Context opcodes', () => {
         0,
         queueOrigin,
         contractAddress32,
-        encodeMethodId('callThroughExecutionManager'),
+        methodIds.callThroughExecutionManager,
         contract2Address32,
-        encodeMethodId('getQueueOrigin'),
+        methodIds.getQueueOrigin,
       ])
 
       log.debug(`QUEUE ORIGIN result: ${result}`)
@@ -218,9 +221,9 @@ describe('Execution Manager -- Context opcodes', () => {
         0,
         queueOrigin,
         contractAddress32,
-        encodeMethodId('callThroughExecutionManager'),
+        methodIds.callThroughExecutionManager,
         contract2Address32,
-        encodeMethodId('getQueueOrigin'),
+        methodIds.getQueueOrigin,
       ])
 
       log.debug(`QUEUE ORIGIN result: ${result}`)

--- a/packages/ovm/test/contracts/execution-manager.create-opcodes.spec.ts
+++ b/packages/ovm/test/contracts/execution-manager.create-opcodes.spec.ts
@@ -22,13 +22,13 @@ import {
   encodeMethodId,
   encodeRawArguments,
 } from '../helpers'
-import { fromPairs } from "lodash";
+import { fromPairs } from 'lodash'
 
-const methodIds = fromPairs([
-  'ovmCREATE',
-  'ovmCREATE2',
-].map((methodId) =>
-  [methodId, encodeMethodId(methodId)])
+const methodIds = fromPairs(
+  ['ovmCREATE', 'ovmCREATE2'].map((methodId) => [
+    methodId,
+    encodeMethodId(methodId),
+  ])
 )
 
 /*********
@@ -72,9 +72,9 @@ describe('ExecutionManager -- Create opcodes', () => {
   })
 
   describe('ovmCREATE', async () => {
-    it('returns created address when passed valid bytecode', async () => {
+    it.only('returns created address when passed valid bytecode', async () => {
       const result = await executeOVMCall(executionManager, 'ovmCREATE', [
-        remove0x(deployTx.data)
+        deployTx.data,
       ])
 
       log.debug(`Result: [${result}]`)
@@ -85,7 +85,9 @@ describe('ExecutionManager -- Create opcodes', () => {
     })
 
     it('returns 0 address when passed invalid bytecode', async () => {
-      const data = add0x(methodIds.ovmCREATE + encodeRawArguments([deployInvalidTx.data]))
+      const data = add0x(
+        methodIds.ovmCREATE + encodeRawArguments([deployInvalidTx.data])
+      )
 
       // Now actually apply it to our execution manager
       const result = await executionManager.provider.call({
@@ -104,7 +106,9 @@ describe('ExecutionManager -- Create opcodes', () => {
 
   describe('ovmCREATE2', async () => {
     it('returns created address when passed salt and bytecode', async () => {
-      const data = add0x(methodIds.ovmCREATE2 + encodeRawArguments([0, deployTx.data]))
+      const data = add0x(
+        methodIds.ovmCREATE2 + encodeRawArguments([0, deployTx.data])
+      )
 
       // Now actually apply it to our execution manager
       const result = await executionManager.provider.call({
@@ -121,7 +125,9 @@ describe('ExecutionManager -- Create opcodes', () => {
     })
 
     it('returns 0 address when passed salt and invalid bytecode', async () => {
-      const data = add0x(methodIds.ovmCREATE2 + encodeRawArguments([0, deployInvalidTx.data]))
+      const data = add0x(
+        methodIds.ovmCREATE2 + encodeRawArguments([0, deployInvalidTx.data])
+      )
 
       // Now actually apply it to our execution manager
       const result = await executionManager.provider.call({

--- a/packages/ovm/test/contracts/execution-manager.create-opcodes.spec.ts
+++ b/packages/ovm/test/contracts/execution-manager.create-opcodes.spec.ts
@@ -3,7 +3,6 @@ import '../setup'
 /* External Imports */
 import { createMockProvider, deployContract, getWallets } from 'ethereum-waffle'
 import { getLogger, remove0x, add0x } from '@eth-optimism/core-utils'
-import * as ethereumjsAbi from 'ethereumjs-abi'
 import { Contract, ContractFactory } from 'ethers'
 
 /* Contract Imports */
@@ -72,7 +71,7 @@ describe('ExecutionManager -- Create opcodes', () => {
   })
 
   describe('ovmCREATE', async () => {
-    it.only('returns created address when passed valid bytecode', async () => {
+    it('returns created address when passed valid bytecode', async () => {
       const result = await executeOVMCall(executionManager, 'ovmCREATE', [
         deployTx.data,
       ])

--- a/packages/ovm/test/contracts/execution-manager.create-opcodes.spec.ts
+++ b/packages/ovm/test/contracts/execution-manager.create-opcodes.spec.ts
@@ -2,7 +2,7 @@ import '../setup'
 
 /* External Imports */
 import { createMockProvider, deployContract, getWallets } from 'ethereum-waffle'
-import { getLogger, remove0x } from '@eth-optimism/core-utils'
+import { getLogger, remove0x, add0x } from '@eth-optimism/core-utils'
 import * as ethereumjsAbi from 'ethereumjs-abi'
 import { Contract, ContractFactory } from 'ethers'
 
@@ -15,7 +15,21 @@ const log = getLogger('execution-manager-create', true)
 
 /* Internal Imports */
 import { OPCODE_WHITELIST_MASK, GAS_LIMIT } from '../../src/app'
-import { DEFAULT_ETHNODE_GAS_LIMIT, gasLimit } from '../helpers'
+import {
+  DEFAULT_ETHNODE_GAS_LIMIT,
+  gasLimit,
+  executeOVMCall,
+  encodeMethodId,
+  encodeRawArguments,
+} from '../helpers'
+import { fromPairs } from "lodash";
+
+const methodIds = fromPairs([
+  'ovmCREATE',
+  'ovmCREATE2',
+].map((methodId) =>
+  [methodId, encodeMethodId(methodId)])
+)
 
 /*********
  * TESTS *
@@ -59,18 +73,9 @@ describe('ExecutionManager -- Create opcodes', () => {
 
   describe('ovmCREATE', async () => {
     it('returns created address when passed valid bytecode', async () => {
-      const methodId: string = ethereumjsAbi
-        .methodID('ovmCREATE', [])
-        .toString('hex')
-
-      const data = `0x${methodId}${remove0x(deployTx.data)}`
-
-      // Now actually apply it to our execution manager
-      const result = await executionManager.provider.call({
-        to: executionManager.address,
-        data,
-        gasLimit,
-      })
+      const result = await executeOVMCall(executionManager, 'ovmCREATE', [
+        remove0x(deployTx.data)
+      ])
 
       log.debug(`Result: [${result}]`)
 
@@ -80,11 +85,7 @@ describe('ExecutionManager -- Create opcodes', () => {
     })
 
     it('returns 0 address when passed invalid bytecode', async () => {
-      const methodId: string = ethereumjsAbi
-        .methodID('ovmCREATE', [])
-        .toString('hex')
-
-      const data = `0x${methodId}${remove0x(deployInvalidTx.data)}`
+      const data = add0x(methodIds.ovmCREATE + encodeRawArguments([deployInvalidTx.data]))
 
       // Now actually apply it to our execution manager
       const result = await executionManager.provider.call({
@@ -103,11 +104,7 @@ describe('ExecutionManager -- Create opcodes', () => {
 
   describe('ovmCREATE2', async () => {
     it('returns created address when passed salt and bytecode', async () => {
-      const methodId: string = ethereumjsAbi
-        .methodID('ovmCREATE2', [])
-        .toString('hex')
-
-      const data = `0x${methodId}${'00'.repeat(32)}${remove0x(deployTx.data)}`
+      const data = add0x(methodIds.ovmCREATE2 + encodeRawArguments([0, deployTx.data]))
 
       // Now actually apply it to our execution manager
       const result = await executionManager.provider.call({
@@ -124,13 +121,7 @@ describe('ExecutionManager -- Create opcodes', () => {
     })
 
     it('returns 0 address when passed salt and invalid bytecode', async () => {
-      const methodId: string = ethereumjsAbi
-        .methodID('ovmCREATE2', [])
-        .toString('hex')
-
-      const data = `0x${methodId}${'00'.repeat(32)}${remove0x(
-        deployInvalidTx.data
-      )}`
+      const data = add0x(methodIds.ovmCREATE2 + encodeRawArguments([0, deployInvalidTx.data]))
 
       // Now actually apply it to our execution manager
       const result = await executionManager.provider.call({

--- a/packages/ovm/test/contracts/execution-manager.executeCall.spec.ts
+++ b/packages/ovm/test/contracts/execution-manager.executeCall.spec.ts
@@ -2,13 +2,7 @@ import '../setup'
 
 /* External Imports */
 import { Address } from '@eth-optimism/rollup-core'
-import {
-  add0x,
-  getLogger,
-  padToLength,
-  remove0x,
-  ZERO_ADDRESS,
-} from '@eth-optimism/core-utils'
+import { getLogger, padToLength, ZERO_ADDRESS } from '@eth-optimism/core-utils'
 
 import { Contract, ContractFactory, ethers } from 'ethers'
 import { createMockProvider, deployContract, getWallets } from 'ethereum-waffle'
@@ -22,8 +16,6 @@ import * as DummyContract from '../../build/contracts/DummyContract.json'
 import {
   manuallyDeployOvmContract,
   getUnsignedTransactionCalldata,
-  getTransactionResult,
-  numberToHexWord,
   DEFAULT_ETHNODE_GAS_LIMIT,
 } from '../helpers'
 import { GAS_LIMIT, CHAIN_ID, OPCODE_WHITELIST_MASK } from '../../src/app'

--- a/packages/ovm/test/contracts/execution-manager.purity-checking.spec.ts
+++ b/packages/ovm/test/contracts/execution-manager.purity-checking.spec.ts
@@ -13,7 +13,6 @@ import * as DummyContract from '../../build/contracts/DummyContract.json'
 /* Internal Imports */
 import { OPCODE_WHITELIST_MASK, GAS_LIMIT } from '../../src/app'
 import {
-  manuallyDeployOvmContract,
   DEFAULT_ETHNODE_GAS_LIMIT,
   manuallyDeployOvmContractReturnReceipt,
   didCreateSucceed,

--- a/packages/ovm/test/contracts/execution-manager.recover-eoa-address.spec.ts
+++ b/packages/ovm/test/contracts/execution-manager.recover-eoa-address.spec.ts
@@ -7,7 +7,6 @@ import { createMockProvider, deployContract, getWallets } from 'ethereum-waffle'
 
 /* Contract Imports */
 import * as ExecutionManager from '../../build/contracts/ExecutionManager.json'
-import * as DummyContract from '../../build/contracts/DummyContract.json'
 
 /* Internal Imports */
 import { GAS_LIMIT, CHAIN_ID, OPCODE_WHITELIST_MASK } from '../../src/app'

--- a/packages/ovm/test/contracts/execution-manager.storage-opcodes.spec.ts
+++ b/packages/ovm/test/contracts/execution-manager.storage-opcodes.spec.ts
@@ -12,9 +12,21 @@ import * as SimpleStorage from '../../build/contracts/SimpleStorage.json'
 
 /* Internal Imports */
 import { OPCODE_WHITELIST_MASK, GAS_LIMIT } from '../../src/app'
-import { DEFAULT_ETHNODE_GAS_LIMIT, gasLimit, encodeMethodId, encodeRawArguments } from '../helpers'
+import {
+  DEFAULT_ETHNODE_GAS_LIMIT,
+  gasLimit,
+  encodeMethodId,
+  encodeRawArguments,
+} from '../helpers'
+import { fromPairs } from 'lodash'
 
 const log = getLogger('execution-manager-storage', true)
+const methodIds = fromPairs(
+  ['ovmSSTORE', 'ovmSLOAD'].map((methodId) => [
+    methodId,
+    encodeMethodId(methodId),
+  ])
+)
 
 /*********
  * TESTS *
@@ -40,7 +52,10 @@ describe('ExecutionManager -- Storage opcodes', () => {
   })
 
   const sstore = async (): Promise<void> => {
-      const data = add0x(encodeMethodId('ovmSSTORE') + encodeRawArguments([ONE_FILLED_BYTES_32, TWO_FILLED_BYTES_32]))
+    const data = add0x(
+      encodeMethodId('ovmSSTORE') +
+        encodeRawArguments([ONE_FILLED_BYTES_32, TWO_FILLED_BYTES_32])
+    )
     // Now actually apply it to our execution manager
     const tx = await wallet.sendTransaction({
       to: executionManager.address,
@@ -77,7 +92,10 @@ describe('ExecutionManager -- Storage opcodes', () => {
     it('loads a value immediately after it is stored', async () => {
       await sstore()
 
-      const data = add0x(encodeMethodId('ovmSLOAD') + encodeRawArguments([ONE_FILLED_BYTES_32, TWO_FILLED_BYTES_32]))
+      const data = add0x(
+        encodeMethodId('ovmSLOAD') +
+          encodeRawArguments([ONE_FILLED_BYTES_32, TWO_FILLED_BYTES_32])
+      )
 
       // Now actually apply it to our execution manager
       const result = await executionManager.provider.call({

--- a/packages/ovm/test/contracts/execution-manager.storage-opcodes.spec.ts
+++ b/packages/ovm/test/contracts/execution-manager.storage-opcodes.spec.ts
@@ -2,13 +2,11 @@ import '../setup'
 
 /* External Imports */
 import { createMockProvider, deployContract, getWallets } from 'ethereum-waffle'
-import { abi, getLogger, remove0x, add0x } from '@eth-optimism/core-utils'
-import * as ethereumjsAbi from 'ethereumjs-abi'
-import { Contract, ContractFactory } from 'ethers'
+import { abi, getLogger, add0x } from '@eth-optimism/core-utils'
+import { Contract } from 'ethers'
 
 /* Contract Imports */
 import * as ExecutionManager from '../../build/contracts/ExecutionManager.json'
-import * as SimpleStorage from '../../build/contracts/SimpleStorage.json'
 
 /* Internal Imports */
 import { OPCODE_WHITELIST_MASK, GAS_LIMIT } from '../../src/app'

--- a/packages/ovm/test/contracts/rlp-encode.spec.ts
+++ b/packages/ovm/test/contracts/rlp-encode.spec.ts
@@ -9,7 +9,6 @@ const log = getLogger('rlp-encode', true)
 
 /* Contract Imports */
 import * as RLPEncode from '../../build/contracts/RLPEncode.json'
-import { Contract, ContractFactory, Wallet, utils } from 'ethers'
 
 /* Begin tests */
 describe('RLP Encoder', () => {

--- a/packages/ovm/test/contracts/state-manager.spec.ts
+++ b/packages/ovm/test/contracts/state-manager.spec.ts
@@ -2,13 +2,11 @@ import '../setup'
 
 /* External Imports */
 import { getLogger } from '@eth-optimism/core-utils'
-import { newInMemoryDB, SparseMerkleTreeImpl } from '@eth-optimism/core-db'
 import { createMockProvider, deployContract, getWallets } from 'ethereum-waffle'
 
 /* Contract Imports */
 import * as ExecutionManager from '../../build/contracts/ExecutionManager.json'
-import * as PurityChecker from '../../build/contracts/PurityChecker.json'
-import { Contract, ContractFactory, Wallet, utils } from 'ethers'
+import { Contract } from 'ethers'
 
 /* Internal Imports */
 import { GAS_LIMIT, OPCODE_WHITELIST_MASK } from '../../src/app'

--- a/packages/ovm/test/contracts/tx-origin.spec.ts
+++ b/packages/ovm/test/contracts/tx-origin.spec.ts
@@ -4,8 +4,7 @@ import '../setup'
 import { Address } from '@eth-optimism/rollup-core'
 import { createMockProvider, deployContract, getWallets } from 'ethereum-waffle'
 import { getLogger, add0x } from '@eth-optimism/core-utils'
-import { Contract, ContractFactory, ethers } from 'ethers'
-import { TransactionReceipt } from 'ethers/providers'
+import { Contract, ContractFactory } from 'ethers'
 import * as ethereumjsAbi from 'ethereumjs-abi'
 
 /* Contract Imports */
@@ -19,7 +18,6 @@ import {
   getUnsignedTransactionCalldata,
   signTransation,
   DEFAULT_ETHNODE_GAS_LIMIT,
-  executeEOACall,
 } from '../helpers'
 import { CHAIN_ID, GAS_LIMIT, OPCODE_WHITELIST_MASK } from '../../src/app'
 

--- a/packages/ovm/test/helpers.ts
+++ b/packages/ovm/test/helpers.ts
@@ -325,15 +325,11 @@ export const buildLog = (
 
 export const executeOVMCall = async (
   executionManager: Contract,
-  wallet: Wallet,
   functionName: string,
   args: any[]
 ): Promise<string> => {
-  const methodId: string = ethereumjsAbi
-    .methodID(`ovm${functionName}`, [])
-    .toString('hex')
-  const encodedArguments = encodeOvmArguments(args)
-  const data: string = add0x(methodId + encodedArguments)
+  const data: string = add0x(encodeMethodId(functionName) + encodeRawArguments(args))
+
   return executionManager.provider.call({
     to: executionManager.address,
     data,
@@ -341,7 +337,15 @@ export const executeOVMCall = async (
   })
 }
 
-export const encodeOvmArguments = (
+export const encodeMethodId = (
+  functionName: string,
+): string => {
+  return ethereumjsAbi
+    .methodID(functionName, [])
+    .toString('hex')
+}
+
+export const encodeRawArguments = (
   args: any[]
 ): string => {
   return args.map((arg) => {

--- a/packages/ovm/test/helpers.ts
+++ b/packages/ovm/test/helpers.ts
@@ -322,3 +322,35 @@ export const buildLog = (
     data: encodedData,
   }
 }
+
+export const executeOVMCall = async (
+  executionManager: Contract,
+  wallet: Wallet,
+  functionName: string,
+  args: any[]
+): Promise<string> => {
+  const methodId: string = ethereumjsAbi
+    .methodID(`ovm${functionName}`, [])
+    .toString('hex')
+  const encodedArguments = encodeOvmArguments(args)
+  const data: string = add0x(methodId + encodedArguments)
+  return executionManager.provider.call({
+    to: executionManager.address,
+    data,
+    gasLimit,
+  })
+}
+
+export const encodeOvmArguments = (
+  args: any[]
+): string => {
+  return args.map((arg) => {
+    if(Number.isInteger(arg)) {
+      return bufferUtils.numberToBuffer(arg).toString('hex')
+    } else if(arg.startsWith("0x")) {
+      return remove0x(arg)
+    } else {
+      return arg
+    }
+  }).join("")
+}

--- a/packages/ovm/test/helpers.ts
+++ b/packages/ovm/test/helpers.ts
@@ -323,12 +323,20 @@ export const buildLog = (
   }
 }
 
+/**
+ * Executes a call in the OVM
+ * @param The name of the function to call
+ * @param The function arguments
+ * @returns The return value of the function executed
+ */
 export const executeOVMCall = async (
   executionManager: Contract,
   functionName: string,
   args: any[]
 ): Promise<string> => {
-  const data: string = add0x(encodeMethodId(functionName) + encodeRawArguments(args))
+  const data: string = add0x(
+    encodeMethodId(functionName) + encodeRawArguments(args)
+  )
 
   return executionManager.provider.call({
     to: executionManager.address,
@@ -337,24 +345,31 @@ export const executeOVMCall = async (
   })
 }
 
-export const encodeMethodId = (
-  functionName: string,
-): string => {
-  return ethereumjsAbi
-    .methodID(functionName, [])
-    .toString('hex')
+/**
+ * Computes the method id of a function name and encodes it as
+ * a hexidecimal string.
+ * @param The name of the function
+ * @returns The hex-encoded methodId
+ */
+export const encodeMethodId = (functionName: string): string => {
+  return ethereumjsAbi.methodID(functionName, []).toString('hex')
 }
 
-export const encodeRawArguments = (
-  args: any[]
-): string => {
-  return args.map((arg) => {
-    if(Number.isInteger(arg)) {
-      return bufferUtils.numberToBuffer(arg).toString('hex')
-    } else if(arg.startsWith("0x")) {
-      return remove0x(arg)
-    } else {
-      return arg
-    }
-  }).join("")
+/**
+ * Encodes an array of function arguments into a hex string.
+ * @param any[] An array of arguments
+ * @returns The hex-encoded function arguments
+ */
+export const encodeRawArguments = (args: any[]): string => {
+  return args
+    .map((arg) => {
+      if (Number.isInteger(arg)) {
+        return bufferUtils.numberToBuffer(arg).toString('hex')
+      } else if (arg && arg.startsWith('0x')) {
+        return remove0x(arg)
+      } else {
+        return arg
+      }
+    })
+    .join('')
 }

--- a/packages/ovm/test/helpers.ts
+++ b/packages/ovm/test/helpers.ts
@@ -23,9 +23,7 @@ import {
 import { Transaction } from 'ethers/utils'
 
 /* Contract Imports */
-import * as SimpleStorage from '../build/contracts/SimpleStorage.json'
 import {
-  convertInternalLogsToOvmLogs,
   GAS_LIMIT,
   CHAIN_ID,
   internalTxReceiptToOvmTxReceipt,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3251,7 +3251,7 @@ debug@3.1.0, debug@=3.1.0:
   dependencies:
     ms "2.0.0"
 
-debug@3.2.6, debug@^3.1.0, debug@^3.2.6:
+debug@3.2.6, debug@^3.1.0:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
@@ -3376,11 +3376,6 @@ deep-equal@~1.1.1:
     object-is "^1.0.1"
     object-keys "^1.1.1"
     regexp.prototype.flags "^1.2.0"
-
-deep-extend@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
-  integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
 
 default-compare@^1.0.0:
   version "1.0.0"
@@ -3512,11 +3507,6 @@ detect-indent@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-5.0.0.tgz#3871cc0a6a002e8c3e5b3cf7f336264675f06b9d"
   integrity sha1-OHHMCmoALow+Wzz38zYmRnXwa50=
-
-detect-libc@^1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
-  integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
 
 dezalgo@^1.0.0:
   version "1.0.3"
@@ -5669,7 +5659,7 @@ humanize-ms@^1.2.1:
   dependencies:
     ms "^2.0.0"
 
-iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
+iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@~0.4.13:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -5766,7 +5756,7 @@ inherits@2.0.3:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
 
-ini@^1.3.2, ini@^1.3.4, ini@~1.3.0:
+ini@^1.3.2, ini@^1.3.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
   integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
@@ -7529,15 +7519,6 @@ napi-macros@~2.0.0:
   resolved "https://registry.yarnpkg.com/napi-macros/-/napi-macros-2.0.0.tgz#2b6bae421e7b96eb687aa6c77a7858640670001b"
   integrity sha512-A0xLykHtARfueITVDernsAWdtIMbOJgKgcluwENp3AlsKN/PloyO10HtmoqnFAQAcxPkgZN7wdfPfEd0zNGxbg==
 
-needle@^2.2.1:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/needle/-/needle-2.3.2.tgz#3342dea100b7160960a450dc8c22160ac712a528"
-  integrity sha512-DUzITvPVDUy6vczKKYTnWc/pBZ0EnjMJnQ3y+Jo5zfKFimJs7S3HFCxCRZYB9FUZcrzUQr3WsmvZgddMEIZv6w==
-  dependencies:
-    debug "^3.2.6"
-    iconv-lite "^0.4.4"
-    sax "^1.2.4"
-
 negotiator@0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.2.tgz#feacf7ccf525a77ae9634436a64883ffeca346fb"
@@ -7614,22 +7595,6 @@ node-gyp@^5.0.2:
     semver "^5.7.1"
     tar "^4.4.12"
     which "^1.3.1"
-
-node-pre-gyp@*:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz#9a0596533b877289bcad4e143982ca3d904ddc83"
-  integrity sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==
-  dependencies:
-    detect-libc "^1.0.2"
-    mkdirp "^0.5.1"
-    needle "^2.2.1"
-    nopt "^4.0.1"
-    npm-packlist "^1.1.6"
-    npmlog "^4.0.2"
-    rc "^1.2.7"
-    rimraf "^2.6.1"
-    semver "^5.3.0"
-    tar "^4.4.2"
 
 nopt@^4.0.1:
   version "4.0.1"
@@ -7714,7 +7679,7 @@ npm-normalize-package-bin@^1.0.0, npm-normalize-package-bin@^1.0.1:
     semver "^5.6.0"
     validate-npm-package-name "^3.0.0"
 
-npm-packlist@^1.1.6, npm-packlist@^1.4.4:
+npm-packlist@^1.4.4:
   version "1.4.8"
   resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.8.tgz#56ee6cc135b9f98ad3d51c1c95da22bbb9b2ef3e"
   integrity sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==
@@ -7739,7 +7704,7 @@ npm-run-path@^2.0.0:
   dependencies:
     path-key "^2.0.0"
 
-npmlog@^4.0.2, npmlog@^4.1.2:
+npmlog@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
   integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
@@ -8604,16 +8569,6 @@ raw-body@2.4.0:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
-rc@^1.2.7:
-  version "1.2.8"
-  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
-  integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
-  dependencies:
-    deep-extend "^0.6.0"
-    ini "~1.3.0"
-    minimist "^1.2.0"
-    strip-json-comments "~2.0.1"
-
 read-cmd-shim@^1.0.1:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/read-cmd-shim/-/read-cmd-shim-1.0.5.tgz#87e43eba50098ba5a32d0ceb583ab8e43b961c16"
@@ -9012,7 +8967,7 @@ retry@^0.10.0:
   resolved "https://registry.yarnpkg.com/retry/-/retry-0.10.1.tgz#e76388d217992c252750241d3d3956fed98d8ff4"
   integrity sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=
 
-rimraf@2, rimraf@^2.2.8, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2, rimraf@^2.6.3:
+rimraf@2, rimraf@^2.2.8, rimraf@^2.5.4, rimraf@^2.6.2, rimraf@^2.6.3:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
@@ -9088,11 +9043,6 @@ safe-regex@^1.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
-
-sax@^1.2.4:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
-  integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
 scrypt-js@2.0.3:
   version "2.0.3"
@@ -9748,7 +9698,7 @@ strip-indent@^2.0.0:
   resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-2.0.0.tgz#5ef8db295d01e6ed6cbf7aab96998d7822527b68"
   integrity sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=
 
-strip-json-comments@2.0.1, strip-json-comments@~2.0.1:
+strip-json-comments@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
@@ -9887,7 +9837,7 @@ tar@^2.1.1:
     fstream "^1.0.12"
     inherits "2"
 
-tar@^4.0.2, tar@^4.4.10, tar@^4.4.12, tar@^4.4.2, tar@^4.4.8:
+tar@^4.0.2, tar@^4.4.10, tar@^4.4.12, tar@^4.4.8:
   version "4.4.13"
   resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
   integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==


### PR DESCRIPTION
## Description
Add a test to ensure EXTCODECOPY returns zeroed bytes when the provided range is out of bounds or the provided address is invalid.

## Other Changes
* Add `executeOVMCall`, `encodeMethodId` and `encodeRawArguments` test helpers
* Use those helpers where applicable
* Removed unused variables with `tslint`

## Questions
- Do we want to enable `noUnusedLocals` and `noUnusedParameters` in our `tsconfig` to prevent unused variables?

## Metadata
### Fixes
- Fixes # [YAS-119](https://optimists.atlassian.net/browse/YAS-119)

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
