### PR TITLE
Add dummy from address for calls

### DIFF
--- a/packages/rollup-full-node/src/app/web3-rpc-handler.ts
+++ b/packages/rollup-full-node/src/app/web3-rpc-handler.ts
@@ -196,6 +196,11 @@ export class DefaultWeb3Handler
         txObject
       )}], defaultBlock: [${defaultBlock}]`
     )
+    // TODO allow executing a call without a from address
+    // Currently using a dummy default from_address
+    if(!txObject['from']) {
+      txObject['from'] = '0x' + '88'.repeat(20)
+    }
     // First generate the internalTx calldata
     const internalCalldata = this.getTransactionCalldata(
       this.getTimestamp(),

--- a/packages/rollup-full-node/src/app/web3-rpc-handler.ts
+++ b/packages/rollup-full-node/src/app/web3-rpc-handler.ts
@@ -198,7 +198,7 @@ export class DefaultWeb3Handler
     )
     // TODO allow executing a call without a from address
     // Currently using a dummy default from_address
-    if(!txObject['from']) {
+    if (!txObject['from']) {
       txObject['from'] = '0x' + '88'.repeat(20)
     }
     // First generate the internalTx calldata


### PR DESCRIPTION
## Description
Fixes bugs with metamask, ethers. You should be able to do a call() without setting a from address, but currently we require a from address. This is a temporary fix.

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [X] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
