### PR TITLE
Fix eth_getLogs bugs

### DIFF
--- a/packages/ovm/src/app/utils.ts
+++ b/packages/ovm/src/app/utils.ts
@@ -69,7 +69,7 @@ export interface OvmTransactionMetadata {
  * @return the converted logs
  */
 export const convertInternalLogsToOvmLogs = (logs: Log[]): Log[] => {
-  let activeContract = ZERO_ADDRESS
+  let activeContract =  logs[0] ? logs[0].address : ZERO_ADDRESS
   const ovmLogs = []
   logs.forEach((log) => {
     const executionManagerLog = executionManagerInterface.parseLog(log)

--- a/packages/ovm/src/app/utils.ts
+++ b/packages/ovm/src/app/utils.ts
@@ -69,7 +69,7 @@ export interface OvmTransactionMetadata {
  * @return the converted logs
  */
 export const convertInternalLogsToOvmLogs = (logs: Log[]): Log[] => {
-  let activeContract =  logs[0] ? logs[0].address : ZERO_ADDRESS
+  let activeContract = logs[0] ? logs[0].address : ZERO_ADDRESS
   const ovmLogs = []
   logs.forEach((log) => {
     const executionManagerLog = executionManagerInterface.parseLog(log)

--- a/packages/ovm/src/app/utils.ts
+++ b/packages/ovm/src/app/utils.ts
@@ -5,6 +5,7 @@ import {
   getLogger,
   hexStrToBuf,
   bufToHexString,
+  numberToHexString,
   logError,
   remove0x,
   ZERO_ADDRESS,
@@ -189,8 +190,6 @@ export const internalTxReceiptToOvmTxReceipt = async (
   if (ovmTransactionMetadata.ovmTo) {
     ovmTxReceipt.to = ovmTransactionMetadata.ovmTo
   }
-  // TODO: Update this to use some default account abstraction library potentially.
-  ovmTxReceipt.from = ovmTransactionMetadata.ovmFrom
   // Also update the contractAddress in case we deployed a new contract
   ovmTxReceipt.contractAddress = !!ovmTransactionMetadata.ovmCreatedContractAddress
     ? ovmTransactionMetadata.ovmCreatedContractAddress
@@ -208,9 +207,11 @@ export const internalTxReceiptToOvmTxReceipt = async (
 
   logger.debug('Ovm parsed logs:', ovmTxReceipt.logs)
   const logsBloom = new BloomFilter()
-  ovmTxReceipt.logs.forEach((log) => {
+  ovmTxReceipt.logs.forEach((log, index) => {
     logsBloom.add(hexStrToBuf(log.address))
     log.topics.forEach((topic) => logsBloom.add(hexStrToBuf(topic)))
+    log.transactionHash = ovmTxReceipt.transactionHash
+    log.logIndex = numberToHexString(index) as any
   })
   ovmTxReceipt.logsBloom = bufToHexString(logsBloom.bitvector)
 

--- a/packages/rollup-full-node/src/app/web3-rpc-handler.ts
+++ b/packages/rollup-full-node/src/app/web3-rpc-handler.ts
@@ -586,21 +586,15 @@ export class DefaultWeb3Handler
       log.debug(
         `Internal tx previously failed for this OVM tx, creating receipt from the OVM tx itself.`
       )
-      const rawOvmTx = await this.getOvmTransactionByHash(ovmTxHash)
-      const ovmTx = utils.parseTransaction(rawOvmTx)
-      // for a failing tx, everything is identical between the internal and external receipts, except to and from
-      ovmTxReceipt = internalTxReceipt
-      ovmTxReceipt.from = ovmTx.from
-      ovmTxReceipt.to = ovmTx.to
     }
+    const ovmTx = await this.getTransactionByHash(ovmTxReceipt.transactionHash)
+    log.debug(`got OVM tx from hash: [${JSON.stringify(ovmTx)}]`)
+    ovmTxReceipt.to = ovmTx.to ? ovmTx.to : ovmTxReceipt.to
+    ovmTxReceipt.from = ovmTx.from
 
     if (ovmTxReceipt.revertMessage !== undefined && !includeRevertMessage) {
       delete ovmTxReceipt.revertMessage
     }
-    if (typeof ovmTxReceipt.status === 'number') {
-      ovmTxReceipt.status = numberToHexString(ovmTxReceipt.status)
-    }
-
     if (typeof ovmTxReceipt.status === 'number') {
       ovmTxReceipt.status = numberToHexString(ovmTxReceipt.status)
     }

--- a/packages/rollup-full-node/src/app/web3-rpc-handler.ts
+++ b/packages/rollup-full-node/src/app/web3-rpc-handler.ts
@@ -375,6 +375,9 @@ export class DefaultWeb3Handler
                   ? ovmTx[key].toNumber()
                   : ovmTx[key]
               }
+              if(typeof transaction[key] === 'number') {
+                transaction[key] = numberToHexString(transaction[key])
+              }
             })
 
             return transaction
@@ -557,17 +560,20 @@ export class DefaultWeb3Handler
     }
 
     // Now let's parse the internal transaction reciept
-    const ovmTxReceipt: OvmTransactionReceipt = await internalTxReceiptToOvmTxReceipt(
+    const ovmTxReceipt: any = await internalTxReceiptToOvmTxReceipt(
       internalTxReceipt,
       ovmTxHash
     )
     if (ovmTxReceipt.revertMessage !== undefined && !includeRevertMessage) {
       delete ovmTxReceipt.revertMessage
     }
+    if (typeof ovmTxReceipt.status === 'number') {
+      ovmTxReceipt.status = numberToHexString(ovmTxReceipt.status)
+    }
 
     log.debug(
       `Returning tx receipt for ovm tx hash [${ovmTxHash}]: [${JSON.stringify(
-        internalTxReceipt
+        ovmTxReceipt
       )}]`
     )
     return ovmTxReceipt

--- a/packages/rollup-full-node/src/app/web3-rpc-handler.ts
+++ b/packages/rollup-full-node/src/app/web3-rpc-handler.ts
@@ -455,9 +455,9 @@ export class DefaultWeb3Handler
     return this.context.executionManager.address
   }
 
-  public async getLogs(filter: any): Promise<any[]> {
-    log.debug(`Requesting logs with filter [${JSON.stringify(filter)}].`)
-
+  public async getLogs(ovmFilter: any): Promise<any[]> {
+    log.debug(`Requesting logs with filter [${JSON.stringify(ovmFilter)}].`)
+    const filter = JSON.parse(JSON.stringify(ovmFilter))
     if (filter['address']) {
       const codeContractAddress = await this.context.executionManager.getCodeContractAddress(
         filter.address
@@ -479,7 +479,12 @@ export class DefaultWeb3Handler
         const transaction = await this.getTransactionByHash(
           logItem['transactionHash']
         )
+        if (transaction['to'] === null) {
+          const receipt = await this.getTransactionReceipt(transaction.hash)
+          transaction['to'] = receipt.contractAddress
+        }
         logItem['address'] = transaction['to']
+
         return logItem
       })
     )

--- a/packages/rollup-full-node/src/app/web3-rpc-handler.ts
+++ b/packages/rollup-full-node/src/app/web3-rpc-handler.ts
@@ -375,7 +375,7 @@ export class DefaultWeb3Handler
                   ? ovmTx[key].toNumber()
                   : ovmTx[key]
               }
-              if(typeof transaction[key] === 'number') {
+              if (typeof transaction[key] === 'number') {
                 transaction[key] = numberToHexString(transaction[key])
               }
             })

--- a/packages/rollup-full-node/src/app/web3-rpc-handler.ts
+++ b/packages/rollup-full-node/src/app/web3-rpc-handler.ts
@@ -464,7 +464,9 @@ export class DefaultWeb3Handler
       )
       filter['address'] = codeContractAddress
     }
-    const res = await this.context.provider.send(Web3RpcMethods.getLogs, [filter])
+    const res = await this.context.provider.send(Web3RpcMethods.getLogs, [
+      filter,
+    ])
 
     let logs = JSON.parse(JSON.stringify(convertInternalLogsToOvmLogs(res)))
     log.debug(`Log result: [${logs}], filter: [${JSON.stringify(filter)}].`)

--- a/packages/rollup-full-node/src/app/web3-rpc-handler.ts
+++ b/packages/rollup-full-node/src/app/web3-rpc-handler.ts
@@ -464,7 +464,7 @@ export class DefaultWeb3Handler
       )
       filter['address'] = codeContractAddress
     }
-    let res = await this.context.provider.send(Web3RpcMethods.getLogs, [filter])
+    const res = await this.context.provider.send(Web3RpcMethods.getLogs, [filter])
 
     let logs = JSON.parse(JSON.stringify(convertInternalLogsToOvmLogs(res)))
     log.debug(`Log result: [${logs}], filter: [${JSON.stringify(filter)}].`)

--- a/packages/rollup-full-node/src/app/web3-rpc-handler.ts
+++ b/packages/rollup-full-node/src/app/web3-rpc-handler.ts
@@ -471,8 +471,12 @@ export class DefaultWeb3Handler
     logs = await Promise.all(
       logs.map(async (logItem, index) => {
         logItem['logIndex'] = numberToHexString(index)
-        logItem['transactionHash'] = await this.getOvmTxHash(logItem['transactionHash'])
-        const transaction = await this.getTransactionByHash(logItem['transactionHash'])
+        logItem['transactionHash'] = await this.getOvmTxHash(
+          logItem['transactionHash']
+        )
+        const transaction = await this.getTransactionByHash(
+          logItem['transactionHash']
+        )
         logItem['address'] = transaction['to']
         return logItem
       })

--- a/packages/rollup-full-node/src/types/web3-rpc-handler.ts
+++ b/packages/rollup-full-node/src/types/web3-rpc-handler.ts
@@ -17,7 +17,7 @@ export interface Web3Handler {
   getBlockByHash(blockHash: string, fullObjects: boolean): Promise<any>
   getCode(address: Address, defaultBlock: string): Promise<string>
   getExecutionManagerAddress()
-  getLogs(filter: any): Promise<any[]>
+  getLogs(ovmFilter: any): Promise<any[]>
   getTransactionByHash(transactionHash: string): Promise<any>
   getTransactionCount(address: Address, defaultBlock: string): Promise<string>
   getTransactionReceipt(txHash: string): Promise<string>

--- a/packages/rollup-full-node/test/app/web-rpc-handler.spec.ts
+++ b/packages/rollup-full-node/test/app/web-rpc-handler.spec.ts
@@ -340,7 +340,7 @@ describe('Web3Handler', () => {
       })
     })
 
-    describe('the getLogs endpoint', () => {
+    describe.only('the getLogs endpoint', () => {
       it('should return logs', async () => {
         const executionManagerAddress = await httpProvider.send(
           'ovm_getExecutionManagerAddress',
@@ -363,9 +363,12 @@ describe('Web3Handler', () => {
           await httpProvider.getLogs({
             address: eventEmitter.address,
           })
-        ).map((x) => factory.interface.parseLog(x))
-        logs.length.should.eq(1)
-        logs[0].name.should.eq('Event')
+        )
+        logs[0].address.should.eq(eventEmitter.address)
+        logs[0].logIndex.should.eq(0)
+        const parsedLogs = logs.map((x) => factory.interface.parseLog(x))
+        parsedLogs.length.should.eq(1)
+        parsedLogs[0].name.should.eq('Event')
       })
     })
 

--- a/packages/rollup-full-node/test/app/web-rpc-handler.spec.ts
+++ b/packages/rollup-full-node/test/app/web-rpc-handler.spec.ts
@@ -340,7 +340,7 @@ describe('Web3Handler', () => {
       })
     })
 
-    describe.only('the getLogs endpoint', () => {
+    describe('the getLogs endpoint', () => {
       it('should return logs', async () => {
         const executionManagerAddress = await httpProvider.send(
           'ovm_getExecutionManagerAddress',

--- a/packages/rollup-full-node/test/app/web-rpc-handler.spec.ts
+++ b/packages/rollup-full-node/test/app/web-rpc-handler.spec.ts
@@ -327,7 +327,7 @@ describe('Web3Handler', () => {
         hexStrToBuf(block.transactions[0]).length.should.eq(32)
       })
 
-      it('should return a block with the correct logsBloom', async () => {
+      it.only('should return a block with the correct logsBloom', async () => {
         const executionManagerAddress = await httpProvider.send(
           'ovm_getExecutionManagerAddress',
           []
@@ -344,7 +344,9 @@ describe('Web3Handler', () => {
           eventEmitter.deployTransaction.hash
         )
         const tx = await eventEmitter.emitEvent(executionManagerAddress)
-
+        await wallet.provider.getTransactionReceipt(
+                  tx.hash
+                )
         const block = await httpProvider.send('eth_getBlockByNumber', [
           'latest',
           true,

--- a/packages/rollup-full-node/test/app/web-rpc-handler.spec.ts
+++ b/packages/rollup-full-node/test/app/web-rpc-handler.spec.ts
@@ -359,11 +359,9 @@ describe('Web3Handler', () => {
         )
         const tx = await eventEmitter.emitEvent(executionManagerAddress)
 
-        const logs = (
-          await httpProvider.getLogs({
-            address: eventEmitter.address,
-          })
-        )
+        const logs = await httpProvider.getLogs({
+          address: eventEmitter.address,
+        })
         logs[0].address.should.eq(eventEmitter.address)
         logs[0].logIndex.should.eq(0)
         const parsedLogs = logs.map((x) => factory.interface.parseLog(x))

--- a/packages/rollup-full-node/test/app/web-rpc-handler.spec.ts
+++ b/packages/rollup-full-node/test/app/web-rpc-handler.spec.ts
@@ -344,9 +344,7 @@ describe('Web3Handler', () => {
           eventEmitter.deployTransaction.hash
         )
         const tx = await eventEmitter.emitEvent(executionManagerAddress)
-        await wallet.provider.getTransactionReceipt(
-                  tx.hash
-                )
+        await wallet.provider.getTransactionReceipt(tx.hash)
         const block = await httpProvider.send('eth_getBlockByNumber', [
           'latest',
           true,


### PR DESCRIPTION
## Description
Fix eth_getLogs bugs

Note:

Logs need to be converted to objects via `JSON.parse(JSON.stringify(x))`
because the Log object's logIndex type is a `number` where here we need
to set it to a `string` (the hex encoded number).

Fixes:
* address
* logIndex
* transactionHash

### Fixes
- Fixes # [YAS-303](https://optimists.atlassian.net/browse/YAS-303)

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
