### PR TITLE
No automated deploys to UAT or PROD

### DIFF
--- a/.github/workflows/synthetix-prod-ecr-deploy.yml
+++ b/.github/workflows/synthetix-prod-ecr-deploy.yml
@@ -35,12 +35,6 @@ jobs:
           AWS_ACCOUNT_NUMBER: ${{ secrets.AWS_CI_AWS_ACCOUNT_ID }}
         run: ./docker/publish-rollup-fullnode-container.sh synthetix-prod
 
-      - name: Stop existing ECS tasks to auto-start task with new image
-        run: |
-          ./.github/scripts/stop-ecs-task.sh synthetix-prod-web synthetix-prod-web
-          ./.github/scripts/stop-ecs-task.sh synthetix-prod-geth synthetix-prod-geth
-
-
       - name: Logout of Amazon ECR
         if: always()
         run: docker logout ${{ steps.login-ecr.outputs.registry }}

--- a/.github/workflows/synthetix-uat-ecr-deploy.yml
+++ b/.github/workflows/synthetix-uat-ecr-deploy.yml
@@ -35,11 +35,6 @@ jobs:
           AWS_ACCOUNT_NUMBER: ${{ secrets.AWS_CI_AWS_ACCOUNT_ID }}
         run: ./docker/publish-rollup-fullnode-container.sh synthetix-uat
 
-      - name: Stop existing ECS tasks to auto-start task with new image
-        run: |
-          ./.github/scripts/stop-ecs-task.sh synthetix-uat-web synthetix-uat-web
-          ./.github/scripts/stop-ecs-task.sh synthetix-uat-geth synthetix-uat-geth
-
 
       - name: Logout of Amazon ECR
         if: always()


### PR DESCRIPTION
## Description
Makes it so that merge to UAT / PROD does not automatically restart servers. We will likely want to be more intentional with timing

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
