### PR TITLE
Revert "Remove "to" field override in getLogs"

### DIFF
--- a/packages/rollup-full-node/src/app/web3-rpc-handler.ts
+++ b/packages/rollup-full-node/src/app/web3-rpc-handler.ts
@@ -498,6 +498,7 @@ export class DefaultWeb3Handler
           const receipt = await this.getTransactionReceipt(transaction.hash)
           transaction['to'] = receipt.contractAddress
         }
+        logItem['address'] = transaction['to']
 
         return logItem
       })


### PR DESCRIPTION
Reverts ethereum-optimism/optimism-monorepo#113

Turns out this does not fix how we are parsing the logs & instead just breaks a test.

To properly fix `getLogs` we will likely need to use a `codeContractAddress` to `ovmContractAddress` mapping to look up the `ovmContractAddress` of arbitrary logs.