### PR TITLE
Using linked packages instead of those in npm

### DIFF
--- a/.github/workflows/dev-ecr-deploy.yml
+++ b/.github/workflows/dev-ecr-deploy.yml
@@ -40,7 +40,6 @@ jobs:
           ECR_REPOSITORY: optimism/rollup-full-node
           IMAGE_TAG: latest
         run: |
-          cd packages/rollup-full-node
           docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
 FROM node:11
 
 WORKDIR /server
-
 COPY . /server
+RUN yarn link
 RUN yarn
+
+WORKDIR /server/packages/rollup-full-node
 
 EXPOSE 8545
 CMD [ "yarn", "run", "server:fullnode" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - internal
       - external
     build:
-      context: packages/rollup-full-node
+      context: .
       dockerfile: Dockerfile
     ports:
       - 8545:8545


### PR DESCRIPTION
## Description
Using linked packages instead of those in npm. 

Allows for deployments to dev that reflect repo changes and don't require publish to npm.

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
