### PR TITLE
Null-Checking for bytecode in solc-transpiler

### DIFF
--- a/packages/solc-transpiler/src/compiler.ts
+++ b/packages/solc-transpiler/src/compiler.ts
@@ -79,52 +79,58 @@ export const compile = (configJsonString: string, callbacks?: any): string => {
   for (const [filename, fileJson] of Object.entries(res.contracts)) {
     log.debug(`Transpiling file: ${filename}`)
     for (const [contractName, contractJson] of Object.entries(fileJson)) {
-      if (!!contractJson && !!contractJson.evm && !!contractJson.evm.bytecode && !!contractJson.evm.deployedBytecode) {
-        // Library links in bytecode strings have invalid hex: they are of the form __$asdfasdf$__.
-        // Because __$ is not a valid hex string, we replace with a valid hex string during transpilation,
-        // storing the links re-substituting the __$* strings afterwards
-        const originalRefStrings = getOriginalLinkRefStringsAndSubstituteValidHex(
-          contractJson
-        )
-        log.debug(
-          `Transpiling contract: ${contractName} with valid hex strings for link placeholders.`
-        )
-        const output = transpileContract(
-          transpiler,
-          contractJson,
-          filename,
-          contractName
-        )
-        log.debug(`Transpiled contract ${contractName}.`)
+      if (
+        !contractJson ||
+        !contractJson.evm ||
+        !contractJson.evm.bytecode ||
+        !contractJson.evm.deployedBytecode
+      ) {
+        continue
+      }
+      // Library links in bytecode strings have invalid hex: they are of the form __$asdfasdf$__.
+      // Because __$ is not a valid hex string, we replace with a valid hex string during transpilation,
+      // storing the links re-substituting the __$* strings afterwards
+      const originalRefStrings = getOriginalLinkRefStringsAndSubstituteValidHex(
+        contractJson
+      )
+      log.debug(
+        `Transpiling contract: ${contractName} with valid hex strings for link placeholders.`
+      )
+      const output = transpileContract(
+        transpiler,
+        contractJson,
+        filename,
+        contractName
+      )
+      log.debug(`Transpiled contract ${contractName}.`)
 
-        res.contracts[filename][contractName].evm.bytecode.object = remove0x(
-          output.bytecode || ''
-        )
-        res.contracts[filename][
-          contractName
-        ].evm.deployedBytecode.object = remove0x(output.deployedBytecode || '')
-        res.contracts[filename][contractName].evm.bytecode.object = remove0x(
-          output.bytecode || ''
-        )
-        res.contracts[filename][
-          contractName
-        ].evm.deployedBytecode.object = remove0x(output.deployedBytecode || '')
+      res.contracts[filename][contractName].evm.bytecode.object = remove0x(
+        output.bytecode || ''
+      )
+      res.contracts[filename][
+        contractName
+      ].evm.deployedBytecode.object = remove0x(output.deployedBytecode || '')
+      res.contracts[filename][contractName].evm.bytecode.object = remove0x(
+        output.bytecode || ''
+      )
+      res.contracts[filename][
+        contractName
+      ].evm.deployedBytecode.object = remove0x(output.deployedBytecode || '')
 
-        log.debug(
-          `Updating links for all libraries by putting back original invalid hex (__$...$__) strings and updating link .start's.`
-        )
-        updateLinkRefsAndSubstituteOriginalStrings(
-          res.contracts[filename][contractName],
-          originalRefStrings
-        )
+      log.debug(
+        `Updating links for all libraries by putting back original invalid hex (__$...$__) strings and updating link .start's.`
+      )
+      updateLinkRefsAndSubstituteOriginalStrings(
+        res.contracts[filename][contractName],
+        originalRefStrings
+      )
 
-        if (!!output.errors) {
-          if (!res.errors) {
-            res.errors = []
-          }
-
-          res.errors.push(...output.errors)
+      if (!!output.errors) {
+        if (!res.errors) {
+          res.errors = []
         }
+
+        res.errors.push(...output.errors)
       }
     }
   }


### PR DESCRIPTION
## Description
When, for example, we transpile an interface, we will use `solc.compile`, which will output an empty bytecode and null deployedBytecode object. We shouldn't be trying to transpile non-existent bytecode

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [X] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
