### PR TITLE
Yas 272/geth config changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,4 @@ RUN yarn
 WORKDIR /server/packages/rollup-full-node
 
 EXPOSE 8545
-ENTRYPOINT [ "yarn", "run", "server:fullnode:debug" ]
+ENTRYPOINT [ "bash", "./exec/wait-for-nodes.sh", "yarn", "run", "server:fullnode:debug" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,11 +4,11 @@ services:
 
   rollup-full-node:
     volumes:
-       - full-node-data:/volume/full-node:rw
-       - l1-node-data:/volume/l1-node:rw
-       - l2-node-data:/volume/l2-node:rw
-#    depends_on:
-#      - geth_l2
+       - full-node-data:/mnt/full-node:rw
+       - l1-node-data:/mnt/l1-node:rw
+       - l2-node-data:/mnt/l2-node:rw
+    depends_on:
+      - geth_l2
 #      - geth_l1
     build:
       context: .
@@ -23,31 +23,33 @@ services:
       - L2_RPC_SERVER_HOST
       - L2_RPC_SERVER_PORT
       - L2_WALLET_MNEMONIC
+      - L2_WALLET_PRIVATE_KEY_PATH=/mnt/l2-node/private_key.txt
       - LOCAL_L1_NODE_PORT
-      - LOCAL_L1_NODE_PERSISTENT_DB_PATH=/volume/l1-node
-      - LOCAL_L2_NODE_PERSISTENT_DB_PATH=/volume/l2-node
+      - LOCAL_L1_NODE_PERSISTENT_DB_PATH=/mnt/l1-node
+      - L2_NODE_WEB3_URL=http://geth_l2:8545/
+#      - LOCAL_L2_NODE_PERSISTENT_DB_PATH=/mnt/l2-node/
 #      - L1_NODE_WEB3_URL=http://geth_l1:8545/
-#      - L2_NODE_WEB3_URL=http://geth_l2:8545/
-#
-#  geth_l2:
-#    volumes:
-#       - l2-node-data:/mnt/geth/l2:rw
-#    build:
-#      context: docker/geth
-#      dockerfile: Dockerfile
-#    environment:
-#      - VOLUME_PATH=/mnt/geth/l2
-#    expose:
-#      - "8545"
+
+  geth_l2:
+    volumes:
+       - l2-node-data:/mnt/l2-node/l2:rw
+    build:
+      context: docker/geth
+      dockerfile: Dockerfile
+    environment:
+      - VOLUME_PATH=/mnt/l2-node/l2
+      - HOSTNAME=geth_l2
+    expose:
+      - "8545"
 #
 #  geth_l1:
 #    volumes:
-#      - l1-node-data:/mnt/geth/l1
+#      - l1-node-data:/mnt/l1-node/l1
 #    build:
 #      context: docker/geth
 #      dockerfile: Dockerfile
 #    environment:
-#      - VOLUME_PATH=/mnt/geth/l1
+#      - VOLUME_PATH=/mnt/l1-node/l1
 #    expose:
 #      - "8545"
 

--- a/docker/geth/entrypoint.sh
+++ b/docker/geth/entrypoint.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 
-HOSTNAME='geth'
+# PASSED IN FROM ENV
+#HOSTNAME=
+
 KEYSTORE_PATH="${VOLUME_PATH}/keystore"
 SEALER_PRIVATE_KEY_PATH="${VOLUME_PATH}/sealer_private_key.txt"
 PRIVATE_KEY_PATH="${VOLUME_PATH}/private_key.txt"

--- a/docker/geth/entrypoint.sh
+++ b/docker/geth/entrypoint.sh
@@ -57,9 +57,10 @@ if [[ ! -f $KEYSTORE_PATH && ! -f $SETUP_RUN_PATH ]]; then
     generate_private_key > $PRIVATE_KEY_PATH
     import_private_key $PRIVATE_KEY_PATH > $ADDRESS_PATH
     generate_geneisis `cat $SEALER_ADDRESS_PATH` `cat $ADDRESS_PATH`
-    echo "Ran Setup" > $SETUP_RUN_PATH
 
     geth --datadir $VOLUME_PATH --nousb --verbosity 0 init $GENISIS_PATH 2> /dev/null;
+    echo "Ran Setup" > $SETUP_RUN_PATH
+
     echo "Setup Complete"
     echo "Sealer Address: 0x`cat $SEALER_PRIVATE_KEY_PATH`"
     echo "Account Address: 0x`cat $PRIVATE_KEY_PATH`"

--- a/packages/rollup-full-node/exec/wait-for-nodes.sh
+++ b/packages/rollup-full-node/exec/wait-for-nodes.sh
@@ -9,8 +9,8 @@ TIMEOUT=10
 
 wait_for_server_to_be_reachable()
 {
-  COUNT=1
   if [ -n "$1" ]; then
+    COUNT=1
     until $(curl --output /dev/null --silent --fail -H "Content-Type: application/json" -d '{"jsonrpc": "2.0", "id": 9999999, "method": "net_version"}' $1); do
       sleep 1
       echo "Slept $COUNT times for $1 to be up..."

--- a/packages/rollup-full-node/exec/wait-for-nodes.sh
+++ b/packages/rollup-full-node/exec/wait-for-nodes.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+# wait-for-nodes.sh
+
+set -e
+
+cmd="$@"
+
+TIMEOUT=10
+
+wait_for_server_to_be_reachable()
+{
+  COUNT=1
+  if [ -n "$1" ]; then
+    until $(curl --output /dev/null --silent --fail -H "Content-Type: application/json" -d '{"jsonrpc": "2.0", "id": 9999999, "method": "net_version"}' $1); do
+      sleep 1
+      echo "Slept $COUNT times for $1 to be up..."
+
+      if [ "$COUNT" -ge "$TIMEOUT" ]; then
+        echo "Timeout waiting for server at $1"
+        exit 1
+      fi
+      COUNT=$($COUNT+1)
+    done
+  fi
+
+
+}
+
+wait_for_server_to_be_reachable $L1_NODE_WEB3_URL
+wait_for_server_to_be_reachable $L2_NODE_WEB3_URL
+
+>&2 echo "Dependent servers are up - executing command"
+exec $cmd

--- a/packages/rollup-full-node/src/app/utils/environment.ts
+++ b/packages/rollup-full-node/src/app/utils/environment.ts
@@ -40,6 +40,9 @@ export class Environment {
   public static l2WalletMnemonic(defaultValue?: string): string {
     return process.env.L2_WALLET_MNEMONIC || defaultValue
   }
+  public static l2WalletPrivateKeyPath(defaultValue?: string): string {
+    return process.env.L2_WALLET_PRIVATE_KEY_PATH || defaultValue
+  }
 
   // L1 Config
   public static l1NodeWeb3Url(defaultValue?: string): string {

--- a/packages/rollup-full-node/src/app/utils/l2-node.ts
+++ b/packages/rollup-full-node/src/app/utils/l2-node.ts
@@ -1,5 +1,9 @@
 /* Externals Import */
-import { getDeployedContractAddress, getLogger } from '@eth-optimism/core-utils'
+import {
+  getDeployedContractAddress,
+  getLogger,
+  logError, remove0x,
+} from '@eth-optimism/core-utils'
 import {
   GAS_LIMIT,
   L2ExecutionManagerContractDefinition,
@@ -20,6 +24,7 @@ import {
 } from '../index'
 import { JsonRpcProvider } from 'ethers/providers'
 import { L2NodeContext } from '../../types'
+import * as fs from 'fs'
 
 const log = getLogger('l2-node')
 
@@ -37,31 +42,73 @@ const log = getLogger('l2-node')
 export async function initializeL2Node(
   web3Provider?: JsonRpcProvider
 ): Promise<L2NodeContext> {
-  let provider: JsonRpcProvider = web3Provider
+  const provider: JsonRpcProvider = web3Provider || deployLocalL2Node()
+  const wallet: Wallet = getL2Wallet(provider)
 
-  if (!web3Provider) {
-    const opts = {
-      port: 9876,
-      gasLimit: DEFAULT_ETHNODE_GAS_LIMIT,
-      allowUnlimitedContractSize: true,
-    }
-    const persistedGanacheDbPath = Environment.localL2NodePersistentDbPath()
-    if (!!persistedGanacheDbPath) {
-      log.info(
-        `Found configuration for L1 Node DB Path: ${persistedGanacheDbPath}`
-      )
-      opts['db_path'] = persistedGanacheDbPath
-      opts['network_id'] = CHAIN_ID
-    }
-    log.info(`Creating Local L2 Node with config: ${JSON.stringify(opts)}`)
-    provider = createMockProvider(opts)
-    log.info(`Local L2 Node created!`)
+  const executionManager: Contract = await getExecutionManagerContract(
+    provider,
+    wallet
+  )
+  const l2ToL1MessagePasser: Contract = getL2ToL1MessagePasserContract(wallet)
+
+  return {
+    wallet,
+    provider,
+    executionManager,
+    l2ToL1MessagePasser,
   }
+}
 
+/**
+ * Deploys a local L2 node and gets the resulting provider.
+ * @returns The provider for use with the local node.
+ */
+function deployLocalL2Node(): JsonRpcProvider {
+  const opts = {
+    port: 9876,
+    gasLimit: DEFAULT_ETHNODE_GAS_LIMIT,
+    allowUnlimitedContractSize: true,
+  }
+  const persistedGanacheDbPath = Environment.localL2NodePersistentDbPath()
+  if (!!persistedGanacheDbPath) {
+    log.info(
+      `Found configuration for L1 Node DB Path: ${persistedGanacheDbPath}`
+    )
+    opts['db_path'] = persistedGanacheDbPath
+    opts['network_id'] = CHAIN_ID
+  }
+  log.info(`Creating Local L2 Node with config: ${JSON.stringify(opts)}`)
+  const provider = createMockProvider(opts)
+  log.info(`Local L2 Node created!`)
+
+  return provider
+}
+
+/**
+ * Gets the wallet to use to interact with the L2 node. This may be configured via mnemonic
+ * or path to private key file specified through environment variables. If not it is assumed
+ * that a local test provider is being used, from which the wallet may be fetched.
+ *
+ * @param provider The provider with which the wallet will be associated.
+ * @returns The wallet to use with the L2 node.
+ */
+function getL2Wallet(provider: JsonRpcProvider): Wallet {
   let wallet: Wallet
-  if (web3Provider && !!Environment.l2WalletMnemonic()) {
+  if (!!Environment.l2WalletMnemonic()) {
     wallet = Wallet.fromMnemonic(Environment.l2WalletMnemonic())
     wallet.connect(provider)
+  } else if (!!Environment.l2WalletPrivateKeyPath()) {
+    try {
+      const pk: string = fs.readFileSync(Environment.l2WalletPrivateKeyPath(), {encoding: 'utf-8'})
+      wallet = new Wallet(pk, provider)
+    } catch (e) {
+      logError(
+        log,
+        `Error creating wallet from PK path: ${Environment.l2WalletPrivateKeyPath()}`,
+        e
+      )
+      throw e
+    }
   } else {
     wallet = getWallets(provider)[0]
   }
@@ -74,15 +121,28 @@ export async function initializeL2Node(
     log.info(`L2 wallet created. Address: ${wallet.address}`)
   }
 
-  let nonce: number = 0
+  return wallet
+}
+
+/**
+ * Gets the ExecutionManager contract to use with the L2 node. This will automatically
+ * deploy a new ExecutionManager contract if one does not exist for the specified provider.
+ *
+ * @param provider The provider to use to determine if the contract has already been deployed.
+ * @param wallet The wallet to use for the contract.
+ * @returns The Execution Manager contract.
+ */
+async function getExecutionManagerContract(
+  provider: JsonRpcProvider,
+  wallet: Wallet
+): Promise<Contract> {
   const executionManagerAddress: Address = await getDeployedContractAddress(
-    nonce++,
+    0,
     provider,
     wallet.address
   )
 
   let executionManager: Contract
-  let l2ToL1MessagePasser: Contract
   if (executionManagerAddress) {
     log.info(
       `Using existing ExecutionManager deployed at ${executionManagerAddress}`
@@ -100,21 +160,7 @@ export async function initializeL2Node(
     )
   }
 
-  log.info(
-    `Using existing L2ToL1MessagePasser deployed at ${L2_TO_L1_MESSAGE_PASSER_OVM_ADDRESS}`
-  )
-  l2ToL1MessagePasser = new Contract(
-    L2_TO_L1_MESSAGE_PASSER_OVM_ADDRESS,
-    L2ToL1MessagePasserContractDefinition.abi,
-    wallet
-  )
-
-  return {
-    wallet,
-    provider,
-    executionManager,
-    l2ToL1MessagePasser,
-  }
+  return executionManager
 }
 
 /**
@@ -124,9 +170,7 @@ export async function initializeL2Node(
  * @param wallet The wallet to be used, containing all connection info.
  * @returns The deployed Contract.
  */
-export async function deployExecutionManager(
-  wallet: Wallet
-): Promise<Contract> {
+async function deployExecutionManager(wallet: Wallet): Promise<Contract> {
   log.debug('Deploying execution manager...')
 
   const executionManager: Contract = await deployContract(
@@ -139,4 +183,23 @@ export async function deployExecutionManager(
   log.info('Deployed execution manager to address:', executionManager.address)
 
   return executionManager
+}
+
+/**
+ * Gets the L2ToL1MessagePasserContract for use within the L2 Node.
+ * This is automatically deployed to a predictable address within the
+ * ExecutionManager, so it's just a matter of creating the contract wrapper.
+ *
+ * @param wallet The wallet to associate with the contract.
+ * @returns The Message Passer contract.
+ */
+function getL2ToL1MessagePasserContract(wallet: Wallet): Contract {
+  log.info(
+    `Using existing L2ToL1MessagePasser deployed at ${L2_TO_L1_MESSAGE_PASSER_OVM_ADDRESS}`
+  )
+  return new Contract(
+    L2_TO_L1_MESSAGE_PASSER_OVM_ADDRESS,
+    L2ToL1MessagePasserContractDefinition.abi,
+    wallet
+  )
 }

--- a/packages/rollup-full-node/src/app/utils/l2-node.ts
+++ b/packages/rollup-full-node/src/app/utils/l2-node.ts
@@ -2,7 +2,8 @@
 import {
   getDeployedContractAddress,
   getLogger,
-  logError, remove0x,
+  logError,
+  remove0x,
 } from '@eth-optimism/core-utils'
 import {
   GAS_LIMIT,
@@ -99,7 +100,9 @@ function getL2Wallet(provider: JsonRpcProvider): Wallet {
     wallet.connect(provider)
   } else if (!!Environment.l2WalletPrivateKeyPath()) {
     try {
-      const pk: string = fs.readFileSync(Environment.l2WalletPrivateKeyPath(), {encoding: 'utf-8'})
+      const pk: string = fs.readFileSync(Environment.l2WalletPrivateKeyPath(), {
+        encoding: 'utf-8',
+      })
       wallet = new Wallet(pk, provider)
     } catch (e) {
       logError(


### PR DESCRIPTION
## Description
* Modifying geth Dockerfile to bootstrap if not already bootstrapped and run
* Adding wait-for-nodes.sh script to make rollup-full-node wait for external node instances to start before starting up

## Metadata
### Fixes
- Fixes # [YAS-272](https://optimists.atlassian.net/browse/YAS-272)

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
