### PR TITLE
Fix bug w/ conversion of nonce to hex

### DIFF
--- a/packages/rollup-full-node/src/app/web3-rpc-handler.ts
+++ b/packages/rollup-full-node/src/app/web3-rpc-handler.ts
@@ -331,11 +331,10 @@ export class DefaultWeb3Handler implements Web3Handler, FullnodeHandler {
     log.debug(
       `Requesting transaction count. Address [${address}], block: [${defaultBlock}].`
     )
-    const response = add0x(
-      (
-        await this.context.executionManager.getOvmContractNonce(address)
-      ).toString(16)
+    const ovmContractNonce = await this.context.executionManager.getOvmContractNonce(
+      address
     )
+    const response = add0x(ovmContractNonce.toNumber().toString(16))
     log.debug(
       `Received transaction count for Address [${address}], block: [${defaultBlock}]: [${response}].`
     )


### PR DESCRIPTION
## Description
Fixes issue where we were returning 0x10 for getTransactionCount instead of 0xa. The issue was that we were calling .toString(16) on a BigNumber, not a number.
## Questions
None
## Metadata
None

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [X] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
