### PR TITLE
`require` timestamp is set on execution

### DIFF
--- a/packages/core-utils/src/app/misc.ts
+++ b/packages/core-utils/src/app/misc.ts
@@ -280,3 +280,12 @@ export const runInDomain = async (
   const domainToUse: domain.Domain = !!d ? d : domain.create()
   return domainToUse.run(func)
 }
+
+/**
+ * Gets the current number of seconds since the epoch.
+ *
+ * @returns The seconds since epoch.
+ */
+export const getCurrentTime = (): number => {
+  return Math.round(Date.now() / 1000)
+}

--- a/packages/core-utils/src/app/test-utils.ts
+++ b/packages/core-utils/src/app/test-utils.ts
@@ -38,4 +38,27 @@ export class TestUtils {
       "Function didn't throw as expected or threw the wrong error."
     )
   }
+
+  public static async assertRevertsAsync(
+    revertMessage: string,
+    func: () => Promise<any>,
+  ): Promise<void> {
+    let succeeded = true
+    try {
+      await func()
+      succeeded = false
+    } catch (e) {
+      if (e instanceof Error) {
+        assert.equal(e.message, `VM Exception while processing transaction: revert ${revertMessage}`)
+      } else {
+        succeeded = false
+      }
+    }
+
+    assert(
+      succeeded,
+      "Function didn't throw as expected or threw the wrong error."
+    )
+
+  }
 }

--- a/packages/core-utils/src/app/test-utils.ts
+++ b/packages/core-utils/src/app/test-utils.ts
@@ -41,7 +41,7 @@ export class TestUtils {
 
   public static async assertRevertsAsync(
     revertMessage: string,
-    func: () => Promise<any>,
+    func: () => Promise<any>
   ): Promise<void> {
     let succeeded = true
     try {
@@ -49,7 +49,10 @@ export class TestUtils {
       succeeded = false
     } catch (e) {
       if (e instanceof Error) {
-        assert.equal(e.message, `VM Exception while processing transaction: revert ${revertMessage}`)
+        assert.equal(
+          e.message,
+          `VM Exception while processing transaction: revert ${revertMessage}`
+        )
       } else {
         succeeded = false
       }
@@ -59,6 +62,5 @@ export class TestUtils {
       succeeded,
       "Function didn't throw as expected or threw the wrong error."
     )
-
   }
 }

--- a/packages/ovm/src/contracts/ExecutionManager.sol
+++ b/packages/ovm/src/contracts/ExecutionManager.sol
@@ -223,6 +223,7 @@ contract ExecutionManager is FullStateManager {
         address _l1MsgSenderAddress,
         bool _allowRevert
     ) public {
+        require(_timestamp > 0, "Timestamp must be greater than 0");
         uint _nonce = getOvmContractNonce(_fromAddress);
         // Initialize our context
         initializeContext(_timestamp, _queueOrigin, _fromAddress, _l1MsgSenderAddress);
@@ -397,9 +398,6 @@ contract ExecutionManager is FullStateManager {
      * returndata: uint256 representing the current timestamp.
      */
     function ovmTIMESTAMP() public view {
-        // First make sure the timestamp was set
-        require(executionContext.timestamp != 0, "Error: attempting to access non-existent timestamp.");
-
         uint t = executionContext.timestamp;
 
         assembly {

--- a/packages/ovm/test/contracts/execution-manager.call-opcodes.spec.ts
+++ b/packages/ovm/test/contracts/execution-manager.call-opcodes.spec.ts
@@ -2,7 +2,7 @@ import '../setup'
 
 /* External Imports */
 import { Address } from '@eth-optimism/rollup-core'
-import { getLogger, remove0x, add0x, TestUtils } from '@eth-optimism/core-utils'
+import { getLogger, remove0x, add0x, TestUtils, getCurrentTime } from '@eth-optimism/core-utils'
 
 import { Contract, ContractFactory, ethers } from 'ethers'
 import { createMockProvider, deployContract, getWallets } from 'ethereum-waffle'
@@ -132,7 +132,7 @@ describe('Execution Manager -- Call opcodes', () => {
       const data: string =
         encodeMethodId('executeCall') +
         encodeRawArguments([
-          0,
+          getCurrentTime(),
           0,
           addressToBytes32Address(callContractAddress),
           methodIds.makeCall,
@@ -202,7 +202,7 @@ describe('Execution Manager -- Call opcodes', () => {
       const data: string =
         methodIds.executeCall +
         encodeRawArguments([
-          0,
+          getCurrentTime(),
           0,
           addressToBytes32Address(callContractAddress),
           methodIds.makeDelegateCall,
@@ -253,7 +253,7 @@ describe('Execution Manager -- Call opcodes', () => {
       const data: string =
         methodIds.executeCall +
         encodeRawArguments([
-          0,
+          getCurrentTime(),
           0,
           addressToBytes32Address(callContractAddress),
           methodIds.makeDelegateCall,
@@ -355,7 +355,7 @@ describe('Execution Manager -- Call opcodes', () => {
       const data: string =
         methodIds.executeCall +
         encodeRawArguments([
-          0,
+          getCurrentTime(),
           0,
           addressToBytes32Address(callContractAddress),
           methodIds.makeStaticCallThenCall,
@@ -374,7 +374,7 @@ describe('Execution Manager -- Call opcodes', () => {
       const data: string =
         methodIds.executeCall +
         encodeRawArguments([
-          0,
+          getCurrentTime(),
           0,
           addressToBytes32Address(callContractAddress),
           methodIds.makeStaticCall,
@@ -396,7 +396,7 @@ describe('Execution Manager -- Call opcodes', () => {
       const data: string =
         methodIds.executeCall +
         encodeRawArguments([
-          0,
+          getCurrentTime(),
           0,
           addressToBytes32Address(callContractAddress),
           methodIds.makeStaticCall,
@@ -420,7 +420,7 @@ describe('Execution Manager -- Call opcodes', () => {
       const data: string =
         methodIds.executeCall +
         encodeRawArguments([
-          0,
+          getCurrentTime(),
           0,
           addressToBytes32Address(callContractAddress),
           methodIds.makeStaticCall,
@@ -447,7 +447,7 @@ describe('Execution Manager -- Call opcodes', () => {
       const data: string =
         methodIds.executeCall +
         encodeRawArguments([
-          0,
+          getCurrentTime(),
           0,
           addressToBytes32Address(callContractAddress),
           methodIds.makeStaticCall,
@@ -470,7 +470,7 @@ describe('Execution Manager -- Call opcodes', () => {
       const data: string =
         methodIds.executeCall +
         encodeRawArguments([
-          0,
+          getCurrentTime(),
           0,
           addressToBytes32Address(callContractAddress),
           methodIds.makeStaticCall,
@@ -498,7 +498,7 @@ describe('Execution Manager -- Call opcodes', () => {
       const data: string =
         methodIds.executeCall +
         encodeRawArguments([
-          0,
+          getCurrentTime(),
           0,
           addressToBytes32Address(callContractAddress),
           methodIds.makeStaticCall,
@@ -522,7 +522,7 @@ describe('Execution Manager -- Call opcodes', () => {
   const executeCall = (args: any[]): Promise<string> => {
     return executeOVMCall(executionManager, 'executeCall', [
       encodeRawArguments([
-        0,
+        getCurrentTime(),
         0,
         addressToBytes32Address(callContractAddress),
         methodIds.makeCall,

--- a/packages/ovm/test/contracts/execution-manager.call-opcodes.spec.ts
+++ b/packages/ovm/test/contracts/execution-manager.call-opcodes.spec.ts
@@ -2,7 +2,13 @@ import '../setup'
 
 /* External Imports */
 import { Address } from '@eth-optimism/rollup-core'
-import { getLogger, remove0x, add0x, TestUtils, getCurrentTime } from '@eth-optimism/core-utils'
+import {
+  getLogger,
+  remove0x,
+  add0x,
+  TestUtils,
+  getCurrentTime,
+} from '@eth-optimism/core-utils'
 
 import { Contract, ContractFactory, ethers } from 'ethers'
 import { createMockProvider, deployContract, getWallets } from 'ethereum-waffle'

--- a/packages/ovm/test/contracts/execution-manager.context-opcodes.spec.ts
+++ b/packages/ovm/test/contracts/execution-manager.context-opcodes.spec.ts
@@ -7,6 +7,7 @@ import {
   hexStrToNumber,
   remove0x,
   TestUtils,
+  getCurrentTime,
 } from '@eth-optimism/core-utils'
 
 import { Contract, ContractFactory, ethers } from 'ethers'
@@ -152,18 +153,7 @@ describe('Execution Manager -- Context opcodes', () => {
   })
 
   describe('ovmTIMESTAMP', async () => {
-    it('reverts when TIMESTAMP is not set', async () => {
-      await TestUtils.assertThrowsAsync(async () => {
-        await executeCall([
-          contractAddress32,
-          methodIds.callThroughExecutionManager,
-          contract2Address32,
-          methodIds.getTIMESTAMP,
-        ])
-      })
-    })
-
-    it('properly retrieves TIMESTAMP when timestamp is set', async () => {
+    it('properly retrieves TIMESTAMP', async () => {
       const timestamp: number = 1582890922
       const result = await executeOVMCall(executionManager, 'executeCall', [
         timestamp,
@@ -201,7 +191,7 @@ describe('Execution Manager -- Context opcodes', () => {
     it('gets Queue Origin when it is 0', async () => {
       const queueOrigin: string = '00'.repeat(32)
       const result = await executeOVMCall(executionManager, 'executeCall', [
-        0,
+        getCurrentTime(),
         queueOrigin,
         contractAddress32,
         methodIds.callThroughExecutionManager,
@@ -218,7 +208,7 @@ describe('Execution Manager -- Context opcodes', () => {
     it('properly retrieves Queue Origin when queue origin is set', async () => {
       const queueOrigin: string = '00'.repeat(30) + '1111'
       const result = await executeOVMCall(executionManager, 'executeCall', [
-        0,
+        getCurrentTime(),
         queueOrigin,
         contractAddress32,
         methodIds.callThroughExecutionManager,
@@ -235,7 +225,7 @@ describe('Execution Manager -- Context opcodes', () => {
 
   const executeCall = (args: any[]): Promise<string> => {
     return executeOVMCall(executionManager, 'executeCall', [
-      encodeRawArguments([0, 0, ...args]),
+      encodeRawArguments([getCurrentTime(), 0, ...args]),
     ])
   }
 })

--- a/packages/ovm/test/contracts/execution-manager.executeCall.spec.ts
+++ b/packages/ovm/test/contracts/execution-manager.executeCall.spec.ts
@@ -104,7 +104,9 @@ describe('Execution Manager -- Call opcodes', () => {
       const signedMessage = await wallet.sign(transaction)
       const [v, r, s] = ethers.utils.RLP.decode(signedMessage).slice(-3)
 
-      await TestUtils.assertThrowsAsync(async () => {
+      await TestUtils.assertRevertsAsync(
+        "Timestamp must be greater than 0",
+      async () => {
         // Call using Ethers
         const tx = await executionManager.executeEOACall(
           0,
@@ -119,6 +121,7 @@ describe('Execution Manager -- Call opcodes', () => {
         await provider.waitForTransaction(tx.hash)
       })
     })
+
     it('properly executes a raw call -- 0 param', async () => {
       // Create the variables we will use for setStorage
       const intParam = 0

--- a/packages/ovm/test/contracts/execution-manager.executeCall.spec.ts
+++ b/packages/ovm/test/contracts/execution-manager.executeCall.spec.ts
@@ -2,7 +2,13 @@ import '../setup'
 
 /* External Imports */
 import { Address } from '@eth-optimism/rollup-core'
-import { getLogger, padToLength, ZERO_ADDRESS, TestUtils, getCurrentTime } from '@eth-optimism/core-utils'
+import {
+  getLogger,
+  padToLength,
+  ZERO_ADDRESS,
+  TestUtils,
+  getCurrentTime,
+} from '@eth-optimism/core-utils'
 
 import { Contract, ContractFactory, ethers } from 'ethers'
 import { createMockProvider, deployContract, getWallets } from 'ethereum-waffle'

--- a/packages/ovm/test/contracts/execution-manager.executeCall.spec.ts
+++ b/packages/ovm/test/contracts/execution-manager.executeCall.spec.ts
@@ -105,21 +105,22 @@ describe('Execution Manager -- Call opcodes', () => {
       const [v, r, s] = ethers.utils.RLP.decode(signedMessage).slice(-3)
 
       await TestUtils.assertRevertsAsync(
-        "Timestamp must be greater than 0",
-      async () => {
-        // Call using Ethers
-        const tx = await executionManager.executeEOACall(
-          0,
-          0,
-          transaction.nonce,
-          transaction.to,
-          transaction.data,
-          padToLength(v, 4),
-          padToLength(r, 64),
-          padToLength(s, 64)
-        )
-        await provider.waitForTransaction(tx.hash)
-      })
+        'Timestamp must be greater than 0',
+        async () => {
+          // Call using Ethers
+          const tx = await executionManager.executeEOACall(
+            0,
+            0,
+            transaction.nonce,
+            transaction.to,
+            transaction.data,
+            padToLength(v, 4),
+            padToLength(r, 64),
+            padToLength(s, 64)
+          )
+          await provider.waitForTransaction(tx.hash)
+        }
+      )
     })
 
     it('properly executes a raw call -- 0 param', async () => {

--- a/packages/ovm/test/contracts/execution-manager.l1-l2-opcodes.spec.ts
+++ b/packages/ovm/test/contracts/execution-manager.l1-l2-opcodes.spec.ts
@@ -4,6 +4,7 @@ import '../setup'
 import { Address } from '@eth-optimism/rollup-core'
 import {
   getLogger,
+  getCurrentTime,
   remove0x,
   add0x,
   TestUtils,
@@ -163,7 +164,7 @@ describe('Execution Manager -- L1 <-> L2 Opcodes', () => {
       ethereumjsAbi.methodID('getL1MessageSender', [])
     )
 
-    it('should return the l1 message sender provided', async () => {
+    it.only('should return the l1 message sender provided', async () => {
       const l1MessageSenderPrecompileAddr =
         '0x4200000000000000000000000000000000000001'
       const testL1MsgSenderAddress = '0x' + '01'.repeat(20)
@@ -171,7 +172,7 @@ describe('Execution Manager -- L1 <-> L2 Opcodes', () => {
       const callResult = await callExecutionManagerExecuteUnsignedEOACall(
         executionManager,
         [
-          0,
+          getCurrentTime(),
           0,
           l1MessageSenderPrecompileAddr,
           getL1MessageSenderMethodId,

--- a/packages/ovm/test/contracts/simple-storage.spec.ts
+++ b/packages/ovm/test/contracts/simple-storage.spec.ts
@@ -3,7 +3,7 @@ import '../setup'
 /* External Imports */
 import { Address } from '@eth-optimism/rollup-core'
 import { createMockProvider, deployContract, getWallets } from 'ethereum-waffle'
-import { getLogger, add0x } from '@eth-optimism/core-utils'
+import { getLogger, add0x, getCurrentTime } from '@eth-optimism/core-utils'
 import { Contract, ContractFactory, ethers } from 'ethers'
 import { TransactionReceipt } from 'ethers/providers'
 import * as ethereumjsAbi from 'ethereumjs-abi'
@@ -118,7 +118,7 @@ describe('SimpleStorage', () => {
       const callData = getUnsignedTransactionCalldata(
         executionManager,
         'executeEOACall',
-        [0, 0, transaction.nonce, transaction.to, transaction.data, v, r, s]
+        [getCurrentTime(), 0, transaction.nonce, transaction.to, transaction.data, v, r, s]
       )
 
       const result = await executionManager.provider.call({

--- a/packages/ovm/test/contracts/simple-storage.spec.ts
+++ b/packages/ovm/test/contracts/simple-storage.spec.ts
@@ -118,7 +118,16 @@ describe('SimpleStorage', () => {
       const callData = getUnsignedTransactionCalldata(
         executionManager,
         'executeEOACall',
-        [getCurrentTime(), 0, transaction.nonce, transaction.to, transaction.data, v, r, s]
+        [
+          getCurrentTime(),
+          0,
+          transaction.nonce,
+          transaction.to,
+          transaction.data,
+          v,
+          r,
+          s,
+        ]
       )
 
       const result = await executionManager.provider.call({

--- a/packages/ovm/test/contracts/tx-origin.spec.ts
+++ b/packages/ovm/test/contracts/tx-origin.spec.ts
@@ -3,7 +3,7 @@ import '../setup'
 /* External Imports */
 import { Address } from '@eth-optimism/rollup-core'
 import { createMockProvider, deployContract, getWallets } from 'ethereum-waffle'
-import { getLogger, add0x } from '@eth-optimism/core-utils'
+import { getLogger, add0x, getCurrentTime } from '@eth-optimism/core-utils'
 import { Contract, ContractFactory } from 'ethers'
 import * as ethereumjsAbi from 'ethereumjs-abi'
 
@@ -85,7 +85,7 @@ describe('SimpleTxOrigin', () => {
       const callData = getUnsignedTransactionCalldata(
         executionManager,
         'executeEOACall',
-        [0, 0, transaction.nonce, transaction.to, transaction.data, v, r, s]
+        [getCurrentTime(), 0, transaction.nonce, transaction.to, transaction.data, v, r, s]
       )
 
       const result = await executionManager.provider.call({

--- a/packages/ovm/test/contracts/tx-origin.spec.ts
+++ b/packages/ovm/test/contracts/tx-origin.spec.ts
@@ -85,7 +85,16 @@ describe('SimpleTxOrigin', () => {
       const callData = getUnsignedTransactionCalldata(
         executionManager,
         'executeEOACall',
-        [getCurrentTime(), 0, transaction.nonce, transaction.to, transaction.data, v, r, s]
+        [
+          getCurrentTime(),
+          0,
+          transaction.nonce,
+          transaction.to,
+          transaction.data,
+          v,
+          r,
+          s,
+        ]
       )
 
       const result = await executionManager.provider.call({

--- a/packages/ovm/test/helpers.ts
+++ b/packages/ovm/test/helpers.ts
@@ -5,6 +5,7 @@ import {
   getLogger,
   add0x,
   abi,
+  getCurrentTime,
   keccak256,
   strToHexStr,
   remove0x,
@@ -119,7 +120,7 @@ export const executeUnsignedEOACall = async (
 
   // Actually make the call
   const tx = await executionManager.executeUnsignedEOACall(
-    0,
+    getCurrentTime(),
     0,
     ovmTo,
     data,


### PR DESCRIPTION
...instead of when calling ovmTimestamp

Transpiled calls to ovmTimestamp don't check the result of the call so
requires are ignored. Instead we check validity of the timestamp in
`executeUnsignedEOACall`. This required us to set valid timestamps in
other calls to the ExecutionManager as well.


## Metadata
### Fixes
- Fixes # [YAS-192](https://optimists.atlassian.net/browse/YAS-192)


## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
