### PR TITLE
Making Router handle JSON RPC Errors

### DIFF
--- a/packages/core-utils/src/app/test-utils.ts
+++ b/packages/core-utils/src/app/test-utils.ts
@@ -22,8 +22,9 @@ export class TestUtils {
   public static async assertThrowsAsync(
     func: () => Promise<any>,
     errorType?: any
-  ): Promise<void> {
+  ): Promise<Error> {
     let succeeded = true
+    let error: Error
     try {
       await func()
       succeeded = false
@@ -31,12 +32,14 @@ export class TestUtils {
       if (!!errorType && !(e instanceof errorType)) {
         succeeded = false
       }
+      error = e
     }
 
     assert(
       succeeded,
       "Function didn't throw as expected or threw the wrong error."
     )
+    return error
   }
 
   public static async assertRevertsAsync(

--- a/packages/core-utils/src/app/transport/client/json-rpc-client.ts
+++ b/packages/core-utils/src/app/transport/client/json-rpc-client.ts
@@ -8,6 +8,7 @@ import {
   JsonRpcRequest,
   Client,
   isJsonRpcErrorResponse,
+  JsonRpcResponse,
 } from '../../../types'
 
 /**
@@ -23,11 +24,34 @@ export class JsonRpcClient<TransportRequest, TransportResponse>
   /**
    * Handles a method call by making a JSON-RPC
    * request to some server.
+   *
+   * @param method Name of the method to call.
+   * @param [params] Parameters to send with the method call.
+   * @returns the `result` field of the response to the method call.
+   * @throws Error if there is any error, including a properly-formatted JsonRpcResponse error.
+   */
+  public async handle<T>(method: string, params?: any): Promise<T> {
+    const response: JsonRpcResponse = await this.makeRpcCall(method, params)
+
+    if (isJsonRpcErrorResponse(response)) {
+      throw new Error(`${JSON.stringify(response.error)}`)
+    }
+    return response.result
+  }
+
+  /**
+   * Makes an RPC call and returns the full JsonRpcResponse.
+   * Notably, this differs from handle<T>(...) because it does not throw on error
+   * or just return the `result` field on success.
+   *
    * @param method Name of the method to call.
    * @param [params] Parameters to send with the method call.
    * @returns the result of the method call.
    */
-  public async handle<T>(method: string, params?: any): Promise<T> {
+  public async makeRpcCall(
+    method: string,
+    params?: any
+  ): Promise<JsonRpcResponse> {
     const request: JsonRpcRequest = {
       jsonrpc: '2.0',
       method,
@@ -37,11 +61,6 @@ export class JsonRpcClient<TransportRequest, TransportResponse>
 
     const encodedRequest = this.adapter.encodeRequest(request)
     const encodedResponse = await this.client.request(encodedRequest)
-    const response = this.adapter.decodeResponse(encodedResponse)
-
-    if (isJsonRpcErrorResponse(response)) {
-      throw new Error(`${JSON.stringify(response.error)}`)
-    }
-    return response.result
+    return this.adapter.decodeResponse(encodedResponse)
   }
 }

--- a/packages/core-utils/src/app/transport/client/simple-client.ts
+++ b/packages/core-utils/src/app/transport/client/simple-client.ts
@@ -2,7 +2,7 @@
  * Wrapper class around a Http-based JsonRpcClient
  */
 import { JsonRpcClient } from './json-rpc-client'
-import { HttpRequest, HttpResponse } from '../../../types'
+import { HttpRequest, HttpResponse, JsonRpcResponse } from '../../../types'
 import { JsonRpcHttpAdapter } from './json-rpc-http-adapter'
 import { AxiosHttpClient } from './axios-http-client'
 
@@ -25,9 +25,25 @@ export class SimpleClient {
    * request to some server.
    * @param method Name of the method to call.
    * @param [params] Parameters to send with the method call.
-   * @returns the result of the method call.
+   * @returns the `result` field of the response to the method call.
+   * @throws Error if there is any error, including a properly-formatted JsonRpcResponse error.
    */
   public async handle<T>(method: string, params?: any): Promise<T> {
     return this.jsonRpcClient.handle<T>(method, params)
+  }
+
+  /**
+   * Makes an RPC call and returns the full JsonRpcResponse.
+   * Notably, this differs from handle<T>(...) because it does not throw one error
+   * or just return the `result` field on success.
+   * @param method Name of the method to call.
+   * @param [params] Parameters to send with the method call.
+   * @returns the result of the method call.
+   */
+  public async makeRpcCall(
+    method: string,
+    params?: any
+  ): Promise<JsonRpcResponse> {
+    return this.jsonRpcClient.makeRpcCall(method, params)
   }
 }

--- a/packages/rollup-full-node/src/app/fullnode-rpc-server.ts
+++ b/packages/rollup-full-node/src/app/fullnode-rpc-server.ts
@@ -14,6 +14,7 @@ import {
 
 /* Internal Imports */
 import {
+  FormattedJsonRpcError,
   FullnodeHandler,
   InvalidParametersError,
   InvalidTransactionDesinationError,
@@ -102,6 +103,14 @@ export class FullnodeRpcServer extends ExpressHttpServer {
         result,
       }
     } catch (err) {
+      if (err instanceof FormattedJsonRpcError) {
+        log.debug(
+          `Received formatted JSON RPC Error response. Returning it as is: ${JSON.stringify(
+            err.jsonRpcResponse
+          )}`
+        )
+        return err.jsonRpcResponse
+      }
       if (err instanceof RevertError) {
         log.debug(`Request reverted. Request: ${JSON.stringify(request)}`)
         const errorResponse: JsonRpcErrorResponse = buildJsonRpcError(

--- a/packages/rollup-full-node/src/types/errors.ts
+++ b/packages/rollup-full-node/src/types/errors.ts
@@ -1,3 +1,5 @@
+import { JsonRpcErrorResponse } from '@eth-optimism/core-utils'
+
 export class TreeUpdateError extends Error {
   constructor(message?: string) {
     super(message || 'Error occurred performing a tree update!')
@@ -60,5 +62,11 @@ export class InvalidTransactionDesinationError extends Error {
         validDestinationAddresses
       )}`
     )
+  }
+}
+
+export class FormattedJsonRpcError extends Error {
+  constructor(public readonly jsonRpcResponse: JsonRpcErrorResponse) {
+    super()
   }
 }


### PR DESCRIPTION
## Description
Right now the router throws when it receives JSON RPC Errors. It should just forward those along as is. This change makes it do that.

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
