### PR TITLE
Add test mode script for full node

### DIFF
--- a/packages/rollup-full-node/exec/fullnode-test.js
+++ b/packages/rollup-full-node/exec/fullnode-test.js
@@ -1,0 +1,5 @@
+const fullnode = require("../build/src/exec/fullnode")
+
+fullnode.runFullnode(true)
+
+

--- a/packages/rollup-full-node/package.json
+++ b/packages/rollup-full-node/package.json
@@ -17,7 +17,9 @@
     "build-contracts": "yarn clean-contracts && waffle waffle-config-untranspiled.json && waffle waffle-config-transpiled.json",
     "server:aggregator": "env DEBUG=\"info:*,error:*\" node ./exec/aggregator.js",
     "server:fullnode": "env DEBUG=\"info:*,error:*\" node ./exec/fullnode.js",
-    "server:fullnode:debug": "env DEBUG=\"info:*,error:*,debug:*\" node ./exec/fullnode.js"
+    "server:fullnode:debug": "env DEBUG=\"info:*,error:*,debug:*\" node ./exec/fullnode.js",
+    "server:fullnode-test": "env DEBUG=\"info:*,error:*\" node ./exec/fullnode-test.js",
+    "server:fullnode-test:debug": "env DEBUG=\"info:*,error:*,debug:*\" node ./exec/fullnode-test.js"
   },
   "keywords": [
     "plasma",


### PR DESCRIPTION
## Description
Allows the deployment of a local full node in test mode (using ganache). This is necessary for many projects which require you to spin up a local ganache node to start testing (e.g. tornado cash, moloch dao).

### Fixes
- Fixes # YAS304

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [X] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
