### PR TITLE
Remove `ExecutionManager#executeTransactionRaw`

### DIFF
--- a/packages/ovm/test/contracts/execution-manager.call-opcodes.spec.ts
+++ b/packages/ovm/test/contracts/execution-manager.call-opcodes.spec.ts
@@ -43,7 +43,6 @@ const log = getLogger('execution-manager-calls', true)
 
 const methodIds = fromPairs(
   [
-    'executeTransactionRaw',
     'makeCall',
     'makeStaticCall',
     'makeStaticCallThenCall',

--- a/packages/ovm/test/contracts/execution-manager.call-opcodes.spec.ts
+++ b/packages/ovm/test/contracts/execution-manager.call-opcodes.spec.ts
@@ -334,9 +334,7 @@ describe('Execution Manager -- Call opcodes', () => {
       await executeTransaction(
         callContractAddress,
         methodIds.makeStaticCallThenCall,
-        [
-          addressToBytes32Address(callContractAddress),
-        ]
+        [addressToBytes32Address(callContractAddress)]
       )
     })
 

--- a/packages/ovm/test/contracts/execution-manager.call-opcodes.spec.ts
+++ b/packages/ovm/test/contracts/execution-manager.call-opcodes.spec.ts
@@ -59,7 +59,7 @@ const sloadKey: string = '11'.repeat(32)
 const unpopultedSLOADResult: string = '00'.repeat(32)
 const populatedSLOADResult: string = '22'.repeat(32)
 
-describe.only('Execution Manager -- Call opcodes', () => {
+describe('Execution Manager -- Call opcodes', () => {
   const provider = createMockProvider({ gasLimit: DEFAULT_ETHNODE_GAS_LIMIT })
   const [wallet] = getWallets(provider)
   // Create pointers to our execution manager & simple copier contract

--- a/packages/ovm/test/contracts/execution-manager.context-opcodes.spec.ts
+++ b/packages/ovm/test/contracts/execution-manager.context-opcodes.spec.ts
@@ -123,10 +123,8 @@ describe('Execution Manager -- Context opcodes', () => {
       const result = await executeTransaction(
         contractAddress,
         methodIds.callThroughExecutionManager,
-      [
-        contract2Address32,
-        methodIds.getCALLER,
-      ])
+        [contract2Address32, methodIds.getCALLER]
+      )
       log.debug(`CALLER result: ${result}`)
 
       should.exist(result, 'Result should exist!')
@@ -144,10 +142,9 @@ describe('Execution Manager -- Context opcodes', () => {
     it('properly retrieves ADDRESS when address is set', async () => {
       const result = await executeTransaction(
         contractAddress,
-        methodIds.callThroughExecutionManager,[
-        contract2Address32,
-        methodIds.getADDRESS,
-      ])
+        methodIds.callThroughExecutionManager,
+        [contract2Address32, methodIds.getADDRESS]
+      )
 
       log.debug(`ADDRESS result: ${result}`)
 
@@ -160,17 +157,18 @@ describe('Execution Manager -- Context opcodes', () => {
     it('properly retrieves TIMESTAMP', async () => {
       const timestamp: number = getCurrentTime()
       const result = await executeTransaction(
-          contractAddress,
-          methodIds.callThroughExecutionManager, [
-          contract2Address32,
-          methodIds.getTIMESTAMP,
-        ]
+        contractAddress,
+        methodIds.callThroughExecutionManager,
+        [contract2Address32, methodIds.getTIMESTAMP]
       )
 
       log.debug(`TIMESTAMP result: ${result}`)
 
       should.exist(result, 'Result should exist!')
-      hexStrToNumber(result).should.be.gte(timestamp, 'Timestamps do not match.')
+      hexStrToNumber(result).should.be.gte(
+        timestamp,
+        'Timestamps do not match.'
+      )
     })
   })
 
@@ -178,10 +176,9 @@ describe('Execution Manager -- Context opcodes', () => {
     it('properly retrieves GASLIMIT', async () => {
       const result = await executeTransaction(
         contractAddress,
-        methodIds.callThroughExecutionManager,[
-        contract2Address32,
-        methodIds.getGASLIMIT,
-      ])
+        methodIds.callThroughExecutionManager,
+        [contract2Address32, methodIds.getGASLIMIT]
+      )
 
       log.debug(`GASLIMIT result: ${result}`)
 
@@ -194,11 +191,9 @@ describe('Execution Manager -- Context opcodes', () => {
     it('gets Queue Origin when it is 0', async () => {
       const queueOrigin: string = '00'.repeat(32)
       const result = await executeTransaction(
-          contractAddress,
-          methodIds.callThroughExecutionManager,[
-          contract2Address32,
-          methodIds.getQueueOrigin,
-        ]
+        contractAddress,
+        methodIds.callThroughExecutionManager,
+        [contract2Address32, methodIds.getQueueOrigin]
       )
 
       log.debug(`QUEUE ORIGIN result: ${result}`)
@@ -211,10 +206,8 @@ describe('Execution Manager -- Context opcodes', () => {
       const queueOrigin: string = '00'.repeat(30) + '1111'
       const result = await executeTransaction(
         contractAddress,
-        methodIds.callThroughExecutionManager,[
-        contract2Address32,
-        methodIds.getQueueOrigin,
-      ],
+        methodIds.callThroughExecutionManager,
+        [contract2Address32, methodIds.getQueueOrigin],
         add0x(queueOrigin)
       )
 
@@ -229,7 +222,7 @@ describe('Execution Manager -- Context opcodes', () => {
     address: string,
     methodId: string,
     args: any[],
-    queueOrigin = ZERO_ADDRESS,
+    queueOrigin = ZERO_ADDRESS
   ): Promise<string> => {
     const callBytes = add0x(methodId + encodeRawArguments(args))
     const data = executionManager.interface.functions[

--- a/packages/ovm/test/contracts/execution-manager.context-opcodes.spec.ts
+++ b/packages/ovm/test/contracts/execution-manager.context-opcodes.spec.ts
@@ -39,7 +39,6 @@ const log = getLogger('execution-manager-context', true)
 const methodIds = fromPairs(
   [
     'callThroughExecutionManager',
-    'executeTransactionRaw',
     'getADDRESS',
     'getCALLER',
     'getGASLIMIT',

--- a/packages/ovm/test/contracts/execution-manager.context-opcodes.spec.ts
+++ b/packages/ovm/test/contracts/execution-manager.context-opcodes.spec.ts
@@ -6,6 +6,8 @@ import {
   getLogger,
   hexStrToNumber,
   remove0x,
+  add0x,
+  ZERO_ADDRESS,
   TestUtils,
   getCurrentTime,
 } from '@eth-optimism/core-utils'
@@ -25,6 +27,7 @@ import {
   executeOVMCall,
   encodeRawArguments,
   encodeMethodId,
+  gasLimit,
 } from '../helpers'
 import { GAS_LIMIT, DEFAULT_OPCODE_WHITELIST_MASK } from '../../src/app'
 import { fromPairs } from 'lodash'
@@ -112,14 +115,15 @@ describe('Execution Manager -- Context opcodes', () => {
   describe('ovmCALLER', async () => {
     it('reverts when CALLER is not set', async () => {
       await TestUtils.assertThrowsAsync(async () => {
-        await executeTransaction([contractAddress32, methodIds.ovmCALLER])
+        await executeTransaction(contractAddress, methodIds.ovmCALLER, [])
       })
     })
 
     it('properly retrieves CALLER when caller is set', async () => {
-      const result = await executeTransaction([
-        contractAddress32,
+      const result = await executeTransaction(
+        contractAddress,
         methodIds.callThroughExecutionManager,
+      [
         contract2Address32,
         methodIds.getCALLER,
       ])
@@ -133,14 +137,14 @@ describe('Execution Manager -- Context opcodes', () => {
   describe('ovmADDRESS', async () => {
     it('reverts when ADDRESS is not set', async () => {
       await TestUtils.assertThrowsAsync(async () => {
-        await executeTransaction([contractAddress32, methodIds.ovmADDRESS])
+        await executeTransaction(contractAddress, methodIds.ovmADDRESS, [])
       })
     })
 
     it('properly retrieves ADDRESS when address is set', async () => {
-      const result = await executeTransaction([
-        contractAddress32,
-        methodIds.callThroughExecutionManager,
+      const result = await executeTransaction(
+        contractAddress,
+        methodIds.callThroughExecutionManager,[
         contract2Address32,
         methodIds.getADDRESS,
       ])
@@ -154,15 +158,10 @@ describe('Execution Manager -- Context opcodes', () => {
 
   describe('ovmTIMESTAMP', async () => {
     it('properly retrieves TIMESTAMP', async () => {
-      const timestamp: number = 1582890922
-      const result = await executeOVMCall(
-        executionManager,
-        'executeTransactionRaw',
-        [
-          timestamp,
-          0,
-          contractAddress32,
-          methodIds.callThroughExecutionManager,
+      const timestamp: number = getCurrentTime()
+      const result = await executeTransaction(
+          contractAddress,
+          methodIds.callThroughExecutionManager, [
           contract2Address32,
           methodIds.getTIMESTAMP,
         ]
@@ -171,15 +170,15 @@ describe('Execution Manager -- Context opcodes', () => {
       log.debug(`TIMESTAMP result: ${result}`)
 
       should.exist(result, 'Result should exist!')
-      hexStrToNumber(result).should.equal(timestamp, 'Timestamps do not match.')
+      hexStrToNumber(result).should.be.gte(timestamp, 'Timestamps do not match.')
     })
   })
 
   describe('ovmGASLIMIT', async () => {
     it('properly retrieves GASLIMIT', async () => {
-      const result = await executeTransaction([
-        contractAddress32,
-        methodIds.callThroughExecutionManager,
+      const result = await executeTransaction(
+        contractAddress,
+        methodIds.callThroughExecutionManager,[
         contract2Address32,
         methodIds.getGASLIMIT,
       ])
@@ -194,14 +193,9 @@ describe('Execution Manager -- Context opcodes', () => {
   describe('ovmQueueOrigin', async () => {
     it('gets Queue Origin when it is 0', async () => {
       const queueOrigin: string = '00'.repeat(32)
-      const result = await executeOVMCall(
-        executionManager,
-        'executeTransactionRaw',
-        [
-          getCurrentTime(),
-          queueOrigin,
-          contractAddress32,
-          methodIds.callThroughExecutionManager,
+      const result = await executeTransaction(
+          contractAddress,
+          methodIds.callThroughExecutionManager,[
           contract2Address32,
           methodIds.getQueueOrigin,
         ]
@@ -215,17 +209,13 @@ describe('Execution Manager -- Context opcodes', () => {
 
     it('properly retrieves Queue Origin when queue origin is set', async () => {
       const queueOrigin: string = '00'.repeat(30) + '1111'
-      const result = await executeOVMCall(
-        executionManager,
-        'executeTransactionRaw',
-        [
-          getCurrentTime(),
-          queueOrigin,
-          contractAddress32,
-          methodIds.callThroughExecutionManager,
-          contract2Address32,
-          methodIds.getQueueOrigin,
-        ]
+      const result = await executeTransaction(
+        contractAddress,
+        methodIds.callThroughExecutionManager,[
+        contract2Address32,
+        methodIds.getQueueOrigin,
+      ],
+        add0x(queueOrigin)
       )
 
       log.debug(`QUEUE ORIGIN result: ${result}`)
@@ -235,9 +225,28 @@ describe('Execution Manager -- Context opcodes', () => {
     })
   })
 
-  const executeTransaction = (args: any[]): Promise<string> => {
-    return executeOVMCall(executionManager, 'executeTransactionRaw', [
-      encodeRawArguments([getCurrentTime(), 0, ...args]),
+  const executeTransaction = async (
+    address: string,
+    methodId: string,
+    args: any[],
+    queueOrigin = ZERO_ADDRESS,
+  ): Promise<string> => {
+    const callBytes = add0x(methodId + encodeRawArguments(args))
+    const data = executionManager.interface.functions[
+      'executeTransaction'
+    ].encode([
+      getCurrentTime(),
+      queueOrigin,
+      address,
+      callBytes,
+      ZERO_ADDRESS,
+      ZERO_ADDRESS,
+      true,
     ])
+    return executionManager.provider.call({
+      to: executionManager.address,
+      data,
+      gasLimit,
+    })
   }
 })

--- a/packages/ovm/test/helpers.ts
+++ b/packages/ovm/test/helpers.ts
@@ -372,6 +372,8 @@ export const encodeRawArguments = (args: any[]): string => {
     .map((arg) => {
       if (Number.isInteger(arg)) {
         return bufferUtils.numberToBuffer(arg).toString('hex')
+      } else if (Buffer.isBuffer(arg)) {
+        return arg.toString('hex')
       } else if (arg && arg.startsWith('0x')) {
         return remove0x(arg)
       } else {


### PR DESCRIPTION
## Description
`ExecutionManager#executeTransactionRaw` just called `executeTransaction` so it was no longer needed. Remove `ExecutionManager#executeTransactionRaw` and use `ExecutionManager#executeTransaction` instead.

## Metadata
### Fixes
- Fixes # [YAS-256](https://optimists.atlassian.net/browse/YAS-256)

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
