### PR TITLE
Surfacing revert messages for eth_call and eth_sendRawTransaction

### DIFF
--- a/packages/ovm/src/app/utils.ts
+++ b/packages/ovm/src/app/utils.ts
@@ -121,6 +121,7 @@ export const getSuccessfulOvmTransactionMetadata = (
 
   if (callingWithEoaLog) {
     ovmFrom = callingWithEoaLog.values._ovmFromAddress
+    ovmTo = callingWithEoaLog.values._ovmToAddress
   }
 
   const eoaContractCreatedLog = logs.find(
@@ -129,8 +130,6 @@ export const getSuccessfulOvmTransactionMetadata = (
   if (eoaContractCreatedLog) {
     ovmCreatedContractAddress = eoaContractCreatedLog.values._ovmContractAddress
     ovmTo = ovmCreatedContractAddress
-  } else {
-    ovmTo = callingWithEoaLog.values._ovmToAddress
   }
 
   const metadata: OvmTransactionMetadata = {
@@ -177,7 +176,9 @@ export const internalTxReceiptToOvmTxReceipt = async (
   internalTxReceipt: TransactionReceipt,
   ovmTxHash?: string
 ): Promise<OvmTransactionReceipt> => {
-  const ovmTransactionMetadata = getSuccessfulOvmTransactionMetadata(internalTxReceipt)
+  const ovmTransactionMetadata = getSuccessfulOvmTransactionMetadata(
+    internalTxReceipt
+  )
   // Construct a new receipt
   //
   // Start off with the internalTxReceipt

--- a/packages/ovm/src/contracts/ExecutionManager.sol
+++ b/packages/ovm/src/contracts/ExecutionManager.sol
@@ -47,7 +47,8 @@ contract ExecutionManager is FullStateManager {
         bytes32 _codeContractHash
     );
     event CallingWithEOA(
-        address _ovmFromAddress
+        address _ovmFromAddress,
+        address _ovmToAddress
     );
     event EOACreatedContract(
         address _ovmContractAddress
@@ -137,7 +138,10 @@ contract ExecutionManager is FullStateManager {
         require(eoaAddress != ZERO_ADDRESS, "Failed to recover signature");
         // Require nonce to be correct
         require(_nonce == getOvmContractNonce(eoaAddress), "Incorrect nonce!");
-        emit CallingWithEOA(eoaAddress);
+        emit CallingWithEOA(
+            eoaAddress,
+            _ovmEntrypoint
+        );
         // Make the EOA call for the account
         executeTransaction(_timestamp, _queueOrigin, _ovmEntrypoint, _callBytes, eoaAddress, ZERO_ADDRESS, false);
     }

--- a/packages/ovm/test/app/utils.spec.ts
+++ b/packages/ovm/test/app/utils.spec.ts
@@ -49,7 +49,11 @@ describe('getSuccessfulOvmTransactionMetadata', () => {
       byzantium: true,
       logs: [
         [EXECUTION_MANAGER_ADDRESS, 'ActiveContract(address)', [ALICE]],
-        [EXECUTION_MANAGER_ADDRESS, 'CallingWithEOA(address,address)', [ALICE,CONTRACT]],
+        [
+          EXECUTION_MANAGER_ADDRESS,
+          'CallingWithEOA(address,address)',
+          [ALICE, CONTRACT],
+        ],
         [EXECUTION_MANAGER_ADDRESS, 'ActiveContract(address)', [ALICE]],
         [EXECUTION_MANAGER_ADDRESS, 'EOACreatedContract(address)', [CONTRACT]],
         [EXECUTION_MANAGER_ADDRESS, 'ActiveContract(address)', [CONTRACT]],

--- a/packages/ovm/test/app/utils.spec.ts
+++ b/packages/ovm/test/app/utils.spec.ts
@@ -10,7 +10,7 @@ import {
 import { TransactionReceipt } from 'ethers/providers'
 import {
   convertInternalLogsToOvmLogs,
-  getOvmTransactionMetadata,
+  getSuccessfulOvmTransactionMetadata,
   OvmTransactionMetadata,
   revertMessagePrefix,
 } from '../../src/app'
@@ -43,13 +43,13 @@ describe('convertInternalLogsToOvmLogs', () => {
   })
 })
 
-describe('getOvmTransactionMetadata', () => {
+describe('getSuccessfulOvmTransactionMetadata', () => {
   it('should return transaction metadata from calls from externally owned accounts', async () => {
     const transactionReceipt: TransactionReceipt = {
       byzantium: true,
       logs: [
         [EXECUTION_MANAGER_ADDRESS, 'ActiveContract(address)', [ALICE]],
-        [EXECUTION_MANAGER_ADDRESS, 'CallingWithEOA(address)', [ALICE]],
+        [EXECUTION_MANAGER_ADDRESS, 'CallingWithEOA(address,address)', [ALICE,CONTRACT]],
         [EXECUTION_MANAGER_ADDRESS, 'ActiveContract(address)', [ALICE]],
         [EXECUTION_MANAGER_ADDRESS, 'EOACreatedContract(address)', [CONTRACT]],
         [EXECUTION_MANAGER_ADDRESS, 'ActiveContract(address)', [CONTRACT]],
@@ -61,33 +61,11 @@ describe('getOvmTransactionMetadata', () => {
       ].map((args) => buildLog.apply(null, args)),
     }
 
-    getOvmTransactionMetadata(transactionReceipt).should.deep.eq({
+    getSuccessfulOvmTransactionMetadata(transactionReceipt).should.deep.eq({
       ovmCreatedContractAddress: CONTRACT,
       ovmFrom: ALICE,
       ovmTo: CONTRACT,
       ovmTxSucceeded: true,
     })
-  })
-
-  it('should return with ovmTxSucceeded equal to false if the transaction reverted', async () => {
-    const revertMessage: string = 'The tx reverted!'
-    const msgHex: string = add0x(
-      Buffer.from(revertMessage, 'utf8').toString('hex')
-    )
-    const encodedMessage: string = abi.encode(['bytes'], [msgHex])
-    // needs 4 bytes of sighash
-    const eventData: string = add0x('ab'.repeat(4) + remove0x(encodedMessage))
-    const transactionReceipt: TransactionReceipt = {
-      byzantium: true,
-      logs: [
-        [EXECUTION_MANAGER_ADDRESS, 'EOACallRevert(bytes)', [eventData]],
-      ].map((args) => buildLog.apply(null, args)),
-    }
-
-    const metadata: OvmTransactionMetadata = getOvmTransactionMetadata(
-      transactionReceipt
-    )
-    metadata.ovmTxSucceeded.should.eq(false)
-    metadata.revertMessage.should.eq(revertMessagePrefix + revertMessage)
   })
 })

--- a/packages/rollup-full-node/src/app/utils/l2-node.ts
+++ b/packages/rollup-full-node/src/app/utils/l2-node.ts
@@ -212,3 +212,17 @@ function getL2ToL1MessagePasserContract(wallet: Wallet): Contract {
     wallet
   )
 }
+
+/**
+ * Detects whether an internal L2 node error is due to an EVM revert or some other error
+ *
+ * @param e The error message reterned from either eth_sendRawTransaction or eth_call on the internal L2 node
+ * @returns Whether the error is an EVM revert error or some other issue.
+ */
+export function isErrorEVMRevert(e: any): boolean {
+  return (
+    !!e.results &&
+    !!Object.keys(e.results)[0] &&
+    e.results[Object.keys(e.results)[0]].error === 'revert'
+  )
+}

--- a/packages/rollup-full-node/src/app/web3-rpc-handler.ts
+++ b/packages/rollup-full-node/src/app/web3-rpc-handler.ts
@@ -246,7 +246,6 @@ export class DefaultWeb3Handler
           txObject
         )}, default block: ${defaultBlock}, error: ${JSON.stringify(e)}`
       )
-      console.log('here')
       if (isErrorEVMRevert(e)) {
         log.debug(
           `Internal error appears to be an EVM revert, surfacing revert message up...`

--- a/packages/rollup-full-node/src/app/web3-rpc-handler.ts
+++ b/packages/rollup-full-node/src/app/web3-rpc-handler.ts
@@ -828,7 +828,7 @@ export class DefaultWeb3Handler
       .waitForTransaction(res.hash)
       .then((receipt) => {
         log.debug(
-          `Got receipt mapping ${ovmTxHash} to ${internalTxHash}: ${JSON.stringify(
+          `Got receipt mapping ovm tx hash ${ovmTxHash} to internal tx hash ${internalTxHash}: ${JSON.stringify(
             receipt
           )}`
         )

--- a/packages/rollup-full-node/src/app/web3-rpc-handler.ts
+++ b/packages/rollup-full-node/src/app/web3-rpc-handler.ts
@@ -540,19 +540,26 @@ export class DefaultWeb3Handler
       return null
     }
 
-    log.debug(`Converting internal tx receipt to ovm receipt, internal receipt is:`, internalTxReceipt)
-    
+    log.debug(
+      `Converting internal tx receipt to ovm receipt, internal receipt is:`,
+      internalTxReceipt
+    )
+
     // if there are no logs, the tx must have failed, as the Execution Mgr always logs stuff
     const txSucceeded: boolean = internalTxReceipt.logs.length !== 0
     let ovmTxReceipt
     if (txSucceeded) {
-      log.debug(`The internal tx previously succeeded for this OVM tx, converting internal receipt to OVM receipt...`)
+      log.debug(
+        `The internal tx previously succeeded for this OVM tx, converting internal receipt to OVM receipt...`
+      )
       ovmTxReceipt = await internalTxReceiptToOvmTxReceipt(
         internalTxReceipt,
         ovmTxHash
       )
     } else {
-      log.debug(`Internal tx previously failed for this OVM tx, creating receipt from the OVM tx itself.`)
+      log.debug(
+        `Internal tx previously failed for this OVM tx, creating receipt from the OVM tx itself.`
+      )
       const rawOvmTx = await this.getOvmTransactionByHash(ovmTxHash)
       const ovmTx = utils.parseTransaction(rawOvmTx)
       // for a failing tx, everything is identical between the internal and external receipts, except to and from

--- a/packages/rollup-full-node/test/app/test-web-rpc-handler.spec.ts
+++ b/packages/rollup-full-node/test/app/test-web-rpc-handler.spec.ts
@@ -22,7 +22,7 @@ import {
 import * as SimpleStorage from '../contracts/build/untranspiled/SimpleStorage.json'
 import * as EmptyContract from '../contracts/build/untranspiled/EmptyContract.json'
 import * as CallerStorer from '../contracts/build/transpiled/CallerStorer.json'
-import { getOvmTransactionMetadata } from '@eth-optimism/ovm'
+import { getSuccessfulOvmTransactionMetadata } from '@eth-optimism/ovm'
 
 const log = getLogger('test-web3-handler', true)
 

--- a/packages/rollup-full-node/test/app/test-web-rpc-handler.spec.ts
+++ b/packages/rollup-full-node/test/app/test-web-rpc-handler.spec.ts
@@ -22,7 +22,6 @@ import {
 import * as SimpleStorage from '../contracts/build/untranspiled/SimpleStorage.json'
 import * as EmptyContract from '../contracts/build/untranspiled/EmptyContract.json'
 import * as CallerStorer from '../contracts/build/transpiled/CallerStorer.json'
-import { getSuccessfulOvmTransactionMetadata } from '@eth-optimism/ovm'
 
 const log = getLogger('test-web3-handler', true)
 

--- a/packages/rollup-full-node/test/app/web-rpc-handler.spec.ts
+++ b/packages/rollup-full-node/test/app/web-rpc-handler.spec.ts
@@ -129,7 +129,10 @@ const assertAsyncThrowsWithMessage = async (
       succeeded = false
     }
   }
-  succeeded.should.equal(true, 'Function didn\'t throw as expected or threw with the wrong error message.' )
+  succeeded.should.equal(
+    true,
+    "Function didn't throw as expected or threw with the wrong error message."
+  )
 }
 
 /*********
@@ -181,36 +184,27 @@ describe('Web3Handler', () => {
         simpleReversion = await factory.deploy()
       })
       it('Should propogate generic internal EVM reverts upwards for sendRawTransaction', async () => {
-        await assertAsyncThrowsWithMessage(
-          async () => {
-            await simpleReversion.doRevert()
-          },
-          'VM Exception while processing transaction: revert'
-        )
+        await assertAsyncThrowsWithMessage(async () => {
+          await simpleReversion.doRevert()
+        }, 'VM Exception while processing transaction: revert')
       })
       it('Should propogate solidity require messages upwards for sendRawTransaction', async () => {
         const solidityRevertMessage = 'trolololo'
-        await assertAsyncThrowsWithMessage(
-          async () => {
-            await simpleReversion.doRevertWithMessage(solidityRevertMessage)
-          },
-          'VM Exception while processing transaction: revert ' + solidityRevertMessage
-        )
+        await assertAsyncThrowsWithMessage(async () => {
+          await simpleReversion.doRevertWithMessage(solidityRevertMessage)
+        }, 'VM Exception while processing transaction: revert ' + solidityRevertMessage)
       })
       it('Logs should acknowledge the reversion as well', async () => {
         // this will fail, but that's fine, we want it to and then check its logs
         try {
           await simpleReversion.doRevert()
         } catch {}
-        const receipt = (
-          await httpProvider.getTransactionReceipt(
-            '0xade9e00b889b02e994f9ef2d652f3fdb6f34c5862c4a78e959b2b36c79142dc9'
-          )
+        const receipt = await httpProvider.getTransactionReceipt(
+          '0xade9e00b889b02e994f9ef2d652f3fdb6f34c5862c4a78e959b2b36c79142dc9'
         )
         log.debug(`the receipt is: ${JSON.stringify(receipt)}`)
         // .map((x) => simpleReversion.interface.parseLog(x))
       })
-
     })
 
     describe('the getBlockByNumber endpoint', () => {

--- a/packages/rollup-full-node/test/app/web-rpc-handler.spec.ts
+++ b/packages/rollup-full-node/test/app/web-rpc-handler.spec.ts
@@ -9,7 +9,7 @@ import {
   ZERO_ADDRESS,
   hexStrToBuf,
 } from '@eth-optimism/core-utils'
-import { CHAIN_ID, convertInternalLogsToOvmLogs } from '@eth-optimism/ovm'
+import { CHAIN_ID } from '@eth-optimism/ovm'
 
 import {
   ethers,

--- a/packages/rollup-full-node/test/app/web-rpc-handler.spec.ts
+++ b/packages/rollup-full-node/test/app/web-rpc-handler.spec.ts
@@ -11,7 +11,14 @@ import {
 } from '@eth-optimism/core-utils'
 import { CHAIN_ID, convertInternalLogsToOvmLogs } from '@eth-optimism/ovm'
 
-import { ethers, ContractFactory, Wallet, Contract, utils, providers } from 'ethers'
+import {
+  ethers,
+  ContractFactory,
+  Wallet,
+  Contract,
+  utils,
+  providers,
+} from 'ethers'
 import { resolve } from 'path'
 import * as rimraf from 'rimraf'
 import * as fs from 'fs'
@@ -203,23 +210,19 @@ describe('Web3Handler', () => {
           gasLimit: 9999999999,
           to: simpleReversion.address,
           chainId: CHAIN_ID,
-          data: simpleReversion.interface.functions[
-            'doRevert'
-          ].encode([])
+          data: simpleReversion.interface.functions['doRevert'].encode([]),
         }
         const signedTx = await wallet.sign(revertingTx)
         const txHash = ethers.utils.keccak256(signedTx)
         try {
-          await httpProvider.send(
-            'eth_sendRawTransaction',
-            [signedTx]
+          await httpProvider.send('eth_sendRawTransaction', [signedTx])
+        } catch (e) {
+          e.message.should.equal(
+            EVM_REVERT_MSG,
+            'expected EVM revert but got some other error!'
           )
-        } catch(e) {
-          e.message.should.equal(EVM_REVERT_MSG, 'expected EVM revert but got some other error!')
         }
-        const receipt = await httpProvider.getTransactionReceipt(
-          txHash
-        )
+        const receipt = await httpProvider.getTransactionReceipt(txHash)
         receipt.from.should.equal(wallet.address)
         receipt.to.should.equal(simpleReversion.address)
       })

--- a/packages/rollup-full-node/test/app/web-rpc-handler.spec.ts
+++ b/packages/rollup-full-node/test/app/web-rpc-handler.spec.ts
@@ -183,6 +183,7 @@ describe('Web3Handler', () => {
     describe('EVM reversion handling', async () => {
       let wallet
       let simpleReversion
+      const solidityRevertMessage = 'trolololo'
       beforeEach(async () => {
         wallet = getWallet(httpProvider)
         const factory = new ContractFactory(
@@ -192,13 +193,12 @@ describe('Web3Handler', () => {
         )
         simpleReversion = await factory.deploy()
       })
-      it('Should propogate generic internal EVM reverts upwards for sendRawTransaction', async () => {
+      it('Should propogate generic internal EVM reverts upwards for eth_sendRawTransaction', async () => {
         await assertAsyncThrowsWithMessage(async () => {
           await simpleReversion.doRevert()
         }, EVM_REVERT_MSG)
       })
-      it('Should propogate solidity require messages upwards for sendRawTransaction', async () => {
-        const solidityRevertMessage = 'trolololo'
+      it('Should propogate solidity require messages upwards for eth_sendRawTransaction', async () => {
         await assertAsyncThrowsWithMessage(async () => {
           await simpleReversion.doRevertWithMessage(solidityRevertMessage)
         }, EVM_REVERT_MSG + ' ' + solidityRevertMessage)
@@ -225,6 +225,16 @@ describe('Web3Handler', () => {
         const receipt = await httpProvider.getTransactionReceipt(txHash)
         receipt.from.should.equal(wallet.address)
         receipt.to.should.equal(simpleReversion.address)
+      })
+      it('Should propogate generic EVM reverts for eth_call', async () => {
+        await assertAsyncThrowsWithMessage(async () => {
+          await simpleReversion.doRevertPure()
+        }, EVM_REVERT_MSG)
+      })
+      it('Should propogate custom message EVM reverts for eth_call', async () => {
+        await assertAsyncThrowsWithMessage(async () => {
+          await simpleReversion.doRevertWithMessagePure(solidityRevertMessage)
+        }, EVM_REVERT_MSG + ' ' + solidityRevertMessage)
       })
     })
 

--- a/packages/rollup-full-node/test/app/web-rpc-handler.spec.ts
+++ b/packages/rollup-full-node/test/app/web-rpc-handler.spec.ts
@@ -203,6 +203,29 @@ describe('Web3Handler', () => {
           await simpleReversion.doRevertWithMessage(solidityRevertMessage)
         }, EVM_REVERT_MSG + ' ' + solidityRevertMessage)
       })
+      it('Should increment the nonce after a revert', async () => {
+        const beforeNonce = await httpProvider.getTransactionCount(
+          wallet.address
+        )
+        let didError = false
+        try {
+          await simpleReversion.doRevertWithMessage(solidityRevertMessage)
+        } catch (e) {
+          didError = true
+        }
+        didError.should.equal(
+          true,
+          'Expected doRevertWithMessage(...) to throw!'
+        )
+        const afterNonce = await httpProvider.getTransactionCount(
+          wallet.address
+        )
+
+        afterNonce.should.equal(
+          beforeNonce + 1,
+          'Expected the nonce to be incremented by 1!'
+        )
+      })
       it('Should serve receipts for reverting transactions', async () => {
         const revertingTx = {
           nonce: await wallet.getTransactionCount(),

--- a/packages/rollup-full-node/test/contracts/transpiled/SimpleReversion.sol
+++ b/packages/rollup-full-node/test/contracts/transpiled/SimpleReversion.sol
@@ -7,4 +7,10 @@ contract SimpleReversion {
     function doRevertWithMessage(string memory _message) public {
         require(false, _message);
     }
+    function doRevertPure() public pure {
+        revert();
+    }
+        function doRevertWithMessagePure(string memory _message) public pure {
+        require(false, _message);
+    }
 }

--- a/packages/rollup-full-node/test/contracts/transpiled/SimpleReversion.sol
+++ b/packages/rollup-full-node/test/contracts/transpiled/SimpleReversion.sol
@@ -10,7 +10,7 @@ contract SimpleReversion {
     function doRevertPure() public pure {
         revert();
     }
-        function doRevertWithMessagePure(string memory _message) public pure {
+    function doRevertWithMessagePure(string memory _message) public pure {
         require(false, _message);
     }
 }

--- a/packages/rollup-full-node/test/contracts/transpiled/SimpleReversion.sol
+++ b/packages/rollup-full-node/test/contracts/transpiled/SimpleReversion.sol
@@ -1,0 +1,10 @@
+pragma solidity ^0.5.0;
+
+contract SimpleReversion {
+    function doRevert() public {
+        revert();
+    }
+    function doRevertWithMessage(string memory _message) public {
+        require(false, _message);
+    }
+}


### PR DESCRIPTION
## Description
PR adds support for propagating internal EVM error messages up to the OVM caller for both `eth_call` and `eth_sendTransaction`

We previously were able to accomplish this by having the EM's event logs indicate reverts, but not having the internal transactions themselves revert.  Now that we are not waiting for transactions to be mined, we had to go back to the model where a reverting OVM transaction reverts the internal EVM transaction, too.  This adds a bit of complication for receipts, but it's manageable. 

Also incorporates some random bugfixes from a hotfix branch of @K-Ho 's.
## Questions
- Should we remove `allowRevert` from EM which appears to be only ever set to true?  My bias is towards leaving it for now as we may need to change things up again in the future.

## Metadata
### Fixes
- Fixes YAS 328

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
