### PR TITLE
Stopping our event parsing logging from OOMing our read-only node

### DIFF
--- a/packages/core-utils/src/app/log.ts
+++ b/packages/core-utils/src/app/log.ts
@@ -1,7 +1,7 @@
 import debug from 'debug'
 import { Logger } from '../types'
 
-export const LOG_NEWLINE_STRING = '<\n>'
+export const LOG_NEWLINE_STRING = '<\\n>'
 export const joinNewlinesAndDebug = (logs: string) =>
   debug(logs.replace('\n', LOG_NEWLINE_STRING))
 


### PR DESCRIPTION
## Description
We  buffer interim debug log statements while converting EVM event logs to OVM event logs. Sometimes the volume of data logged (buffered) is large enough to cause our node to run out of memory. This makes it so we don't buffer nearly as much info.

## Metadata
### Fixes
- Fixes # [YAS-339](https://optimists.atlassian.net/browse/YAS-339)

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
