### PR TITLE
YAS 292: fix test provider's `eth_sendTransaction` behavior

### DIFF
--- a/packages/core-utils/src/app/misc.ts
+++ b/packages/core-utils/src/app/misc.ts
@@ -291,10 +291,10 @@ export const getCurrentTime = (): number => {
   return Math.round(Date.now() / 1000)
 }
 /**
- * Encodes a transaction in RLP format
+ * Encodes a transaction in RLP format, using an invalid but present signature
  * @param {object} Transaction object
  */
-export const rlpEncodeTransaction = (transaction: object): string => {
+export const rlpEncodeTransactionWithInvalidSig = (transaction: object): string => {
   return RLP.encode([
     hexlify(transaction['nonce']),
     hexlify(transaction['gasPrice']),
@@ -302,5 +302,8 @@ export const rlpEncodeTransaction = (transaction: object): string => {
     hexlify(transaction['to']),
     hexlify(transaction['value']),
     transaction['data'],
+    '0x01', // v
+    '0x' + '01'.repeat(32), // r
+    '0x' + '01'.repeat(32), // s
   ])
 }

--- a/packages/core-utils/src/app/misc.ts
+++ b/packages/core-utils/src/app/misc.ts
@@ -297,7 +297,6 @@ export const getCurrentTime = (): number => {
 export const rlpEncodeTransactionWithRandomSig = (
   transaction: object
 ): string => {
-  console.log(`input tx is:\n${JSON.stringify(transaction)}`)
   return RLP.encode([
     hexlify(transaction['nonce']),
     hexlify(transaction['gasPrice']),

--- a/packages/core-utils/src/app/misc.ts
+++ b/packages/core-utils/src/app/misc.ts
@@ -297,15 +297,16 @@ export const getCurrentTime = (): number => {
 export const rlpEncodeTransactionWithRandomSig = (
   transaction: object
 ): string => {
+  console.log(`input tx is:\n${JSON.stringify(transaction)}`)
   return RLP.encode([
     hexlify(transaction['nonce']),
     hexlify(transaction['gasPrice']),
     hexlify(transaction['gasLimit']),
     hexlify(transaction['to']),
     hexlify(transaction['value']),
-    transaction['data'],
-    '0x01', // v
-    '0x' + '01'.repeat(32), // r
-    '0x' + '01'.repeat(32), // s
+    hexlify(transaction['data']),
+    '0x11', // v
+    '0x' + '11'.repeat(32), // r
+    '0x' + '11'.repeat(32), // s
   ])
 }

--- a/packages/core-utils/src/app/misc.ts
+++ b/packages/core-utils/src/app/misc.ts
@@ -294,7 +294,9 @@ export const getCurrentTime = (): number => {
  * Encodes a transaction in RLP format, using an invalid but present signature
  * @param {object} Transaction object
  */
-export const rlpEncodeTransactionWithInvalidSig = (transaction: object): string => {
+export const rlpEncodeTransactionWithInvalidSig = (
+  transaction: object
+): string => {
   return RLP.encode([
     hexlify(transaction['nonce']),
     hexlify(transaction['gasPrice']),

--- a/packages/core-utils/src/app/misc.ts
+++ b/packages/core-utils/src/app/misc.ts
@@ -291,10 +291,10 @@ export const getCurrentTime = (): number => {
   return Math.round(Date.now() / 1000)
 }
 /**
- * Encodes a transaction in RLP format, using an invalid but present signature
+ * Encodes a transaction in RLP format, using a random signature
  * @param {object} Transaction object
  */
-export const rlpEncodeTransactionWithInvalidSig = (
+export const rlpEncodeTransactionWithRandomSig = (
   transaction: object
 ): string => {
   return RLP.encode([

--- a/packages/rollup-full-node/src/app/test-web3-rpc-handler.ts
+++ b/packages/rollup-full-node/src/app/test-web3-rpc-handler.ts
@@ -4,13 +4,15 @@ import {
   getLogger,
   numberToHexString,
   castToNumber,
-  rlpEncodeTransaction,
+  rlpEncodeTransactionWithInvalidSig,
+  ZERO_ADDRESS,
 } from '@eth-optimism/core-utils'
+import { GAS_LIMIT } from '@eth-optimism/ovm'
 import { JsonRpcProvider, Web3Provider } from 'ethers/providers'
 import { utils } from 'ethers'
 
 /* Internal Imports */
-import { initializeL2Node } from './index'
+import { initializeL2Node, latestBlock } from './index'
 import { DefaultWeb3Handler } from './web3-rpc-handler'
 import {
   L2NodeContext,
@@ -132,8 +134,21 @@ export class TestWeb3Handler extends DefaultWeb3Handler {
    *
    * @param The transaction to send
    */
-  public async sendTransaction(ovmTx: object): Promise<string> {
-    return this.sendRawTransaction(rlpEncodeTransaction(ovmTx))
+  public async sendTransaction(ovmTx: any): Promise<string> {
+    if (!ovmTx.nonce) { 
+      ovmTx.nonce = await this.getTransactionCount(ovmTx.from, latestBlock)
+    }
+    if (!ovmTx.to) {
+      ovmTx.to = ZERO_ADDRESS
+    }
+    if (!ovmTx.gasPrice) {
+      ovmTx.gasPrice = 0
+    }
+    if (!ovmTx.gasLimit) {
+      ovmTx.gasLimit = GAS_LIMIT
+    }
+    ovmTx.value = 0
+    return this.sendRawTransaction(rlpEncodeTransactionWithInvalidSig(ovmTx), ovmTx.from)
   }
 
   /**

--- a/packages/rollup-full-node/src/app/test-web3-rpc-handler.ts
+++ b/packages/rollup-full-node/src/app/test-web3-rpc-handler.ts
@@ -4,7 +4,7 @@ import {
   getLogger,
   numberToHexString,
   castToNumber,
-  rlpEncodeTransactionWithInvalidSig,
+  rlpEncodeTransactionWithRandomSig,
   ZERO_ADDRESS,
 } from '@eth-optimism/core-utils'
 import { GAS_LIMIT } from '@eth-optimism/ovm'
@@ -149,7 +149,7 @@ export class TestWeb3Handler extends DefaultWeb3Handler {
     }
     ovmTx.value = 0
     return this.sendRawTransaction(
-      rlpEncodeTransactionWithInvalidSig(ovmTx),
+      rlpEncodeTransactionWithRandomSig(ovmTx),
       ovmTx.from
     )
   }

--- a/packages/rollup-full-node/src/app/test-web3-rpc-handler.ts
+++ b/packages/rollup-full-node/src/app/test-web3-rpc-handler.ts
@@ -135,7 +135,7 @@ export class TestWeb3Handler extends DefaultWeb3Handler {
    * @param The transaction to send
    */
   public async sendTransaction(ovmTx: any): Promise<string> {
-    if (!ovmTx.nonce) { 
+    if (!ovmTx.nonce) {
       ovmTx.nonce = await this.getTransactionCount(ovmTx.from, latestBlock)
     }
     if (!ovmTx.to) {
@@ -148,7 +148,10 @@ export class TestWeb3Handler extends DefaultWeb3Handler {
       ovmTx.gasLimit = GAS_LIMIT
     }
     ovmTx.value = 0
-    return this.sendRawTransaction(rlpEncodeTransactionWithInvalidSig(ovmTx), ovmTx.from)
+    return this.sendRawTransaction(
+      rlpEncodeTransactionWithInvalidSig(ovmTx),
+      ovmTx.from
+    )
   }
 
   /**

--- a/packages/rollup-full-node/src/app/test-web3-rpc-handler.ts
+++ b/packages/rollup-full-node/src/app/test-web3-rpc-handler.ts
@@ -139,7 +139,7 @@ export class TestWeb3Handler extends DefaultWeb3Handler {
       ovmTx.nonce = await this.getTransactionCount(ovmTx.from, latestBlock)
     }
     if (!ovmTx.to) {
-      ovmTx.to = ZERO_ADDRESS
+      ovmTx.to = '0x'
     }
     if (!ovmTx.gasPrice) {
       ovmTx.gasPrice = 0

--- a/packages/rollup-full-node/src/app/web3-rpc-handler.ts
+++ b/packages/rollup-full-node/src/app/web3-rpc-handler.ts
@@ -541,7 +541,10 @@ export class DefaultWeb3Handler
     return response
   }
 
-  public async sendRawTransaction(rawOvmTx: string, fromAddressOverride?: string): Promise<string> {
+  public async sendRawTransaction(
+    rawOvmTx: string,
+    fromAddressOverride?: string
+  ): Promise<string> {
     const debugTime = new Date().getTime()
     const blockTimestamp = this.getTimestamp()
     log.debug('Sending raw transaction with params:', rawOvmTx)
@@ -549,7 +552,9 @@ export class DefaultWeb3Handler
     // Decode the OVM transaction -- this will be used to construct our internal transaction
     const ovmTx = utils.parseTransaction(rawOvmTx)
     // override the from address if in testing mode
-    if (!!fromAddressOverride) { ovmTx.from = fromAddressOverride }
+    if (!!fromAddressOverride) {
+      ovmTx.from = fromAddressOverride
+    }
     log.debug(
       `OVM Transaction being parsed ${rawOvmTx}, with from address override of [${fromAddressOverride}], parsed: ${JSON.stringify(
         ovmTx

--- a/packages/rollup-full-node/src/app/web3-rpc-handler.ts
+++ b/packages/rollup-full-node/src/app/web3-rpc-handler.ts
@@ -43,7 +43,7 @@ import { NoOpL2ToL1MessageSubmitter } from './message-submitter'
 
 const log = getLogger('web3-handler')
 
-const latestBlock: string = 'latest'
+export const latestBlock: string = 'latest'
 
 export class DefaultWeb3Handler
   implements Web3Handler, FullnodeHandler, L1ToL2TransactionListener {
@@ -541,15 +541,17 @@ export class DefaultWeb3Handler
     return response
   }
 
-  public async sendRawTransaction(rawOvmTx: string): Promise<string> {
+  public async sendRawTransaction(rawOvmTx: string, fromAddressOverride?: string): Promise<string> {
     const debugTime = new Date().getTime()
     const blockTimestamp = this.getTimestamp()
     log.debug('Sending raw transaction with params:', rawOvmTx)
 
     // Decode the OVM transaction -- this will be used to construct our internal transaction
     const ovmTx = utils.parseTransaction(rawOvmTx)
+    // override the from address if in testing mode
+    if (!!fromAddressOverride) { ovmTx.from = fromAddressOverride }
     log.debug(
-      `OVM Transaction being parsed ${rawOvmTx}, parsed: ${JSON.stringify(
+      `OVM Transaction being parsed ${rawOvmTx}, with from address override of [${fromAddressOverride}], parsed: ${JSON.stringify(
         ovmTx
       )}`
     )

--- a/packages/rollup-full-node/src/app/web3-rpc-handler.ts
+++ b/packages/rollup-full-node/src/app/web3-rpc-handler.ts
@@ -840,7 +840,6 @@ export class DefaultWeb3Handler
       )
       throw new Error('Non-EOA transaction detected')
     }
-    // TODO: Make sure we lock this function with this nonce so we don't send to txs with the same nonce
     // Generate the calldata which we'll use to call our internal execution manager
     // First pull out the `to` field (we just need to check if it's null & if so set ovmTo to the zero address as that's how we deploy contracts)
     const ovmTo = ovmTx.to === null ? ZERO_ADDRESS : ovmTx.to

--- a/packages/rollup-full-node/test/app/test-web-rpc-handler.spec.ts
+++ b/packages/rollup-full-node/test/app/test-web-rpc-handler.spec.ts
@@ -33,7 +33,7 @@ const host = '0.0.0.0'
 const port = 9998
 const baseUrl = `http://${host}:${port}`
 
-describe.only('TestHandler', () => {
+describe('TestHandler', () => {
   let testHandler: TestWeb3Handler
 
   beforeEach(async () => {
@@ -211,7 +211,7 @@ describe.only('TestHandler', () => {
     })
   })
 
-  describe.only('the sendTransaction endpoint', () => {
+  describe('the sendTransaction endpoint', () => {
     let testRpcServer
     let httpProvider
     let wallet
@@ -249,9 +249,7 @@ describe.only('TestHandler', () => {
         data: transactionData,
       }
 
-      await httpProvider.send('eth_sendTransaction', [
-        transaction,
-      ])
+      await httpProvider.send('eth_sendTransaction', [transaction])
       const res = await simpleStorage.getStorage(
         executionManagerAddress,
         storageKey
@@ -269,15 +267,13 @@ describe.only('TestHandler', () => {
       const setData = await callerStorer.interface.functions[
         'storeMsgSender'
       ].encode([])
-      const randomFromAddress =  add0x('02'.repeat(20))
+      const randomFromAddress = add0x('02'.repeat(20))
       const transaction = {
         from: randomFromAddress,
         to: callerStorer.address,
-        data: setData
+        data: setData,
       }
-      await httpProvider.send('eth_sendTransaction', [
-        transaction,
-      ])
+      await httpProvider.send('eth_sendTransaction', [transaction])
       const res = await callerStorer.getLastMsgSender()
       res.should.equal(randomFromAddress)
     })

--- a/packages/rollup-full-node/test/app/test-web-rpc-handler.spec.ts
+++ b/packages/rollup-full-node/test/app/test-web-rpc-handler.spec.ts
@@ -283,14 +283,14 @@ describe('TestHandler', () => {
       const creationInitcode = '0x' + SimpleStorage.bytecode
       const transaction = {
         from: randomFromAddress,
-        data: creationInitcode
+        data: creationInitcode,
       }
-      const txHash = await httpProvider.send('eth_sendTransaction', [transaction])
-      const txReceipt = await wallet.provider.getTransactionReceipt(
-        txHash
-      )
+      const txHash = await httpProvider.send('eth_sendTransaction', [
+        transaction,
+      ])
+      const txReceipt = await wallet.provider.getTransactionReceipt(txHash)
       // make sure the receipt's contractAddress is set
-      txReceipt.contractAddress.slice(0,2).should.equal('0x')
+      txReceipt.contractAddress.slice(0, 2).should.equal('0x')
     })
   })
 })

--- a/packages/rollup-full-node/test/app/test-web-rpc-handler.spec.ts
+++ b/packages/rollup-full-node/test/app/test-web-rpc-handler.spec.ts
@@ -277,5 +277,20 @@ describe('TestHandler', () => {
       const res = await callerStorer.getLastMsgSender()
       res.should.equal(randomFromAddress)
     })
+    it('should allow for contract deployment through the endpoint', async () => {
+      log.debug(`here is a working log`)
+      const randomFromAddress = add0x('02'.repeat(20))
+      const creationInitcode = '0x' + SimpleStorage.bytecode
+      const transaction = {
+        from: randomFromAddress,
+        data: creationInitcode
+      }
+      const txHash = await httpProvider.send('eth_sendTransaction', [transaction])
+      const txReceipt = await wallet.provider.getTransactionReceipt(
+        txHash
+      )
+      // make sure the receipt's contractAddress is set
+      txReceipt.contractAddress.slice(0,2).should.equal('0x')
+    })
   })
 })

--- a/packages/rollup-full-node/test/contracts/transpiled/CallerStorer.sol
+++ b/packages/rollup-full-node/test/contracts/transpiled/CallerStorer.sol
@@ -1,0 +1,11 @@
+pragma solidity ^0.5.0;
+
+contract CallerStorer {
+    address public lastMsgSender;
+    function storeMsgSender() public {
+        lastMsgSender = msg.sender;
+    }
+    function getLastMsgSender() public view returns(address) {
+        return lastMsgSender;
+    }
+}


### PR DESCRIPTION
## Description
This PR makes the test web3 handler be much more permissive with accounts, making the `eth_sendTransaction` parameters compliant with the specification.  Note that behavior does differ a little bit from other RPC provision--instead of only allowing this on accounts which are unlocked, we bypass/override signature checking and allow any `.from` to be valid in the test case.
## Questions
Is there a cleaner way to do this, short of incorporating a full-blown account management system into the provider?  Chatted with @karlfloersch for a bit about it; we concluded not.

## Metadata
### Fixes
- Fixes YAS 292

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
