### PR TITLE
changing sh script because of version of sh on debian

### DIFF
--- a/aws/synthetix/dev/full-node/docker-compose.yml
+++ b/aws/synthetix/dev/full-node/docker-compose.yml
@@ -112,6 +112,9 @@ services:
       RUST_LOG: info
       STARTUP_WAIT_TIMEOUT: 30
       OVM_URL_WITH_PORT: 'http://0.0.0.0:8545'
+    volumes:
+      - postgres-data:/data/postgres
+      - ipfs-data:/data/ipfs
 
     logging:
       driver: awslogs

--- a/aws/synthetix/prod/web/docker-compose.yml
+++ b/aws/synthetix/prod/web/docker-compose.yml
@@ -86,6 +86,9 @@ services:
       RUST_LOG: info
       STARTUP_WAIT_TIMEOUT: 30
       OVM_URL_WITH_PORT: 'http://0.0.0.0:8545'
+    volumes:
+      - postgres-data:/data/postgres
+      - ipfs-data:/data/ipfs
 
     logging:
       driver: awslogs

--- a/aws/synthetix/uat/web/docker-compose.yml
+++ b/aws/synthetix/uat/web/docker-compose.yml
@@ -86,6 +86,9 @@ services:
       RUST_LOG: info
       STARTUP_WAIT_TIMEOUT: 30
       OVM_URL_WITH_PORT: 'http://0.0.0.0:8545'
+    volumes:
+      - postgres-data:/data/postgres
+      - ipfs-data:/data/ipfs
 
     logging:
       driver: awslogs

--- a/docker/the-graph/wait-for-ovm.sh
+++ b/docker/the-graph/wait-for-ovm.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # wait-for-ovm.sh <ovm url with port>
-# NOTE: set the CLEAR_DATA_KEY environment variable to clear the /data directory on startup.
+# NOTE: set the CLEAR_DATA_KEY environment variable to clear the $POSTGRES_DIR and $IPFS_DIR on startup.
 # Directory will only be cleared if CLEAR_DATA_KEY is set AND different from last start.
 
 set -e
@@ -33,16 +33,23 @@ wait_for_server_to_be_reachable()
 
 clear_data_if_necessary()
 {
-  DATA_DIRECTORY=${DATA_DIRECTORY:-/data}
-  CLEAR_DATA_FILE_PATH="$DATA_DIRECTORY/.clear_data_key_$CLEAR_DATA_KEY"
+  POSTGRES_DIR=${POSTGRES_DIR:-/data/postgres}
+  IPFS_DIR=${IPFS_DIR:-/data/ipfs}
+  CLEAR_DATA_FILE_PATH="${IPFS_DIR}/.clear_data_key_${CLEAR_DATA_KEY}"
 
   if [ -n "$CLEAR_DATA_KEY" -a ! -f "$CLEAR_DATA_FILE_PATH" ]; then
     echo "Detected change in CLEAR_DATA_KEY. Purging data."
-    rm -rf ${DATA_DIRECTORY}/*
-    rm -rf ${DATA_DIRECTORY}/.clear_data_key_*
-    echo "Local data cleared from '${DATA_DIRECTORY}/*'"
-    echo "Contents of data dir: $(ls -alh $DATA_DIRECTORY)"
+    rm -rf ${IPFS_DIR}/*
+    rm -rf ${IPFS_DIR}/.clear_data_key_*
+    echo "Local data cleared from '${IPFS_DIR}/*'"
+    echo "Contents of ipfs dir: $(ls -alh $IPFS_DIR)"
+
+    rm -rf ${POSTGRES_DIR}/*
+    echo "Local data cleared from '${POSTGRES_DIR}/*'"
+    echo "Contents of postgres dir: $(ls -alh $POSTGRES_DIR)"
     touch $CLEAR_DATA_FILE_PATH
+  else
+    echo "No change detected in CLEAR_DATA_KEY not deleting data."
   fi
 }
 

--- a/docker/the-graph/wait-for-ovm.sh
+++ b/docker/the-graph/wait-for-ovm.sh
@@ -36,7 +36,7 @@ clear_data_if_necessary()
   DATA_DIRECTORY=${DATA_DIRECTORY:-/data}
   CLEAR_DATA_FILE_PATH="$DATA_DIRECTORY/.clear_data_key_$CLEAR_DATA_KEY"
 
-  if [[ -n "$CLEAR_DATA_KEY" && ! -f "$CLEAR_DATA_FILE_PATH" ]]; then
+  if [ -n "$CLEAR_DATA_KEY" -a ! -f "$CLEAR_DATA_FILE_PATH" ]; then
     echo "Detected change in CLEAR_DATA_KEY. Purging data."
     rm -rf ${DATA_DIRECTORY}/*
     rm -rf ${DATA_DIRECTORY}/.clear_data_key_*


### PR DESCRIPTION
## Description
- Changing sh script `&&` -> `-a` and braces because of version of sh on debian.
- Changing the DEV / UAT / PROD scripts to mount the postgres & IPFS volumes

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
