### PR TITLE
Fix parseInternalBlock transaction filtering bug

### DIFF
--- a/packages/rollup-full-node/src/app/web3-rpc-handler.ts
+++ b/packages/rollup-full-node/src/app/web3-rpc-handler.ts
@@ -369,7 +369,7 @@ export class DefaultWeb3Handler
         )
       )
         // Filter transactions that aren't included in the execution manager
-        .filter((transaction) => transaction['hash'] === ZERO_ADDRESS)
+        .filter((transaction) => transaction['hash'] !== add0x("00".repeat(32)))
     }
 
     log.debug(

--- a/packages/rollup-full-node/src/app/web3-rpc-handler.ts
+++ b/packages/rollup-full-node/src/app/web3-rpc-handler.ts
@@ -369,7 +369,7 @@ export class DefaultWeb3Handler
         )
       )
         // Filter transactions that aren't included in the execution manager
-        .filter((transaction) => transaction['hash'] !== add0x("00".repeat(32)))
+        .filter((transaction) => transaction['hash'] !== add0x('00'.repeat(32)))
     }
 
     log.debug(

--- a/packages/rollup-full-node/test/app/web-rpc-handler.spec.ts
+++ b/packages/rollup-full-node/test/app/web-rpc-handler.spec.ts
@@ -18,7 +18,6 @@ import assert from 'assert'
 /* Internal Imports */
 import { FullnodeRpcServer, DefaultWeb3Handler } from '../../src/app'
 import * as SimpleStorage from '../contracts/build/untranspiled/SimpleStorage.json'
-import * as EventEmitter from '../contracts/build/untranspiled/EventEmitter.json'
 import { Web3RpcMethods } from '../../src/types'
 
 const log = getLogger('web3-handler', true)
@@ -292,31 +291,6 @@ describe('Web3Handler', () => {
           httpProvider,
           executionManagerAddress
         )
-      })
-    })
-
-    describe.only('EventEmitter integration test', () => {
-      it('should set storage & retrieve the value', async () => {
-        const executionManagerAddress = await httpProvider.send(
-          'ovm_getExecutionManagerAddress',
-          []
-        )
-
-        const wallet = getWallet(httpProvider)
-        const factory = new ContractFactory(
-          EventEmitter.abi,
-          EventEmitter.bytecode,
-          wallet
-        )
-
-        const eventEmitter = await factory.deploy()
-        const tx = await eventEmitter.emitEvent(
-          executionManagerAddress,
-        )
-        
-        await httpProvider.getTransactionReceipt(tx.hash)
-        const block = await httpProvider.getBlock('latest', true)
-        block.transactions.length.should.be.gt(0)
       })
     })
 

--- a/packages/rollup-full-node/test/app/web-rpc-handler.spec.ts
+++ b/packages/rollup-full-node/test/app/web-rpc-handler.spec.ts
@@ -18,6 +18,7 @@ import assert from 'assert'
 /* Internal Imports */
 import { FullnodeRpcServer, DefaultWeb3Handler } from '../../src/app'
 import * as SimpleStorage from '../contracts/build/untranspiled/SimpleStorage.json'
+import * as EventEmitter from '../contracts/build/untranspiled/EventEmitter.json'
 import { Web3RpcMethods } from '../../src/types'
 
 const log = getLogger('web3-handler', true)
@@ -291,6 +292,31 @@ describe('Web3Handler', () => {
           httpProvider,
           executionManagerAddress
         )
+      })
+    })
+
+    describe.only('EventEmitter integration test', () => {
+      it('should set storage & retrieve the value', async () => {
+        const executionManagerAddress = await httpProvider.send(
+          'ovm_getExecutionManagerAddress',
+          []
+        )
+
+        const wallet = getWallet(httpProvider)
+        const factory = new ContractFactory(
+          EventEmitter.abi,
+          EventEmitter.bytecode,
+          wallet
+        )
+
+        const eventEmitter = await factory.deploy()
+        const tx = await eventEmitter.emitEvent(
+          executionManagerAddress,
+        )
+        
+        await httpProvider.getTransactionReceipt(tx.hash)
+        const block = await httpProvider.getBlock('latest', true)
+        block.transactions.length.should.be.gt(0)
       })
     })
 


### PR DESCRIPTION
## Description
Previously we were filtering transactions in parseInternalBlock that weren't equal to the ZERO_ADDRESS. The zero hash is actually 32 bytes instead of the 20 byte ZERO_ADDRESS. The filter condition was also reversed  which it why it was passing tests.

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
