### PR TITLE
Fixing issue in rollup full node if missing l2RpcServerPersistentDbPath env var

### DIFF
--- a/packages/rollup-full-node/src/exec/fullnode.ts
+++ b/packages/rollup-full-node/src/exec/fullnode.ts
@@ -117,7 +117,7 @@ export const runFullnode = async (
  * Initializes filesystem DB paths. This will also purge all data if the `CLEAR_DATA_KEY` has changed.
  */
 const initializeDBPaths = (isTestMode: boolean) => {
-  if (isTestMode) {
+  if (isTestMode || !Environment.l2RpcServerPersistentDbPath()) {
     return
   }
 


### PR DESCRIPTION
# Description
Fixing issue in rollup full node if missing l2RpcServerPersistentDbPath env var.

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
