### PR TITLE
Add eth_getTransactionByHash endpoint

### DIFF
--- a/packages/ovm/src/app/utils.ts
+++ b/packages/ovm/src/app/utils.ts
@@ -165,10 +165,12 @@ export const getOvmTransactionMetadata = (
  * Converts an EVM receipt to an OVM receipt.
  *
  * @param internalTxReceipt The EVM tx receipt to convert to an OVM tx receipt
+ * @param ovmTxHash The OVM tx hash to replace the internal tx hash with.
  * @returns The converted receipt
  */
 export const internalTxReceiptToOvmTxReceipt = async (
-  internalTxReceipt: TransactionReceipt
+  internalTxReceipt: TransactionReceipt,
+  ovmTxHash?: string
 ): Promise<OvmTransactionReceipt> => {
   const ovmTransactionMetadata = getOvmTransactionMetadata(internalTxReceipt)
   // Construct a new receipt
@@ -186,6 +188,10 @@ export const internalTxReceiptToOvmTxReceipt = async (
     ovmTransactionMetadata.ovmCreatedContractAddress
 
   ovmTxReceipt.status = ovmTransactionMetadata.ovmTxSucceeded ? 1 : 0
+
+  if (!!ovmTxReceipt.transactionHash && !!ovmTxHash) {
+    ovmTxReceipt.transactionHash = ovmTxHash
+  }
 
   if (ovmTransactionMetadata.revertMessage !== undefined) {
     ovmTxReceipt.revertMessage = ovmTransactionMetadata.revertMessage

--- a/packages/ovm/src/contracts/L2ExecutionManager.sol
+++ b/packages/ovm/src/contracts/L2ExecutionManager.sol
@@ -11,6 +11,7 @@ import {ExecutionManager} from "./ExecutionManager.sol";
  */
 contract L2ExecutionManager is ExecutionManager {
     mapping(bytes32 => bytes32) ovmHashToEvmHash;
+    mapping(bytes32 => bytes) ovmHashToOvmTx;
 
     constructor(
         uint256 _opcodeWhitelistMask,
@@ -20,21 +21,32 @@ contract L2ExecutionManager is ExecutionManager {
     ) ExecutionManager(_opcodeWhitelistMask, _owner, _gasLimit, _overridePurityChecker) public {}
 
     /**
-    @notice Associates the provided OVM transaction hash with the EVM transaction hash so that we can properly
-            look up transaction receipts based on the OVM transaction hash.
+    @notice Stores the provided OVM transaction, mapping its hash to its value and its hash to the EVM tx
+            with which it's associated.
     @param ovmTransactionHash The OVM transaction hash, used publicly as the reference to the transaction.
     @param internalTransactionHash The internal transaction hash of the transaction actually executed.
+    @param signedOvmTx The signed OVM tx that we received
     */
-    function mapOvmTransactionHashToInternalTransactionHash(bytes32 ovmTransactionHash, bytes32 internalTransactionHash) public {
+    function storeOvmTransaction(bytes32 ovmTransactionHash, bytes32 internalTransactionHash, bytes memory signedOvmTx) public {
         ovmHashToEvmHash[ovmTransactionHash] = internalTransactionHash;
+        ovmHashToOvmTx[ovmTransactionHash] = signedOvmTx;
     }
 
-  /**
-   @notice Gets the EVM transaction hash associated with the provided OVM transaction hash.
-   @param ovmTransactionHash The OVM transaction hash.
-   @return The associated EVM transaction hash.
-   */
+    /**
+    @notice Gets the EVM transaction hash associated with the provided OVM transaction hash.
+    @param ovmTransactionHash The OVM transaction hash.
+    @return The associated EVM transaction hash.
+    */
     function getInternalTransactionHash(bytes32 ovmTransactionHash) public view returns (bytes32) {
         return ovmHashToEvmHash[ovmTransactionHash];
+    }
+
+    /**
+    @notice Gets the OVM transaction associated with the provided OVM transaction hash.
+    @param ovmTransactionHash The OVM transaction hash.
+    @return The associated signed OVM transaction.
+    */
+    function getOvmTransaction(bytes32 ovmTransactionHash) public view returns (bytes memory) {
+        return ovmHashToOvmTx[ovmTransactionHash];
     }
 }

--- a/packages/ovm/src/contracts/L2ExecutionManager.sol
+++ b/packages/ovm/src/contracts/L2ExecutionManager.sol
@@ -21,7 +21,7 @@ contract L2ExecutionManager is ExecutionManager {
     ) ExecutionManager(_opcodeWhitelistMask, _owner, _gasLimit, _overridePurityChecker) public {}
 
     /**
-    @notice Stores the provided OVM transaction, mapping its hash to its value and its hash to the EVM tx
+    @notice Stores the provided OVM transaction, mapping its hash to its value and its hash to the EVM tx hash
             with which it's associated.
     @param ovmTransactionHash The OVM transaction hash, used publicly as the reference to the transaction.
     @param internalTransactionHash The internal transaction hash of the transaction actually executed.

--- a/packages/ovm/test/contracts/l2-execution-manager.spec.ts
+++ b/packages/ovm/test/contracts/l2-execution-manager.spec.ts
@@ -11,6 +11,7 @@ import * as L2ExecutionManager from '../../build/contracts/L2ExecutionManager.js
 /* Internal Imports */
 import { DEFAULT_OPCODE_WHITELIST_MASK, GAS_LIMIT } from '../../src/app'
 import { DEFAULT_ETHNODE_GAS_LIMIT } from '../helpers'
+import { keccak256 } from 'ethers/utils'
 
 const log = getLogger('l2-execution-manager-calls', true)
 
@@ -41,12 +42,14 @@ describe('L2 Execution Manager', () => {
     )
   })
 
-  describe('Store external-to-internal tx hash map', async () => {
+  describe('Store OVM transactions', async () => {
+    const fakeSignedTx = add0x(
+      Buffer.from('derp')
+        .toString('hex')
+        .repeat(20)
+    )
     it('properly maps OVM tx hash to internal tx hash', async () => {
-      await l2ExecutionManager.mapOvmTransactionHashToInternalTransactionHash(
-        key,
-        value
-      )
+      await l2ExecutionManager.storeOvmTransaction(key, value, fakeSignedTx)
     })
 
     it('properly reads non-existent mapping', async () => {
@@ -54,13 +57,16 @@ describe('L2 Execution Manager', () => {
       result.should.equal(zero32, 'Incorrect unpopulated result!')
     })
 
-    it('properly reads existing mapping', async () => {
-      await l2ExecutionManager.mapOvmTransactionHashToInternalTransactionHash(
-        key,
-        value
-      )
+    it('properly reads existing OVM tx hash -> internal tx hash mapping', async () => {
+      await l2ExecutionManager.storeOvmTransaction(key, value, fakeSignedTx)
       const result = await l2ExecutionManager.getInternalTransactionHash(key)
-      result.should.equal(value, 'Incorrect populated result!')
+      result.should.equal(value, 'Incorrect hash mapped!')
+    })
+
+    it('properly reads existing OVM tx hash -> OVM tx mapping', async () => {
+      await l2ExecutionManager.storeOvmTransaction(key, value, fakeSignedTx)
+      const result = await l2ExecutionManager.getOvmTransaction(key)
+      result.should.equal(fakeSignedTx, 'Incorrect tx mapped!')
     })
   })
 })

--- a/packages/rollup-full-node/src/app/web3-rpc-handler.ts
+++ b/packages/rollup-full-node/src/app/web3-rpc-handler.ts
@@ -432,7 +432,7 @@ export class DefaultWeb3Handler
     // First convert our ovmTxHash into an internalTxHash
     const signedOvmTx: string = await this.getOvmTransactionByHash(ovmTxHash)
 
-    if (!signedOvmTx) {
+    if (!remove0x(signedOvmTx)) {
       log.debug(`There is no OVM tx associated with OVM tx hash [${ovmTxHash}]`)
       return null
     }

--- a/packages/rollup-full-node/src/types/web3-rpc-handler.ts
+++ b/packages/rollup-full-node/src/types/web3-rpc-handler.ts
@@ -18,6 +18,7 @@ export interface Web3Handler {
   getCode(address: Address, defaultBlock: string): Promise<string>
   getExecutionManagerAddress()
   getLogs(filter: any): Promise<any[]>
+  getTransactionByHash(transactionHash: string): Promise<any>
   getTransactionCount(address: Address, defaultBlock: string): Promise<string>
   getTransactionReceipt(txHash: string): Promise<string>
   networkVersion(): Promise<string>
@@ -37,6 +38,7 @@ export enum Web3RpcMethods {
   getCode = 'eth_getCode',
   getExecutionManagerAddress = 'ovm_getExecutionManagerAddress',
   getLogs = 'eth_getLogs',
+  getTransactionByHash = 'eth_getTransactionByHash',
   getTransactionCount = 'eth_getTransactionCount',
   getTransactionReceipt = 'eth_getTransactionReceipt',
   networkVersion = 'net_version',


### PR DESCRIPTION
## Description
Also makes sure that returned receipts have the correct OVM tx hash instead of EVM tx hash.

## Metadata
### Fixes
- Fixes # [YAS-312](https://optimists.atlassian.net/browse/YAS-312)

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
