### PR TITLE
Optimizing JUMP table PUSH32s

### DIFF
--- a/packages/core-db/package.json
+++ b/packages/core-db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/core-db",
-  "version": "0.0.1-alpha.17",
+  "version": "0.0.1-alpha.18",
   "description": "Optimism DB Utils",
   "main": "build/index.js",
   "files": [
@@ -29,7 +29,7 @@
     "url": "https://github.com/ethereum-optimism/optimism-monorepo.git"
   },
   "dependencies": {
-    "@eth-optimism/core-utils": "^0.0.1-alpha.17",
+    "@eth-optimism/core-utils": "^0.0.1-alpha.18",
     "abstract-leveldown": "^6.2.2",
     "async-lock": "^1.2.2",
     "chai": "^4.2.0",

--- a/packages/core-utils/package.json
+++ b/packages/core-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/core-utils",
-  "version": "0.0.1-alpha.17",
+  "version": "0.0.1-alpha.18",
   "description": "Optimism Core Utils",
   "main": "build/index.js",
   "files": [

--- a/packages/core-utils/test/app/buffer.spec.ts
+++ b/packages/core-utils/test/app/buffer.spec.ts
@@ -1,0 +1,24 @@
+import '../setup'
+import { bufferUtils } from '../../src/app'
+
+describe('Buffer Utils tests', () => {
+  describe('numberToBufferPacked', () => {
+    it('works for single-byte small number', () => {
+      const buf: Buffer = bufferUtils.numberToBufferPacked(2)
+
+      buf.should.eql(Buffer.from('02', 'hex'))
+    })
+
+    it('works for single-byte big number', () => {
+      const buf: Buffer = bufferUtils.numberToBufferPacked(22)
+
+      buf.should.eql(Buffer.from('16', 'hex'))
+    })
+
+    it('works for multi-byte big number', () => {
+      const buf: Buffer = bufferUtils.numberToBufferPacked(333)
+
+      buf.should.eql(Buffer.from('014d', 'hex'))
+    })
+  })
+})

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@eth-optimism/docs",
   "private": true,
-  "version": "0.0.1-alpha.17",
+  "version": "0.0.1-alpha.18",
   "description": "Optimism docs",
   "author": "Optimism",
   "license": "MIT",

--- a/packages/optimistic-game-semantics/package.json
+++ b/packages/optimistic-game-semantics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/optimistic-game-semantics",
-  "version": "0.0.1-alpha.17",
+  "version": "0.0.1-alpha.18",
   "description": "Optimism Optimistic Game Semantics",
   "main": "build/index.js",
   "files": [
@@ -29,8 +29,8 @@
     "url": "https://github.com/ethereum-optimism/optimism-monorepo.git"
   },
   "dependencies": {
-    "@eth-optimism/core-db": "^0.0.1-alpha.17",
-    "@eth-optimism/core-utils": "^0.0.1-alpha.17",
+    "@eth-optimism/core-db": "^0.0.1-alpha.18",
+    "@eth-optimism/core-utils": "^0.0.1-alpha.18",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "debug": "^4.1.1",

--- a/packages/ovm-truffle-provider-wrapper/package.json
+++ b/packages/ovm-truffle-provider-wrapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/ovm-truffle-provider-wrapper",
-  "version": "0.0.1-alpha.17",
+  "version": "0.0.1-alpha.18",
   "description": "Optimism Truffle Provider Wrapper",
   "main": "build/index.js",
   "files": [
@@ -28,7 +28,7 @@
     "url": "https://github.com/ethereum-optimism/optimism-monorepo.git"
   },
   "dependencies": {
-    "@eth-optimism/rollup-full-node": "^0.0.1-alpha.17"
+    "@eth-optimism/rollup-full-node": "^0.0.1-alpha.18"
   },
   "devDependencies": {
     "@types/node": "^12.0.7",

--- a/packages/ovm/package.json
+++ b/packages/ovm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/ovm",
-  "version": "0.0.1-alpha.17",
+  "version": "0.0.1-alpha.18",
   "description": "An optimistic execution-compatible EVM",
   "main": "build/index.js",
   "files": [
@@ -50,9 +50,9 @@
     "typescript": "^3.3.3333"
   },
   "dependencies": {
-    "@eth-optimism/core-db": "^0.0.1-alpha.17",
-    "@eth-optimism/core-utils": "^0.0.1-alpha.17",
-    "@eth-optimism/rollup-core": "^0.0.1-alpha.17",
+    "@eth-optimism/core-db": "^0.0.1-alpha.18",
+    "@eth-optimism/core-utils": "^0.0.1-alpha.18",
+    "@eth-optimism/rollup-core": "^0.0.1-alpha.18",
     "@types/sinon-chai": "^3.2.2",
     "chai": "^4.2.0",
     "ethereum-waffle": "2.1.0",

--- a/packages/rollup-contracts/package.json
+++ b/packages/rollup-contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/rollup-contracts",
-  "version": "0.0.1-alpha.17",
+  "version": "0.0.1-alpha.18",
   "description": "Optimistic Rollup smart contracts",
   "main": "build/index.js",
   "files": [
@@ -43,9 +43,9 @@
     "typescript": "^3.3.3333"
   },
   "dependencies": {
-    "@eth-optimism/core-db": "^0.0.1-alpha.17",
-    "@eth-optimism/core-utils": "^0.0.1-alpha.17",
-    "@eth-optimism/rollup-core": "^0.0.1-alpha.17",
+    "@eth-optimism/core-db": "^0.0.1-alpha.18",
+    "@eth-optimism/core-utils": "^0.0.1-alpha.18",
+    "@eth-optimism/rollup-core": "^0.0.1-alpha.18",
     "@types/sinon-chai": "^3.2.2",
     "chai": "^4.2.0",
     "ethereum-waffle": "2.1.0",

--- a/packages/rollup-core/package.json
+++ b/packages/rollup-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/rollup-core",
-  "version": "0.0.1-alpha.17",
+  "version": "0.0.1-alpha.18",
   "description": "[Optimism] Optimistic Rollup Core Library",
   "main": "build/index.js",
   "files": [
@@ -29,8 +29,8 @@
     "url": "https://github.com/ethereum-optimism/optimism-monorepo.git"
   },
   "dependencies": {
-    "@eth-optimism/core-db": "^0.0.1-alpha.17",
-    "@eth-optimism/core-utils": "^0.0.1-alpha.17",
+    "@eth-optimism/core-db": "^0.0.1-alpha.18",
+    "@eth-optimism/core-utils": "^0.0.1-alpha.18",
     "async-lock": "^1.2.2",
     "ethers": "^4.0.39"
   },

--- a/packages/rollup-dev-tools/package.json
+++ b/packages/rollup-dev-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/rollup-dev-tools",
-  "version": "0.0.1-alpha.17",
+  "version": "0.0.1-alpha.18",
   "description": "[Optimism] Optimistic Rollup Dev Tools Library",
   "main": "build/index.js",
   "files": [
@@ -33,8 +33,8 @@
     "url": "https://github.com/ethereum-optimism/optimism-monorepo.git"
   },
   "dependencies": {
-    "@eth-optimism/core-utils": "^0.0.1-alpha.17",
-    "@eth-optimism/rollup-core": "^0.0.1-alpha.17",
+    "@eth-optimism/core-utils": "^0.0.1-alpha.18",
+    "@eth-optimism/rollup-core": "^0.0.1-alpha.18",
     "async-lock": "^1.2.2",
     "bn.js": "^5.1.1",
     "dotenv": "^8.2.0",

--- a/packages/rollup-dev-tools/src/tools/transpiler/jump-replacement.ts
+++ b/packages/rollup-dev-tools/src/tools/transpiler/jump-replacement.ts
@@ -111,8 +111,9 @@ export const getJumpiReplacementBytecodeLength = (): number => {
 export const getJumpReplacementBytecode = (
   footerSwitchJumpdestIndex: number
 ): EVMBytecode => {
-  const indexBuffer: Buffer = bufferUtils.numberToBuffer(
-    footerSwitchJumpdestIndex
+  const indexBuffer: Buffer = bufferUtils.numberToBufferPacked(
+    footerSwitchJumpdestIndex,
+    2
   )
   return [
     {
@@ -138,8 +139,9 @@ export const getJumpReplacementBytecode = (
 export const getJumpiReplacementBytecode = (
   footerSwitchJumpdestIndex: number
 ): EVMBytecode => {
-  const indexBuffer: Buffer = bufferUtils.numberToBuffer(
-    footerSwitchJumpdestIndex
+  const indexBuffer: Buffer = bufferUtils.numberToBufferPacked(
+    footerSwitchJumpdestIndex,
+    2
   )
   return [
     {
@@ -197,7 +199,10 @@ export const getJumpIndexSwitchStatementBytecode = (
   jumpdestIndexesAfter: number[],
   indexOfThisBlock: number
 ): EVMBytecode => {
-  const successJumpIndex: Buffer = bufferUtils.numberToBuffer(indexOfThisBlock)
+  const successJumpIndex: Buffer = bufferUtils.numberToBufferPacked(
+    indexOfThisBlock,
+    2
+  )
 
   const footerBytecode: EVMBytecode = [
     ...getJumpIndexSwitchStatementSuccessJumpdestBytecode(),
@@ -211,11 +216,13 @@ export const getJumpIndexSwitchStatementBytecode = (
 
     const beforeIndex: number = jumpdestIndexesBefore[i]
     const afterIndex: number = jumpdestIndexesAfter[i]
-    const beforeBuffer: Buffer = bufferUtils.numberToBuffer(
-      jumpdestIndexesBefore[i]
+    const beforeBuffer: Buffer = bufferUtils.numberToBufferPacked(
+      jumpdestIndexesBefore[i],
+      2
     )
-    const afterBuffer: Buffer = bufferUtils.numberToBuffer(
-      jumpdestIndexesAfter[i]
+    const afterBuffer: Buffer = bufferUtils.numberToBufferPacked(
+      jumpdestIndexesAfter[i],
+      2
     )
 
     footerBytecode.push(

--- a/packages/rollup-dev-tools/test/helpers.ts
+++ b/packages/rollup-dev-tools/test/helpers.ts
@@ -40,6 +40,7 @@ export const invalidOpcode: Buffer = Buffer.from('5d', 'hex')
 
 export const whitelistedOpcodes: EVMOpcode[] = [
   Opcode.PUSH1,
+  Opcode.PUSH2,
   Opcode.PUSH4,
   Opcode.PUSH29,
   Opcode.PUSH32,

--- a/packages/rollup-dev-tools/test/helpers.ts
+++ b/packages/rollup-dev-tools/test/helpers.ts
@@ -10,7 +10,9 @@ import {
 import {
   bufferUtils,
   bufToHexString,
+  getLogger,
   hexStrToBuf,
+  Logger,
   remove0x,
 } from '@eth-optimism/core-utils'
 import * as abi from 'ethereumjs-abi'
@@ -28,6 +30,8 @@ import {
 } from '../src/'
 
 import { getPUSHBuffer, getPUSHIntegerOp } from '../src'
+
+const log: Logger = getLogger('helpers')
 
 export const emptyBuffer: Buffer = Buffer.from('', 'hex')
 export const stateManagerAddress: Address =
@@ -482,6 +486,10 @@ export const transpileAndDeployInitcode = async (
     remove0x(abiCoder.encode(constructorParamsEncoding, constructorParams)),
     'hex'
   )
+  log.debug(
+    `deploying contract with bytecode: ${transpiledInitcode.toString('hex')}`
+  )
+
   const deployedViaInitcode = await evmUtil.deployContract(
     transpiledInitcode,
     encodedConstructorParams

--- a/packages/rollup-dev-tools/test/transpiler/constructor-transpilation.spec.ts
+++ b/packages/rollup-dev-tools/test/transpiler/constructor-transpilation.spec.ts
@@ -55,7 +55,7 @@ import { transpileAndDeployInitcode, stripAuxData } from '../helpers'
 const abi = new ethers.utils.AbiCoder()
 const log = getLogger(`constructor-transpilation`)
 
-describe.only('Solitity contracts with constructors that take inputs should be correctly deployed', () => {
+describe('Solitity contracts with constructors that take inputs should be correctly deployed', () => {
   let evmUtil: EvmIntrospectionUtil
   const mockReplacer: OpcodeReplacer = {
     replaceIfNecessary(opcodeAndBytes: EVMOpcodeAndBytes): EVMBytecode {

--- a/packages/rollup-dev-tools/test/transpiler/transpile.jump.spec.ts
+++ b/packages/rollup-dev-tools/test/transpiler/transpile.jump.spec.ts
@@ -14,6 +14,7 @@ import {
 
 /* Internal imports */
 import {
+  ErroredTranspilation,
   OpcodeReplacer,
   OpcodeWhitelist,
   SuccessfulTranspilation,
@@ -130,7 +131,10 @@ const getSuccessfulTranspilationResult = (
   bytecode: Buffer
 ): SuccessfulTranspilation => {
   const result: TranspilationResult = transpiler.transpileRawBytecode(bytecode)
-  result.succeeded.should.equal(true)
+  result.succeeded.should.equal(
+    true,
+    `${JSON.stringify((result as ErroredTranspilation).errors)}`
+  )
   return result as SuccessfulTranspilation
 }
 
@@ -153,8 +157,8 @@ describe('Transpile - JUMPs', () => {
   it('handles simple JUMPs properly', async () => {
     const evmBytecode: EVMBytecode = [
       {
-        opcode: Opcode.PUSH1,
-        consumedBytes: bufferUtils.numberToBufferPacked(3, 2),
+        opcode: Opcode.PUSH2,
+        consumedBytes: bufferUtils.numberToBufferPacked(4, 2),
       },
       { opcode: Opcode.JUMP, consumedBytes: undefined },
       { opcode: Opcode.JUMPDEST, consumedBytes: undefined },

--- a/packages/rollup-dev-tools/test/transpiler/transpile.jump.spec.ts
+++ b/packages/rollup-dev-tools/test/transpiler/transpile.jump.spec.ts
@@ -108,12 +108,15 @@ const validateJumpBytecode = (successResult: SuccessfulTranspilation): void => {
         'Opcode before JUMP should be a PUSH32, pushing the location of the footer JUMP switch!'
       )
       opcodeBeforeJump.consumedBytes.should.eql(
-        bufferUtils.numberToBuffer(switchJumpdestIndex),
+        bufferUtils.numberToBufferPacked(switchJumpdestIndex, 2),
         'JUMP should be equal to index of footer switch JUMPDEST!'
       )
     } else if (index > switchJumpdestIndex) {
       // Make sure that all footer JUMPS go to footer JUMP success jumpdest
-      const dest: number = opcodeBeforeJump.consumedBytes.readInt32BE(28)
+      const dest: number = parseInt(
+        opcodeBeforeJump.consumedBytes.toString('hex'),
+        16
+      )
       dest.should.eq(
         switchSuccessJumpdestIndex,
         'All footer JUMPs should go to success JUMPDEST block'
@@ -149,7 +152,10 @@ describe('Transpile - JUMPs', () => {
 
   it('handles simple JUMPs properly', async () => {
     const evmBytecode: EVMBytecode = [
-      { opcode: Opcode.PUSH32, consumedBytes: bufferUtils.numberToBuffer(34) },
+      {
+        opcode: Opcode.PUSH1,
+        consumedBytes: bufferUtils.numberToBufferPacked(3, 2),
+      },
       { opcode: Opcode.JUMP, consumedBytes: undefined },
       { opcode: Opcode.JUMPDEST, consumedBytes: undefined },
       { opcode: Opcode.STOP, consumedBytes: undefined },

--- a/packages/rollup-full-node/package.json
+++ b/packages/rollup-full-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/rollup-full-node",
-  "version": "0.0.1-alpha.17",
+  "version": "0.0.1-alpha.18",
   "description": "[Optimism] Optimistic Rollup Full Node Library",
   "main": "build/index.js",
   "files": [
@@ -34,10 +34,10 @@
     "url": "https://github.com/ethereum-optimism/optimism-monorepo.git"
   },
   "dependencies": {
-    "@eth-optimism/core-db": "^0.0.1-alpha.17",
-    "@eth-optimism/core-utils": "^0.0.1-alpha.17",
-    "@eth-optimism/ovm": "^0.0.1-alpha.17",
-    "@eth-optimism/rollup-core": "^0.0.1-alpha.17",
+    "@eth-optimism/core-db": "^0.0.1-alpha.18",
+    "@eth-optimism/core-utils": "^0.0.1-alpha.18",
+    "@eth-optimism/ovm": "^0.0.1-alpha.18",
+    "@eth-optimism/rollup-core": "^0.0.1-alpha.18",
     "async-lock": "^1.2.2",
     "axios": "^0.19.0",
     "cors": "^2.8.5",
@@ -47,7 +47,7 @@
     "fastpriorityqueue": "^0.6.3"
   },
   "devDependencies": {
-    "@eth-optimism/solc-transpiler": "^0.0.1-alpha.17",
+    "@eth-optimism/solc-transpiler": "^0.0.1-alpha.18",
     "@types/abstract-leveldown": "^5.0.1",
     "@types/chai": "^4.1.7",
     "@types/mocha": "^5.2.7",

--- a/packages/solc-transpiler/package.json
+++ b/packages/solc-transpiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/solc-transpiler",
-  "version": "0.0.1-alpha.17",
+  "version": "0.0.1-alpha.18",
   "description": "Optimism Transpiler Solc Compiler Wrapper",
   "main": "build/index.js",
   "files": [
@@ -29,8 +29,8 @@
     "url": "https://github.com/ethereum-optimism/optimism-monorepo.git"
   },
   "dependencies": {
-    "@eth-optimism/core-utils": "^0.0.1-alpha.17",
-    "@eth-optimism/rollup-dev-tools": "^0.0.1-alpha.17",
+    "@eth-optimism/core-utils": "^0.0.1-alpha.18",
+    "@eth-optimism/rollup-dev-tools": "^0.0.1-alpha.18",
     "ethers": "^4.0.45",
     "require-from-string": "^2.0.2",
     "solc": "^0.5.12"


### PR DESCRIPTION
## Description
Before this, all PUSHs for the JUMP table JUMPDESTs were PUSH32s. This makes them all PUSH2s.

## Metadata
### Fixes
- Fixes # [YAS-235](https://optimists.atlassian.net/browse/YAS-235)

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
