### PR TITLE
Hardcodes gas estimates since there's no concept of gas right now

### DIFF
--- a/packages/rollup-full-node/src/app/web3-rpc-handler.ts
+++ b/packages/rollup-full-node/src/app/web3-rpc-handler.ts
@@ -309,29 +309,30 @@ export class DefaultWeb3Handler
         txObject
       )}], defaultBlock: [${defaultBlock}]`
     )
-    // First generate the internalTx calldata
-    const internalCalldata = this.getTransactionCalldata(
-      this.getTimestamp(),
-      0,
-      txObject['to'],
-      txObject['data'],
-      txObject['from'],
-      ZERO_ADDRESS,
-      true
-    )
-
-    log.debug(internalCalldata)
-    // Then estimate the gas
-    const response = await this.context.provider.send(
-      Web3RpcMethods.estimateGas,
-      [
-        {
-          from: this.context.wallet.address,
-          to: this.context.executionManager.address,
-          data: internalCalldata,
-        },
-      ]
-    )
+    // // First generate the internalTx calldata
+    // const internalCalldata = this.getTransactionCalldata(
+    //   this.getTimestamp(),
+    //   0,
+    //   txObject['to'],
+    //   txObject['data'],
+    //   txObject['from'],
+    //   ZERO_ADDRESS,
+    //   true
+    // )
+    //
+    // log.debug(internalCalldata)
+    // // Then estimate the gas
+    // const response = await this.context.provider.send(
+    //   Web3RpcMethods.estimateGas,
+    //   [
+    //     {
+    //       from: this.context.wallet.address,
+    //       to: this.context.executionManager.address,
+    //       data: internalCalldata,
+    //     },
+    //   ]
+    // )
+    const response = `hard-coded return: ${GAS_LIMIT}`
     // TODO: Make sure gas limit is below max
     log.debug(
       `Estimated gas: request: [${JSON.stringify(
@@ -660,8 +661,9 @@ export class DefaultWeb3Handler
       log.debug(
         `Internal tx previously failed for this OVM tx, creating receipt from the OVM tx itself.`
       )
+      ovmTxReceipt = internalTxReceipt
     }
-    const ovmTx = await this.getTransactionByHash(ovmTxReceipt.transactionHash)
+    const ovmTx = await this.getTransactionByHash(ovmTxHash)
     log.debug(`got OVM tx from hash: [${JSON.stringify(ovmTx)}]`)
     ovmTxReceipt.to = ovmTx.to ? ovmTx.to : ovmTxReceipt.to
     ovmTxReceipt.from = ovmTx.from


### PR DESCRIPTION
## Description
Gas estimates are just wasting cycles if there's no such thing as gas, so hard-code the response without actually doing the call.

## Metadata
### Fixes
- Fixes # [YAS-365](https://optimists.atlassian.net/browse/YAS-365)

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
