### PR TITLE
Adding tx detail cache to sendRawTransaction

### DIFF
--- a/packages/rollup-full-node/src/app/web3-rpc-handler.ts
+++ b/packages/rollup-full-node/src/app/web3-rpc-handler.ts
@@ -542,7 +542,8 @@ export class DefaultWeb3Handler
   }
 
   public async sendRawTransaction(rawOvmTx: string): Promise<string> {
-    const timestamp = this.getTimestamp()
+    const debugTime = new Date().getTime()
+    const blockTimestamp = this.getTimestamp()
     log.debug('Sending raw transaction with params:', rawOvmTx)
 
     // Decode the OVM transaction -- this will be used to construct our internal transaction
@@ -611,10 +612,13 @@ export class DefaultWeb3Handler
         log.debug(`Transaction mined successfully: ${rawOvmTx}`)
         await this.processTransactionEvents(receipt)
       }
-      this.blockTimestamps[receipt.blockNumber] = timestamp
+      this.blockTimestamps[receipt.blockNumber] = blockTimestamp
     })
 
-    log.debug(`Completed send raw tx [${rawOvmTx}]. Response: [${ovmTxHash}]`)
+    log.debug(
+      `Completed send raw tx [${rawOvmTx}]. Response: [${ovmTxHash}]. Total time: ${new Date().getTime() -
+        debugTime}ms`
+    )
     // Return the *OVM* tx hash. We can do this because we store a mapping to the ovmTxHashs in the EM contract.
     return ovmTxHash
   }


### PR DESCRIPTION
## Description
This allows `sendRawTransaction(...)` to not wait for the OVM -> EVM tx mapping transaction to proceed processing, reducing latency.

## Metadata
### Fixes
- Fixes # [YAS-326](https://optimists.atlassian.net/browse/YAS-326)

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
