### PR TITLE
Making log statements a single line

### DIFF
--- a/packages/core-utils/src/app/log.ts
+++ b/packages/core-utils/src/app/log.ts
@@ -1,9 +1,49 @@
 import debug from 'debug'
 import { Logger } from '../types'
 
-export const LOG_CR_STRING = '<\\r>'
-export const LOG_NEWLINE_STRING = '<\\n>'
-export const joinNewlinesAndDebug = (...logs: any[]) => {
+export const LOG_NEWLINE_STRING = ' <\\n> '
+
+/**
+ * Gets a logger specific to the provided identifier.
+ *
+ * @param identifier The identifier to use to tag log statements from this logger.
+ * @param isTest Whether or not this is a test logger.
+ * @param debugToUseTestOnly The debug instance to use *should only be used for tests*
+ * @returns a Logger instance.
+ */
+export const getLogger = (
+  identifier: string,
+  isTest: boolean = false,
+  debugToUseTestOnly?: debug
+): Logger => {
+  const testString = isTest ? 'test:' : ''
+  return {
+    debug: getLogFunction(
+      `${testString}debug:${identifier}`,
+      debugToUseTestOnly
+    ),
+    info: getLogFunction(`${testString}info:${identifier}`, debugToUseTestOnly),
+    warn: getLogFunction(`${testString}warn:${identifier}`, debugToUseTestOnly),
+    error: getLogFunction(
+      `${testString}error:${identifier}`,
+      debugToUseTestOnly
+    ),
+  }
+}
+
+export const logError = (logger: Logger, message: string, e: Error): void => {
+  logger.error(`${message}. 
+    Error: ${e.message}. 
+    Stack: ${e.stack}`)
+}
+
+/**
+ * Converts one or more items to log into a single line string.
+ *
+ * @param logs The array of items to log
+ * @returns The single-line string.
+ */
+const joinNewLines = (...logs: any[]): string => {
   const stringifiedLogs = []
   for (const l of logs) {
     if (typeof l !== 'string') {
@@ -12,29 +52,26 @@ export const joinNewlinesAndDebug = (...logs: any[]) => {
       stringifiedLogs.push(l)
     }
   }
-  return debug(
-    stringifiedLogs
-      .join(' ')
-      .replace(/\n/g, LOG_NEWLINE_STRING)
-      .replace(/\r/g, LOG_CR_STRING)
-  )
+
+  return stringifiedLogs.join(' ').replace(/\n/g, LOG_NEWLINE_STRING)
 }
 
-export const getLogger = (
+/**
+ * Creates a debug instance with the provided identifier and wraps
+ * its only function in a function that makes the strings to be logged a single
+ * line before calling debug(identifier)(log).
+ *
+ * @param identifier The identifier used to prepend this log
+ * @param debugToUseTestOnly The debug instance to use *should only be used for tests*
+ * @returns The log function for the provided identifier
+ */
+const getLogFunction = (
   identifier: string,
-  isTest: boolean = false
-): Logger => {
-  const testString = isTest ? 'test:' : ''
-  return {
-    debug: joinNewlinesAndDebug(`${testString}debug:${identifier}`),
-    info: joinNewlinesAndDebug(`${testString}info:${identifier}`),
-    warn: joinNewlinesAndDebug(`${testString}warn:${identifier}`),
-    error: joinNewlinesAndDebug(`${testString}error:${identifier}`),
+  debugToUseTestOnly: debug = debug
+): any => {
+  const d = debugToUseTestOnly(identifier)
+  return (...logs: any[]): any => {
+    const singleLine = joinNewLines(...logs)
+    return d(singleLine)
   }
-}
-
-export const logError = (logger: Logger, message: string, e: Error): void => {
-  logger.error(`${message}. 
-    Error: ${e.message}. 
-    Stack: ${e.stack}`)
 }

--- a/packages/core-utils/test/app/log.spec.ts
+++ b/packages/core-utils/test/app/log.spec.ts
@@ -1,0 +1,67 @@
+import { getLogger, logError } from '../../src/app'
+import { Logger } from '../../src/types'
+
+let lastDebug
+const FakeDebug = (identifier) => {
+  return (...logs: any[]) => {
+    lastDebug = `${identifier} ${logs.join(' ')}`
+  }
+}
+
+describe('Logger Tests', () => {
+  let log: Logger
+  beforeEach(() => {
+    log = getLogger('derp', true, FakeDebug)
+    lastDebug = undefined
+  })
+
+  it('logs single line non-error', () => {
+    const logString = '\n test \n'
+    logString
+      .indexOf('\n')
+      .should.eq(0, 'Cannot find newline when it should be at pos 0')
+
+    lastDebug = undefined
+    log.debug(logString)
+    lastDebug.indexOf('\n').should.equal(-1, 'Log line has multiple lines!')
+  })
+
+  it('logs single line error', () => {
+    const e = new Error()
+    e.stack.indexOf('\n').should.be.gt(-1, 'No new line in stack trace!')
+
+    lastDebug = undefined
+    logError(log, `some error`, e)
+    lastDebug.indexOf('\n').should.eq(-1, 'Stack trace has new line!')
+  })
+
+  it('logs objects in single line', () => {
+    const obj = {
+      test: 'yes',
+      question: 'answer',
+      bools: true,
+      numbers: 735,
+      somethingVeryLong:
+        'ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok',
+    }
+    lastDebug = undefined
+    log.debug(obj)
+    lastDebug.indexOf('\n').should.equal(-1, 'Log line has multiple lines!')
+  })
+
+  it('logs many different things in single line', () => {
+    const obj = {
+      test: 'yes',
+      question: 'answer',
+      bools: true,
+      numbers: 735,
+      somethingVeryLong:
+        'ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok',
+    }
+    const e = new Error('some error here')
+    const string = '\n test \n'
+    lastDebug = undefined
+    log.debug(obj, e, string)
+    lastDebug.indexOf('\n').should.equal(-1, 'Log line has multiple lines!')
+  })
+})


### PR DESCRIPTION
## Description
Making logging always log a single line, never multiple. We can easily format after the fact by replacing new line replacements.

## Metadata
### Fixes
- Fixes # [YAS-364](https://optimists.atlassian.net/browse/YAS-364)

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
