### PR TITLE
Fixing truffle provider wrapper import so that sub-process works

### DIFF
--- a/packages/core-db/package.json
+++ b/packages/core-db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/core-db",
-  "version": "0.0.1-alpha.14",
+  "version": "0.0.1-alpha.15",
   "description": "Optimism DB Utils",
   "main": "build/index.js",
   "files": [
@@ -29,7 +29,7 @@
     "url": "https://github.com/ethereum-optimism/optimism-monorepo.git"
   },
   "dependencies": {
-    "@eth-optimism/core-utils": "^0.0.1-alpha.14",
+    "@eth-optimism/core-utils": "^0.0.1-alpha.15",
     "abstract-leveldown": "^6.2.2",
     "async-lock": "^1.2.2",
     "chai": "^4.2.0",

--- a/packages/core-utils/package.json
+++ b/packages/core-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/core-utils",
-  "version": "0.0.1-alpha.14",
+  "version": "0.0.1-alpha.15",
   "description": "Optimism Core Utils",
   "main": "build/index.js",
   "files": [

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@eth-optimism/docs",
   "private": true,
-  "version": "0.0.1-alpha.14",
+  "version": "0.0.1-alpha.15",
   "description": "Optimism docs",
   "author": "Optimism",
   "license": "MIT",

--- a/packages/optimistic-game-semantics/package.json
+++ b/packages/optimistic-game-semantics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/optimistic-game-semantics",
-  "version": "0.0.1-alpha.14",
+  "version": "0.0.1-alpha.15",
   "description": "Optimism Optimistic Game Semantics",
   "main": "build/index.js",
   "files": [
@@ -29,8 +29,8 @@
     "url": "https://github.com/ethereum-optimism/optimism-monorepo.git"
   },
   "dependencies": {
-    "@eth-optimism/core-db": "^0.0.1-alpha.14",
-    "@eth-optimism/core-utils": "^0.0.1-alpha.14",
+    "@eth-optimism/core-db": "^0.0.1-alpha.15",
+    "@eth-optimism/core-utils": "^0.0.1-alpha.15",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "debug": "^4.1.1",

--- a/packages/ovm-truffle-provider-wrapper/index.ts
+++ b/packages/ovm-truffle-provider-wrapper/index.ts
@@ -1,4 +1,5 @@
-// *Important*: needed for sub-process
+// *Important*: runFullNode import is needed for sub-process
+// noinspection ES6UnusedImports
 import {runFullnode} from "@eth-optimism/rollup-full-node";
 import { execSync, spawn } from 'child_process'
 

--- a/packages/ovm-truffle-provider-wrapper/index.ts
+++ b/packages/ovm-truffle-provider-wrapper/index.ts
@@ -1,6 +1,6 @@
 // *Important*: runFullNode import is needed for sub-process
 // noinspection ES6UnusedImports
-import {runFullnode} from "@eth-optimism/rollup-full-node";
+import { runFullnode } from '@eth-optimism/rollup-full-node'
 import { execSync, spawn } from 'child_process'
 
 /**

--- a/packages/ovm-truffle-provider-wrapper/index.ts
+++ b/packages/ovm-truffle-provider-wrapper/index.ts
@@ -1,3 +1,5 @@
+// *Important*: needed for sub-process
+import {runFullnode} from "@eth-optimism/rollup-full-node";
 import { execSync, spawn } from 'child_process'
 
 /**

--- a/packages/ovm-truffle-provider-wrapper/package.json
+++ b/packages/ovm-truffle-provider-wrapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/ovm-truffle-provider-wrapper",
-  "version": "0.0.1-alpha.14",
+  "version": "0.0.1-alpha.15",
   "description": "Optimism Truffle Provider Wrapper",
   "main": "build/index.js",
   "files": [
@@ -28,7 +28,7 @@
     "url": "https://github.com/ethereum-optimism/optimism-monorepo.git"
   },
   "dependencies": {
-    "@eth-optimism/rollup-full-node": "^0.0.1-alpha.14"
+    "@eth-optimism/rollup-full-node": "^0.0.1-alpha.15"
   },
   "devDependencies": {
     "@types/node": "^12.0.7",

--- a/packages/ovm/package.json
+++ b/packages/ovm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/ovm",
-  "version": "0.0.1-alpha.14",
+  "version": "0.0.1-alpha.15",
   "description": "An optimistic execution-compatible EVM",
   "main": "build/index.js",
   "files": [
@@ -50,9 +50,9 @@
     "typescript": "^3.3.3333"
   },
   "dependencies": {
-    "@eth-optimism/core-db": "^0.0.1-alpha.14",
-    "@eth-optimism/core-utils": "^0.0.1-alpha.14",
-    "@eth-optimism/rollup-core": "^0.0.1-alpha.14",
+    "@eth-optimism/core-db": "^0.0.1-alpha.15",
+    "@eth-optimism/core-utils": "^0.0.1-alpha.15",
+    "@eth-optimism/rollup-core": "^0.0.1-alpha.15",
     "@types/sinon-chai": "^3.2.2",
     "chai": "^4.2.0",
     "ethereum-waffle": "2.1.0",

--- a/packages/rollup-contracts/package.json
+++ b/packages/rollup-contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/rollup-contracts",
-  "version": "0.0.1-alpha.14",
+  "version": "0.0.1-alpha.15",
   "description": "Optimistic Rollup smart contracts",
   "main": "build/index.js",
   "files": [
@@ -43,9 +43,9 @@
     "typescript": "^3.3.3333"
   },
   "dependencies": {
-    "@eth-optimism/core-db": "^0.0.1-alpha.14",
-    "@eth-optimism/core-utils": "^0.0.1-alpha.14",
-    "@eth-optimism/rollup-core": "^0.0.1-alpha.14",
+    "@eth-optimism/core-db": "^0.0.1-alpha.15",
+    "@eth-optimism/core-utils": "^0.0.1-alpha.15",
+    "@eth-optimism/rollup-core": "^0.0.1-alpha.15",
     "@types/sinon-chai": "^3.2.2",
     "chai": "^4.2.0",
     "ethereum-waffle": "2.1.0",

--- a/packages/rollup-core/package.json
+++ b/packages/rollup-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/rollup-core",
-  "version": "0.0.1-alpha.14",
+  "version": "0.0.1-alpha.15",
   "description": "[Optimism] Optimistic Rollup Core Library",
   "main": "build/index.js",
   "files": [
@@ -29,8 +29,8 @@
     "url": "https://github.com/ethereum-optimism/optimism-monorepo.git"
   },
   "dependencies": {
-    "@eth-optimism/core-db": "^0.0.1-alpha.14",
-    "@eth-optimism/core-utils": "^0.0.1-alpha.14",
+    "@eth-optimism/core-db": "^0.0.1-alpha.15",
+    "@eth-optimism/core-utils": "^0.0.1-alpha.15",
     "async-lock": "^1.2.2",
     "ethers": "^4.0.39"
   },

--- a/packages/rollup-dev-tools/package.json
+++ b/packages/rollup-dev-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/rollup-dev-tools",
-  "version": "0.0.1-alpha.14",
+  "version": "0.0.1-alpha.15",
   "description": "[Optimism] Optimistic Rollup Dev Tools Library",
   "main": "build/index.js",
   "files": [
@@ -33,8 +33,8 @@
     "url": "https://github.com/ethereum-optimism/optimism-monorepo.git"
   },
   "dependencies": {
-    "@eth-optimism/core-utils": "^0.0.1-alpha.14",
-    "@eth-optimism/rollup-core": "^0.0.1-alpha.14",
+    "@eth-optimism/core-utils": "^0.0.1-alpha.15",
+    "@eth-optimism/rollup-core": "^0.0.1-alpha.15",
     "async-lock": "^1.2.2",
     "bn.js": "^5.1.1",
     "dotenv": "^8.2.0",

--- a/packages/rollup-full-node/package.json
+++ b/packages/rollup-full-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/rollup-full-node",
-  "version": "0.0.1-alpha.14",
+  "version": "0.0.1-alpha.15",
   "description": "[Optimism] Optimistic Rollup Full Node Library",
   "main": "build/index.js",
   "files": [
@@ -34,10 +34,10 @@
     "url": "https://github.com/ethereum-optimism/optimism-monorepo.git"
   },
   "dependencies": {
-    "@eth-optimism/core-db": "^0.0.1-alpha.14",
-    "@eth-optimism/core-utils": "^0.0.1-alpha.14",
-    "@eth-optimism/ovm": "^0.0.1-alpha.14",
-    "@eth-optimism/rollup-core": "^0.0.1-alpha.14",
+    "@eth-optimism/core-db": "^0.0.1-alpha.15",
+    "@eth-optimism/core-utils": "^0.0.1-alpha.15",
+    "@eth-optimism/ovm": "^0.0.1-alpha.15",
+    "@eth-optimism/rollup-core": "^0.0.1-alpha.15",
     "async-lock": "^1.2.2",
     "axios": "^0.19.0",
     "cors": "^2.8.5",
@@ -47,7 +47,7 @@
     "fastpriorityqueue": "^0.6.3"
   },
   "devDependencies": {
-    "@eth-optimism/solc-transpiler": "^0.0.1-alpha.14",
+    "@eth-optimism/solc-transpiler": "^0.0.1-alpha.15",
     "@types/abstract-leveldown": "^5.0.1",
     "@types/chai": "^4.1.7",
     "@types/mocha": "^5.2.7",

--- a/packages/solc-transpiler/package.json
+++ b/packages/solc-transpiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/solc-transpiler",
-  "version": "0.0.1-alpha.14",
+  "version": "0.0.1-alpha.15",
   "description": "Optimism Transpiler Solc Compiler Wrapper",
   "main": "build/index.js",
   "files": [
@@ -29,8 +29,8 @@
     "url": "https://github.com/ethereum-optimism/optimism-monorepo.git"
   },
   "dependencies": {
-    "@eth-optimism/core-utils": "^0.0.1-alpha.14",
-    "@eth-optimism/rollup-dev-tools": "^0.0.1-alpha.14",
+    "@eth-optimism/core-utils": "^0.0.1-alpha.15",
+    "@eth-optimism/rollup-dev-tools": "^0.0.1-alpha.15",
     "ethers": "^4.0.45",
     "require-from-string": "^2.0.2",
     "solc": "^0.5.12"


### PR DESCRIPTION
The rollup fullnode import is missing in the truffle provider wrapper, causing the spawned subprocess to not be able to find the fullnode. This fixes that by importing it in the truffle provider wrapper's index.ts file.

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
