### PR TITLE
Fixing bug where $DELETE$ can get set as env var sometimes

### DIFF
--- a/packages/rollup-full-node/src/exec/fullnode.ts
+++ b/packages/rollup-full-node/src/exec/fullnode.ts
@@ -390,7 +390,10 @@ const updateEnvironmentVariables = (updateFilePath: string) => {
             delete process.env[key]
             log.info(`Updated process.env.${key} to have no value.`)
             changesExist = true
-          } else if (value !== process.env[key] && value !== deletePlaceholder) {
+          } else if (
+            value !== process.env[key] &&
+            value !== deletePlaceholder
+          ) {
             process.env[key] = value
             log.info(`Updated process.env.${key} to have value ${value}.`)
             changesExist = true

--- a/packages/rollup-full-node/src/exec/fullnode.ts
+++ b/packages/rollup-full-node/src/exec/fullnode.ts
@@ -383,13 +383,14 @@ const updateEnvironmentVariables = (updateFilePath: string) => {
             )
             continue
           }
+          const deletePlaceholder = '$DELETE$'
           const key = varAssignmentSplit[0].trim()
           const value = varAssignmentSplit[1].trim()
-          if (value === '$DELETE$' && !!process.env[key]) {
+          if (value === deletePlaceholder && !!process.env[key]) {
             delete process.env[key]
             log.info(`Updated process.env.${key} to have no value.`)
             changesExist = true
-          } else if (value !== process.env[key]) {
+          } else if (value !== process.env[key] && value !== deletePlaceholder) {
             process.env[key] = value
             log.info(`Updated process.env.${key} to have value ${value}.`)
             changesExist = true


### PR DESCRIPTION
## Description
Fixing bug where $DELETE$ can get set as env var sometimes

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
