### PR TITLE
Fix sendTransaction by using a random account sig

### DIFF
--- a/packages/core-utils/src/app/misc.ts
+++ b/packages/core-utils/src/app/misc.ts
@@ -290,22 +290,3 @@ export const runInDomain = async (
 export const getCurrentTime = (): number => {
   return Math.round(Date.now() / 1000)
 }
-/**
- * Encodes a transaction in RLP format, using a random signature
- * @param {object} Transaction object
- */
-export const rlpEncodeTransactionWithRandomSig = (
-  transaction: object
-): string => {
-  return RLP.encode([
-    hexlify(transaction['nonce']),
-    hexlify(transaction['gasPrice']),
-    hexlify(transaction['gasLimit']),
-    hexlify(transaction['to']),
-    hexlify(transaction['value']),
-    hexlify(transaction['data']),
-    '0x11', // v
-    '0x' + '11'.repeat(32), // r
-    '0x' + '11'.repeat(32), // s
-  ])
-}

--- a/packages/rollup-full-node/src/app/test-web3-rpc-handler.ts
+++ b/packages/rollup-full-node/src/app/test-web3-rpc-handler.ts
@@ -4,7 +4,6 @@ import {
   getLogger,
   numberToHexString,
   castToNumber,
-  rlpEncodeTransactionWithRandomSig,
   ZERO_ADDRESS,
 } from '@eth-optimism/core-utils'
 import { GAS_LIMIT } from '@eth-optimism/ovm'
@@ -150,10 +149,12 @@ export class TestWeb3Handler extends DefaultWeb3Handler {
     if (!ovmTx.gasLimit) {
       ovmTx.gasLimit = GAS_LIMIT
     }
+    const ovmTxFrom = ovmTx.from
+    delete ovmTx.from
     ovmTx.value = 0
     return this.sendRawTransaction(
-      rlpEncodeTransactionWithRandomSig(ovmTx),
-      ovmTx.from
+      await this.getNewWallet().sign(ovmTx),
+      ovmTxFrom
     )
   }
 


### PR DESCRIPTION
## Description
Fixes a small issue with the test web3 rpc server `sendTransaction` endpoint.

Note that sendTransaction will have weird behavior because during tx recovery in things like receipt parsing we will end up getting an incorrect `from` address. 

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
