### PR TITLE
Fixing catch of formatted json rpc error

### DIFF
--- a/packages/rollup-full-node/src/app/routing-handler.ts
+++ b/packages/rollup-full-node/src/app/routing-handler.ts
@@ -117,13 +117,15 @@ export class RoutingHandler implements FullnodeHandler {
       }
       return result.result
     } catch (e) {
-      logError(
-        log,
-        `Error proxying request: [${method}], params: [${JSON.stringify(
-          params
-        )}]`,
-        e
-      )
+      if (!(e instanceof FormattedJsonRpcError)) {
+        logError(
+          log,
+          `Error proxying request: [${method}], params: [${JSON.stringify(
+            params
+          )}]`,
+          e
+        )
+      }
       throw e
     }
   }

--- a/packages/rollup-full-node/test/app/routing-handler.spec.ts
+++ b/packages/rollup-full-node/test/app/routing-handler.spec.ts
@@ -314,7 +314,7 @@ describe('Routing Handler', () => {
       error.should.be.instanceOf(FormattedJsonRpcError, 'Invalid error type!')
       const formatted: FormattedJsonRpcError = error as FormattedJsonRpcError
       formatted.jsonRpcResponse.should.deep.equal(
-        transactionErrorRFesponsePayload,
+        transactionErrorResponsePayload,
         'Incorrect error returned!'
       )
     })

--- a/packages/rollup-full-node/test/app/routing-handler.spec.ts
+++ b/packages/rollup-full-node/test/app/routing-handler.spec.ts
@@ -314,7 +314,7 @@ describe('Routing Handler', () => {
       error.should.be.instanceOf(FormattedJsonRpcError, 'Invalid error type!')
       const formatted: FormattedJsonRpcError = error as FormattedJsonRpcError
       formatted.jsonRpcResponse.should.deep.equal(
-        transactionErrorResponsePayload,
+        transactionErrorRFesponsePayload,
         'Incorrect error returned!'
       )
     })


### PR DESCRIPTION
## Description
The router still logs FormattedJsonRpcErrors as errors, even though they should not be. This fixes that.

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
