### PR TITLE
Support historical code lookups if the block number is current

### DIFF
--- a/packages/core-utils/src/app/misc.ts
+++ b/packages/core-utils/src/app/misc.ts
@@ -150,6 +150,15 @@ export const bnToHexString = (bn: BigNumber): string => {
 }
 
 /**
+ * Converts a JavaScript number to a hex string.
+ * @param number the JavaScript number to be converted.
+ * @returns the JavaScript number as a string.
+ */
+export const numberToHexString = (bn: number): string => {
+  return add0x(bn.toString(16))
+}
+
+/**
  * Converts either a big number or buffer to hex string
  * @param value the big number or buffer to be converted
  * @returns the value as a string.

--- a/packages/rollup-full-node/package.json
+++ b/packages/rollup-full-node/package.json
@@ -42,7 +42,6 @@
     "axios": "^0.19.0",
     "cors": "^2.8.5",
     "dotenv": "^8.2.0",
-    "ethereum-waffle": "2.1.0",
     "ethers": "^4.0.39",
     "fastpriorityqueue": "^0.6.3"
   },
@@ -54,6 +53,7 @@
     "@types/node": "^12.0.7",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
+    "ethereum-waffle": "^2.4.0",
     "ethereumjs-abi": "^0.6.8",
     "mocha": "^6.1.4",
     "rimraf": "^2.6.3",

--- a/packages/rollup-full-node/package.json
+++ b/packages/rollup-full-node/package.json
@@ -42,6 +42,7 @@
     "axios": "^0.19.0",
     "cors": "^2.8.5",
     "dotenv": "^8.2.0",
+    "ethereum-waffle": "2.1.0",
     "ethers": "^4.0.39",
     "fastpriorityqueue": "^0.6.3"
   },
@@ -53,7 +54,6 @@
     "@types/node": "^12.0.7",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
-    "ethereum-waffle": "^2.4.0",
     "ethereumjs-abi": "^0.6.8",
     "mocha": "^6.1.4",
     "rimraf": "^2.6.3",

--- a/packages/rollup-full-node/src/app/web3-rpc-handler.ts
+++ b/packages/rollup-full-node/src/app/web3-rpc-handler.ts
@@ -2,11 +2,14 @@
 import { Address } from '@eth-optimism/rollup-core'
 import {
   add0x,
+  buildJsonRpcError,
   getLogger,
+  numberToHexString,
   logError,
   remove0x,
   ZERO_ADDRESS,
   getFirstDeployedContractAddress,
+  JsonRpcResponse
 } from '@eth-optimism/core-utils'
 import {
   CHAIN_ID,
@@ -309,11 +312,12 @@ export class DefaultWeb3Handler implements Web3Handler, FullnodeHandler {
     address: Address,
     defaultBlock: string
   ): Promise<string> {
-    if (defaultBlock !== 'latest') {
+    const curentBlockNumber = await this.provider.getBlockNumber()
+    if (!['latest', numberToHexString(curentBlockNumber)].includes(defaultBlock)) {
       log.debug(
         `No support for historical code lookups! Anything returned from this may be very wrong.`
       )
-      //throw new Error('No support for historical code lookups!')
+      throw new Error('No support for historical code lookups!')
     }
     log.debug(
       `Getting code for address: [${address}], defaultBlock: [${defaultBlock}]`

--- a/packages/rollup-full-node/src/app/web3-rpc-handler.ts
+++ b/packages/rollup-full-node/src/app/web3-rpc-handler.ts
@@ -318,14 +318,14 @@ export class DefaultWeb3Handler implements Web3Handler, FullnodeHandler {
       !['latest', numberToHexString(curentBlockNumber)].includes(defaultBlock)
     ) {
       log.debug(
-        `Historical code lookups aren't supported. Requested Block: ${hexStrToNumber(
+        `Historical code lookups aren't supported. defaultBlock: [${hexStrToNumber(
           defaultBlock
-        )} Current Block:${curentBlockNumber}`
+        )}] curentBlockNumber:[${curentBlockNumber}]`
       )
       throw new Error(
         `Historical code lookups aren't supported. Requested Block: ${hexStrToNumber(
           defaultBlock
-        )} Current Block:${curentBlockNumber}`
+        )} Current Block: ${curentBlockNumber}`
       )
     }
     log.debug(

--- a/packages/rollup-full-node/src/app/web3-rpc-handler.ts
+++ b/packages/rollup-full-node/src/app/web3-rpc-handler.ts
@@ -9,7 +9,7 @@ import {
   remove0x,
   ZERO_ADDRESS,
   getFirstDeployedContractAddress,
-  JsonRpcResponse
+  JsonRpcResponse,
 } from '@eth-optimism/core-utils'
 import {
   CHAIN_ID,
@@ -313,7 +313,9 @@ export class DefaultWeb3Handler implements Web3Handler, FullnodeHandler {
     defaultBlock: string
   ): Promise<string> {
     const curentBlockNumber = await this.provider.getBlockNumber()
-    if (!['latest', numberToHexString(curentBlockNumber)].includes(defaultBlock)) {
+    if (
+      !['latest', numberToHexString(curentBlockNumber)].includes(defaultBlock)
+    ) {
       log.debug(
         `No support for historical code lookups! Anything returned from this may be very wrong.`
       )

--- a/packages/rollup-full-node/src/app/web3-rpc-handler.ts
+++ b/packages/rollup-full-node/src/app/web3-rpc-handler.ts
@@ -318,14 +318,14 @@ export class DefaultWeb3Handler implements Web3Handler, FullnodeHandler {
       !['latest', numberToHexString(curentBlockNumber)].includes(defaultBlock)
     ) {
       log.debug(
-        `Requested block ${hexStrToNumber(
+        `Historical code lookups aren't supported. Requested Block: ${hexStrToNumber(
           defaultBlock
-        )} but the current block is ${curentBlockNumber}. Historical code lookups aren't supported.`
+        )} Current Block:${curentBlockNumber}`
       )
       throw new Error(
-        `Requested block ${hexStrToNumber(
+        `Historical code lookups aren't supported. Requested Block: ${hexStrToNumber(
           defaultBlock
-        )} but the current block is ${curentBlockNumber}. Historical code lookups aren't supported.`
+        )} Current Block:${curentBlockNumber}`
       )
     }
     log.debug(

--- a/packages/rollup-full-node/src/app/web3-rpc-handler.ts
+++ b/packages/rollup-full-node/src/app/web3-rpc-handler.ts
@@ -1,15 +1,16 @@
 /* External Imports */
 import { Address } from '@eth-optimism/rollup-core'
 import {
+  JsonRpcResponse,
+  ZERO_ADDRESS,
   add0x,
   buildJsonRpcError,
-  getLogger,
-  numberToHexString,
-  logError,
-  remove0x,
-  ZERO_ADDRESS,
   getFirstDeployedContractAddress,
-  JsonRpcResponse,
+  getLogger,
+  hexStrToNumber,
+  logError,
+  numberToHexString,
+  remove0x,
 } from '@eth-optimism/core-utils'
 import {
   CHAIN_ID,
@@ -317,9 +318,15 @@ export class DefaultWeb3Handler implements Web3Handler, FullnodeHandler {
       !['latest', numberToHexString(curentBlockNumber)].includes(defaultBlock)
     ) {
       log.debug(
-        `No support for historical code lookups! Anything returned from this may be very wrong.`
+        `Requested block ${hexStrToNumber(
+          defaultBlock
+        )} but the current block is ${curentBlockNumber}. Historical code lookups aren't supported.`
       )
-      throw new Error('No support for historical code lookups!')
+      throw new Error(
+        `Requested block ${hexStrToNumber(
+          defaultBlock
+        )} but the current block is ${curentBlockNumber}. Historical code lookups aren't supported.`
+      )
     }
     log.debug(
       `Getting code for address: [${address}], defaultBlock: [${defaultBlock}]`

--- a/packages/rollup-full-node/test/app/test-handler.spec.ts
+++ b/packages/rollup-full-node/test/app/test-handler.spec.ts
@@ -150,12 +150,23 @@ describe('TestHandler', () => {
     })
   })
 
-  describe('getCode endpoint', () => {
-    it('should be successful if the default block parameter is "latest"', async () => {
-      const testRpcServer = new FullnodeRpcServer(testHandler, host, port)
+  describe('the getCode endpoint', () => {
+    let testRpcServer
+    let httpProvider
+    let wallet
+
+    beforeEach(async () => {
+      testRpcServer = new FullnodeRpcServer(testHandler, host, port)
       testRpcServer.listen()
-      const httpProvider = new ethers.providers.JsonRpcProvider(baseUrl)
-      const [wallet] = getWallets(httpProvider)
+      httpProvider = new ethers.providers.JsonRpcProvider(baseUrl)
+      wallet = getWallets(httpProvider)[0]
+    })
+    
+    afterEach(async () => {
+      await testRpcServer.close()
+    })
+
+    it('should be successful if the default block parameter is "latest"', async () => {
       const factory = new ethers.ContractFactory(
         EmptyContract.abi,
         EmptyContract.bytecode,
@@ -164,15 +175,9 @@ describe('TestHandler', () => {
       const emptyContract = await deployContract(wallet, EmptyContract, [])
       const code = await httpProvider.getCode(emptyContract.address, 'latest')
       hexStrToBuf(code).byteLength.should.be.greaterThan(0)
-      testRpcServer.close()
     })
 
     it('should be successful if the default block parameter is set to the latest block number', async () => {
-      const testRpcServer = new FullnodeRpcServer(testHandler, host, port)
-
-      testRpcServer.listen()
-      const httpProvider = new ethers.providers.JsonRpcProvider(baseUrl)
-      const [wallet] = getWallets(httpProvider)
       const factory = new ethers.ContractFactory(
         EmptyContract.abi,
         EmptyContract.bytecode,
@@ -185,15 +190,9 @@ describe('TestHandler', () => {
         curentBlockNumber
       )
       hexStrToBuf(code).byteLength.should.be.greaterThan(0)
-      testRpcServer.close()
     })
 
     it('should be fail if the default block parameter is set to a block number before the current one', async () => {
-      const testRpcServer = new FullnodeRpcServer(testHandler, host, port)
-
-      testRpcServer.listen()
-      const httpProvider = new ethers.providers.JsonRpcProvider(baseUrl)
-      const [wallet] = getWallets(httpProvider)
       const factory = new ethers.ContractFactory(
         EmptyContract.abi,
         EmptyContract.bytecode,

--- a/packages/rollup-full-node/test/app/test-handler.spec.ts
+++ b/packages/rollup-full-node/test/app/test-handler.spec.ts
@@ -161,7 +161,7 @@ describe('TestHandler', () => {
       httpProvider = new ethers.providers.JsonRpcProvider(baseUrl)
       wallet = getWallets(httpProvider)[0]
     })
-    
+
     afterEach(async () => {
       await testRpcServer.close()
     })

--- a/packages/rollup-full-node/test/app/test-handler.spec.ts
+++ b/packages/rollup-full-node/test/app/test-handler.spec.ts
@@ -151,44 +151,59 @@ describe('TestHandler', () => {
   })
 
   describe('getCode endpoint', () => {
-    it.only('should be successful if the default block parameter is "latest"', async () => {
-        const testRpcServer = new FullnodeRpcServer(testHandler, host, port)
-        testRpcServer.listen()
-        const httpProvider = new ethers.providers.JsonRpcProvider(baseUrl)
-        const [wallet] = getWallets(httpProvider)
-        const factory = new ethers.ContractFactory(EmptyContract.abi, EmptyContract.bytecode, wallet);
-        const emptyContract = await deployContract(wallet, EmptyContract, [])
-        const code = await httpProvider.getCode(emptyContract.address, "latest")
-        hexStrToBuf(code).byteLength.should.be.greaterThan(0)
-        testRpcServer.close()
-      })
-
-    it.only('should be successful if the default block parameter is set to the latest block number', async () => {
-        const testRpcServer = new FullnodeRpcServer(testHandler, host, port)
-
-        testRpcServer.listen()
-        const httpProvider = new ethers.providers.JsonRpcProvider(baseUrl)
-        const [wallet] = getWallets(httpProvider)
-        const factory = new ethers.ContractFactory(EmptyContract.abi, EmptyContract.bytecode, wallet);
-        const emptyContract = await deployContract(wallet, EmptyContract, [])
-        const curentBlockNumber = await httpProvider.getBlockNumber()
-        const code = await httpProvider.getCode(emptyContract.address, curentBlockNumber)
-        hexStrToBuf(code).byteLength.should.be.greaterThan(0)
-        testRpcServer.close()
-      })
-
-    it.only('should be fail if the default block parameter is set to a block number before the current one', async () => {
-        const testRpcServer = new FullnodeRpcServer(testHandler, host, port)
-
-        testRpcServer.listen()
-        const httpProvider = new ethers.providers.JsonRpcProvider(baseUrl)
-        const [wallet] = getWallets(httpProvider)
-        const factory = new ethers.ContractFactory(EmptyContract.abi, EmptyContract.bytecode, wallet);
-        const emptyContract = await deployContract(wallet, EmptyContract, [])
-        const curentBlockNumber = await httpProvider.getBlockNumber()
-        TestUtils.assertThrowsAsync(async () =>
-          httpProvider.getCode(emptyContract.address, curentBlockNumber-1)
-        )
-      })
+    it('should be successful if the default block parameter is "latest"', async () => {
+      const testRpcServer = new FullnodeRpcServer(testHandler, host, port)
+      testRpcServer.listen()
+      const httpProvider = new ethers.providers.JsonRpcProvider(baseUrl)
+      const [wallet] = getWallets(httpProvider)
+      const factory = new ethers.ContractFactory(
+        EmptyContract.abi,
+        EmptyContract.bytecode,
+        wallet
+      )
+      const emptyContract = await deployContract(wallet, EmptyContract, [])
+      const code = await httpProvider.getCode(emptyContract.address, 'latest')
+      hexStrToBuf(code).byteLength.should.be.greaterThan(0)
+      testRpcServer.close()
     })
+
+    it('should be successful if the default block parameter is set to the latest block number', async () => {
+      const testRpcServer = new FullnodeRpcServer(testHandler, host, port)
+
+      testRpcServer.listen()
+      const httpProvider = new ethers.providers.JsonRpcProvider(baseUrl)
+      const [wallet] = getWallets(httpProvider)
+      const factory = new ethers.ContractFactory(
+        EmptyContract.abi,
+        EmptyContract.bytecode,
+        wallet
+      )
+      const emptyContract = await deployContract(wallet, EmptyContract, [])
+      const curentBlockNumber = await httpProvider.getBlockNumber()
+      const code = await httpProvider.getCode(
+        emptyContract.address,
+        curentBlockNumber
+      )
+      hexStrToBuf(code).byteLength.should.be.greaterThan(0)
+      testRpcServer.close()
+    })
+
+    it('should be fail if the default block parameter is set to a block number before the current one', async () => {
+      const testRpcServer = new FullnodeRpcServer(testHandler, host, port)
+
+      testRpcServer.listen()
+      const httpProvider = new ethers.providers.JsonRpcProvider(baseUrl)
+      const [wallet] = getWallets(httpProvider)
+      const factory = new ethers.ContractFactory(
+        EmptyContract.abi,
+        EmptyContract.bytecode,
+        wallet
+      )
+      const emptyContract = await deployContract(wallet, EmptyContract, [])
+      const curentBlockNumber = await httpProvider.getBlockNumber()
+      TestUtils.assertThrowsAsync(async () =>
+        httpProvider.getCode(emptyContract.address, curentBlockNumber - 1)
+      )
+    })
+  })
 })

--- a/packages/rollup-full-node/test/contracts/untranspiled/EmptyContract.sol
+++ b/packages/rollup-full-node/test/contracts/untranspiled/EmptyContract.sol
@@ -1,0 +1,4 @@
+pragma solidity ^0.5.0;
+
+contract EmptyContract {
+}


### PR DESCRIPTION
## Description
Support historical code lookups if the block number is current

## Metadata
### Fixes
- Fixes # [YAS-208](https://optimists.atlassian.net/browse/YAS-208)

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
