### PR TITLE
Fixing return payload for reverts

### DIFF
--- a/packages/core-db/package.json
+++ b/packages/core-db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/core-db",
-  "version": "0.0.1-alpha.15",
+  "version": "0.0.1-alpha.16",
   "description": "Optimism DB Utils",
   "main": "build/index.js",
   "files": [
@@ -29,7 +29,7 @@
     "url": "https://github.com/ethereum-optimism/optimism-monorepo.git"
   },
   "dependencies": {
-    "@eth-optimism/core-utils": "^0.0.1-alpha.15",
+    "@eth-optimism/core-utils": "^0.0.1-alpha.16",
     "abstract-leveldown": "^6.2.2",
     "async-lock": "^1.2.2",
     "chai": "^4.2.0",

--- a/packages/core-utils/package.json
+++ b/packages/core-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/core-utils",
-  "version": "0.0.1-alpha.15",
+  "version": "0.0.1-alpha.16",
   "description": "Optimism Core Utils",
   "main": "build/index.js",
   "files": [

--- a/packages/core-utils/src/app/transport/server/json-rpc-errors.ts
+++ b/packages/core-utils/src/app/transport/server/json-rpc-errors.ts
@@ -21,6 +21,10 @@ export const JSONRPC_ERRORS = {
     code: -32603,
     message: 'Internal error',
   },
+  REVERT_ERROR: {
+    code: -32015,
+    message: 'revert: requested action reverted',
+  },
 }
 
 /**

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@eth-optimism/docs",
   "private": true,
-  "version": "0.0.1-alpha.15",
+  "version": "0.0.1-alpha.16",
   "description": "Optimism docs",
   "author": "Optimism",
   "license": "MIT",

--- a/packages/optimistic-game-semantics/package.json
+++ b/packages/optimistic-game-semantics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/optimistic-game-semantics",
-  "version": "0.0.1-alpha.15",
+  "version": "0.0.1-alpha.16",
   "description": "Optimism Optimistic Game Semantics",
   "main": "build/index.js",
   "files": [
@@ -29,8 +29,8 @@
     "url": "https://github.com/ethereum-optimism/optimism-monorepo.git"
   },
   "dependencies": {
-    "@eth-optimism/core-db": "^0.0.1-alpha.15",
-    "@eth-optimism/core-utils": "^0.0.1-alpha.15",
+    "@eth-optimism/core-db": "^0.0.1-alpha.16",
+    "@eth-optimism/core-utils": "^0.0.1-alpha.16",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "debug": "^4.1.1",

--- a/packages/ovm-truffle-provider-wrapper/package.json
+++ b/packages/ovm-truffle-provider-wrapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/ovm-truffle-provider-wrapper",
-  "version": "0.0.1-alpha.15",
+  "version": "0.0.1-alpha.16",
   "description": "Optimism Truffle Provider Wrapper",
   "main": "build/index.js",
   "files": [
@@ -28,7 +28,7 @@
     "url": "https://github.com/ethereum-optimism/optimism-monorepo.git"
   },
   "dependencies": {
-    "@eth-optimism/rollup-full-node": "^0.0.1-alpha.15"
+    "@eth-optimism/rollup-full-node": "^0.0.1-alpha.16"
   },
   "devDependencies": {
     "@types/node": "^12.0.7",

--- a/packages/ovm/package.json
+++ b/packages/ovm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/ovm",
-  "version": "0.0.1-alpha.15",
+  "version": "0.0.1-alpha.16",
   "description": "An optimistic execution-compatible EVM",
   "main": "build/index.js",
   "files": [
@@ -50,9 +50,9 @@
     "typescript": "^3.3.3333"
   },
   "dependencies": {
-    "@eth-optimism/core-db": "^0.0.1-alpha.15",
-    "@eth-optimism/core-utils": "^0.0.1-alpha.15",
-    "@eth-optimism/rollup-core": "^0.0.1-alpha.15",
+    "@eth-optimism/core-db": "^0.0.1-alpha.16",
+    "@eth-optimism/core-utils": "^0.0.1-alpha.16",
+    "@eth-optimism/rollup-core": "^0.0.1-alpha.16",
     "@types/sinon-chai": "^3.2.2",
     "chai": "^4.2.0",
     "ethereum-waffle": "2.1.0",

--- a/packages/ovm/src/app/utils.ts
+++ b/packages/ovm/src/app/utils.ts
@@ -28,7 +28,6 @@ export const RLPEncodeContractDefinition = {
   bytecode: RLPEncode.bytecode,
 }
 
-
 const executionManager = new ethers.utils.Interface(ExecutionManager.interface)
 
 const logger = getLogger('utils')

--- a/packages/ovm/src/app/utils.ts
+++ b/packages/ovm/src/app/utils.ts
@@ -28,6 +28,7 @@ export const RLPEncodeContractDefinition = {
   bytecode: RLPEncode.bytecode,
 }
 
+
 const executionManager = new ethers.utils.Interface(ExecutionManager.interface)
 
 const logger = getLogger('utils')
@@ -105,7 +106,6 @@ export const getOvmTransactionMetadata = (
 /**
  * Converts an EVM receipt to an OVM receipt.
  *
- * @param executionManager The EM contract to use to parse th logs.
  * @param internalTxReceipt The EVM tx receipt to convert to an OVM tx receipt
  * @returns The converted receipt
  */

--- a/packages/ovm/src/types/index.ts
+++ b/packages/ovm/src/types/index.ts
@@ -1,2 +1,3 @@
 export * from './errors'
 export * from './ovm'
+export * from './transactionReceipt'

--- a/packages/ovm/src/types/index.ts
+++ b/packages/ovm/src/types/index.ts
@@ -1,3 +1,2 @@
 export * from './errors'
 export * from './ovm'
-export * from './transactionReceipt'

--- a/packages/rollup-contracts/package.json
+++ b/packages/rollup-contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/rollup-contracts",
-  "version": "0.0.1-alpha.15",
+  "version": "0.0.1-alpha.16",
   "description": "Optimistic Rollup smart contracts",
   "main": "build/index.js",
   "files": [
@@ -43,9 +43,9 @@
     "typescript": "^3.3.3333"
   },
   "dependencies": {
-    "@eth-optimism/core-db": "^0.0.1-alpha.15",
-    "@eth-optimism/core-utils": "^0.0.1-alpha.15",
-    "@eth-optimism/rollup-core": "^0.0.1-alpha.15",
+    "@eth-optimism/core-db": "^0.0.1-alpha.16",
+    "@eth-optimism/core-utils": "^0.0.1-alpha.16",
+    "@eth-optimism/rollup-core": "^0.0.1-alpha.16",
     "@types/sinon-chai": "^3.2.2",
     "chai": "^4.2.0",
     "ethereum-waffle": "2.1.0",

--- a/packages/rollup-core/package.json
+++ b/packages/rollup-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/rollup-core",
-  "version": "0.0.1-alpha.15",
+  "version": "0.0.1-alpha.16",
   "description": "[Optimism] Optimistic Rollup Core Library",
   "main": "build/index.js",
   "files": [
@@ -29,8 +29,8 @@
     "url": "https://github.com/ethereum-optimism/optimism-monorepo.git"
   },
   "dependencies": {
-    "@eth-optimism/core-db": "^0.0.1-alpha.15",
-    "@eth-optimism/core-utils": "^0.0.1-alpha.15",
+    "@eth-optimism/core-db": "^0.0.1-alpha.16",
+    "@eth-optimism/core-utils": "^0.0.1-alpha.16",
     "async-lock": "^1.2.2",
     "ethers": "^4.0.39"
   },

--- a/packages/rollup-dev-tools/package.json
+++ b/packages/rollup-dev-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/rollup-dev-tools",
-  "version": "0.0.1-alpha.15",
+  "version": "0.0.1-alpha.16",
   "description": "[Optimism] Optimistic Rollup Dev Tools Library",
   "main": "build/index.js",
   "files": [
@@ -33,8 +33,8 @@
     "url": "https://github.com/ethereum-optimism/optimism-monorepo.git"
   },
   "dependencies": {
-    "@eth-optimism/core-utils": "^0.0.1-alpha.15",
-    "@eth-optimism/rollup-core": "^0.0.1-alpha.15",
+    "@eth-optimism/core-utils": "^0.0.1-alpha.16",
+    "@eth-optimism/rollup-core": "^0.0.1-alpha.16",
     "async-lock": "^1.2.2",
     "bn.js": "^5.1.1",
     "dotenv": "^8.2.0",

--- a/packages/rollup-full-node/package.json
+++ b/packages/rollup-full-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/rollup-full-node",
-  "version": "0.0.1-alpha.15",
+  "version": "0.0.1-alpha.16",
   "description": "[Optimism] Optimistic Rollup Full Node Library",
   "main": "build/index.js",
   "files": [
@@ -34,10 +34,10 @@
     "url": "https://github.com/ethereum-optimism/optimism-monorepo.git"
   },
   "dependencies": {
-    "@eth-optimism/core-db": "^0.0.1-alpha.15",
-    "@eth-optimism/core-utils": "^0.0.1-alpha.15",
-    "@eth-optimism/ovm": "^0.0.1-alpha.15",
-    "@eth-optimism/rollup-core": "^0.0.1-alpha.15",
+    "@eth-optimism/core-db": "^0.0.1-alpha.16",
+    "@eth-optimism/core-utils": "^0.0.1-alpha.16",
+    "@eth-optimism/ovm": "^0.0.1-alpha.16",
+    "@eth-optimism/rollup-core": "^0.0.1-alpha.16",
     "async-lock": "^1.2.2",
     "axios": "^0.19.0",
     "cors": "^2.8.5",
@@ -47,7 +47,7 @@
     "fastpriorityqueue": "^0.6.3"
   },
   "devDependencies": {
-    "@eth-optimism/solc-transpiler": "^0.0.1-alpha.15",
+    "@eth-optimism/solc-transpiler": "^0.0.1-alpha.16",
     "@types/abstract-leveldown": "^5.0.1",
     "@types/chai": "^4.1.7",
     "@types/mocha": "^5.2.7",

--- a/packages/rollup-full-node/src/app/fullnode-rpc-server.ts
+++ b/packages/rollup-full-node/src/app/fullnode-rpc-server.ts
@@ -13,6 +13,7 @@ import {
 import {
   FullnodeHandler,
   InvalidParametersError,
+  RevertError,
   UnsupportedMethodError,
 } from '../types'
 
@@ -65,6 +66,10 @@ export class FullnodeRpcServer extends ExpressHttpServer {
           result,
         })
       } catch (err) {
+        if (err instanceof RevertError) {
+          log.debug(`Request reverted. Request: ${JSON.stringify(request)}`)
+          return res.json(buildJsonRpcError('REVERT_ERROR', request.id))
+        }
         if (err instanceof UnsupportedMethodError) {
           log.debug(
             `Received request with unsupported method: [${JSON.stringify(

--- a/packages/rollup-full-node/src/app/test-web3-rpc-handler.ts
+++ b/packages/rollup-full-node/src/app/test-web3-rpc-handler.ts
@@ -55,18 +55,26 @@ export class TestWeb3Handler extends DefaultWeb3Handler {
    * Override to add some test RPC methods.
    */
   public async handleRequest(method: string, params: any[]): Promise<string> {
-    if (method === Web3RpcMethods.increaseTimestamp) {
-      this.assertParameters(params, 1)
-      this.increaseTimestamp(params[0])
-      log.debug(`Set increased timestamp by ${params[0]} seconds.`)
-      return TestWeb3Handler.successString
+    switch (method) {
+      case Web3RpcMethods.increaseTimestamp:
+        this.assertParameters(params, 1)
+        this.increaseTimestamp(params[0])
+        log.debug(`Set increased timestamp by ${params[0]} seconds.`)
+        return TestWeb3Handler.successString
+      case Web3RpcMethods.getTimestamp:
+        this.assertParameters(params, 0)
+        return add0x(this.getTimestamp().toString(16))
+      case Web3RpcMethods.evmSnapshot:
+        this.assertParameters(params, 0)
+        return this.provider.send(Web3RpcMethods.evmSnapshot, [])
+      case Web3RpcMethods.evmRevert:
+        this.assertParameters(params, 1)
+        return this.provider.send(Web3RpcMethods.evmRevert, params)
+      case Web3RpcMethods.evmMine:
+        return this.provider.send(Web3RpcMethods.evmMine, params)
+      default:
+        return super.handleRequest(method, params)
     }
-    if (method === Web3RpcMethods.getTimestamp) {
-      this.assertParameters(params, 0)
-      return add0x(this.getTimestamp().toString(16))
-    }
-
-    return super.handleRequest(method, params)
   }
 
   /**

--- a/packages/rollup-full-node/src/app/web3-rpc-handler.ts
+++ b/packages/rollup-full-node/src/app/web3-rpc-handler.ts
@@ -16,7 +16,7 @@ import {
 } from '@eth-optimism/ovm'
 
 import { Contract, ethers, utils, Wallet } from 'ethers'
-import { Web3Provider } from 'ethers/providers'
+import { TransactionReceipt, Web3Provider } from 'ethers/providers'
 import { createMockProvider, deployContract, getWallets } from 'ethereum-waffle'
 
 import AsyncLock from 'async-lock'
@@ -26,6 +26,7 @@ import { DEFAULT_ETHNODE_GAS_LIMIT } from '.'
 import {
   FullnodeHandler,
   InvalidParametersError,
+  RevertError,
   UnsupportedMethodError,
   Web3Handler,
   Web3RpcMethods,
@@ -63,9 +64,9 @@ export class DefaultWeb3Handler implements Web3Handler, FullnodeHandler {
   }
 
   protected constructor(
-    private readonly provider: Web3Provider,
-    private readonly wallet: Wallet,
-    private readonly executionManager: Contract
+    protected readonly provider: Web3Provider,
+    protected readonly wallet: Wallet,
+    protected readonly executionManager: Contract
   ) {
     this.lock = new AsyncLock()
   }
@@ -272,7 +273,8 @@ export class DefaultWeb3Handler implements Web3Handler, FullnodeHandler {
     defaultBlock: string
   ): Promise<string> {
     if (defaultBlock !== 'latest') {
-      throw new Error('No support for historical code lookups!')
+      log.info(`No support for historical code lookups! Anything returned from this may be very wrong.`)
+      //throw new Error('No support for historical code lookups!')
     }
     log.debug(
       `Getting code for address: [${address}], defaultBlock: [${defaultBlock}]`
@@ -394,6 +396,17 @@ export class DefaultWeb3Handler implements Web3Handler, FullnodeHandler {
         const msg: string = `Internal Transaction hashes do not match for OVM Hash: [${ovmTxHash}]. Calculated: [${internalTxHash}], returned from tx: [${returnedInternalTxHash}]`
         log.error(msg)
         throw Error(msg)
+      }
+
+      const receipt: TransactionReceipt = await this.getTransactionReceipt(
+        ovmTxHash
+      )
+      log.info(
+        `Transaction receipt for ${rawOvmTx}: ${JSON.stringify(receipt)}`
+      )
+      if (!receipt || !receipt.status) {
+        log.debug(`Transaction reverted: ${rawOvmTx}, ovmTxHash: ${ovmTxHash}`)
+        throw new RevertError()
       }
 
       log.debug(`Completed send raw tx [${rawOvmTx}]. Response: [${ovmTxHash}]`)

--- a/packages/rollup-full-node/src/app/web3-rpc-handler.ts
+++ b/packages/rollup-full-node/src/app/web3-rpc-handler.ts
@@ -273,7 +273,9 @@ export class DefaultWeb3Handler implements Web3Handler, FullnodeHandler {
     defaultBlock: string
   ): Promise<string> {
     if (defaultBlock !== 'latest') {
-      log.info(`No support for historical code lookups! Anything returned from this may be very wrong.`)
+      log.info(
+        `No support for historical code lookups! Anything returned from this may be very wrong.`
+      )
       //throw new Error('No support for historical code lookups!')
     }
     log.debug(

--- a/packages/rollup-full-node/src/exec/fullnode.ts
+++ b/packages/rollup-full-node/src/exec/fullnode.ts
@@ -17,6 +17,7 @@ export const runFullnode = async (
   const host = '0.0.0.0'
   const port = 8545
 
+  log.info(`Starting fullnode in ${testFullnode ? 'TEST' : 'LIVE'} mode`)
   const fullnodeHandler = testFullnode
     ? await TestWeb3Handler.create()
     : await DefaultWeb3Handler.create()

--- a/packages/rollup-full-node/src/types/errors.ts
+++ b/packages/rollup-full-node/src/types/errors.ts
@@ -17,3 +17,9 @@ export class InvalidParametersError extends Error {
     )
   }
 }
+
+export class RevertError extends Error {
+  constructor(message?: string) {
+    super(message || 'Revert: The provided transaction reverted.')
+  }
+}

--- a/packages/rollup-full-node/src/types/web3-rpc-handler.ts
+++ b/packages/rollup-full-node/src/types/web3-rpc-handler.ts
@@ -39,6 +39,9 @@ export enum Web3RpcMethods {
   sendRawTransaction = 'eth_sendRawTransaction',
 
   // Test methods:
+  evmSnapshot = 'evm_snapshot',
+  evmRevert = 'evm_revert',
+  evmMine = 'evm_mine',
   increaseTimestamp = 'evm_increaseTime',
   getTimestamp = 'evm_getTime',
 }

--- a/packages/solc-transpiler/package.json
+++ b/packages/solc-transpiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/solc-transpiler",
-  "version": "0.0.1-alpha.15",
+  "version": "0.0.1-alpha.16",
   "description": "Optimism Transpiler Solc Compiler Wrapper",
   "main": "build/index.js",
   "files": [
@@ -29,8 +29,8 @@
     "url": "https://github.com/ethereum-optimism/optimism-monorepo.git"
   },
   "dependencies": {
-    "@eth-optimism/core-utils": "^0.0.1-alpha.15",
-    "@eth-optimism/rollup-dev-tools": "^0.0.1-alpha.15",
+    "@eth-optimism/core-utils": "^0.0.1-alpha.16",
+    "@eth-optimism/rollup-dev-tools": "^0.0.1-alpha.16",
     "ethers": "^4.0.45",
     "require-from-string": "^2.0.2",
     "solc": "^0.5.12"


### PR DESCRIPTION
## Description
Right now transactions that revert don't return the proper payload. This ticket fixes it such that reverts conform to standard revert payloads.

## Metadata
### Fixes
- Fixes # [YAS-210](https://optimists.atlassian.net/browse/YAS-210)

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
