### PR TITLE
L1 To L2 Transaction Queue

### DIFF
--- a/packages/rollup-contracts/contracts/L1ToL2TransactionQueue.sol
+++ b/packages/rollup-contracts/contracts/L1ToL2TransactionQueue.sol
@@ -1,0 +1,29 @@
+pragma solidity ^0.5.0;
+pragma experimental ABIEncoderV2;
+
+/* Internal Imports */
+import {DataTypes as dt} from "./DataTypes.sol";
+import {RollupMerkleUtils} from "./RollupMerkleUtils.sol";
+import {RollupList} from "./RollupList.sol";
+
+contract L1ToL2TransactionQueue is RollupList {
+  address public l1ToL2TransactionPasser;
+  address public canonicalTransactionChain;
+
+  constructor(
+    address _rollupMerkleUtilsAddress,
+    address _l1ToL2TransactionPasser,
+    address _canonicalTransactionChain
+  ) RollupList(_rollupMerkleUtilsAddress) public {
+    l1ToL2TransactionPasser = _l1ToL2TransactionPasser;
+    canonicalTransactionChain = _canonicalTransactionChain;
+  }
+
+  function authenticateEnqueue(address _sender) public view returns (bool) {
+    return _sender == l1ToL2TransactionPasser;
+  }
+  function authenticateDequeue(address _sender) public view returns (bool) {
+    return _sender == canonicalTransactionChain;
+  }
+  function authenticateDelete(address _sender) public view returns (bool) { return false; }
+}

--- a/packages/rollup-contracts/contracts/RollupList.sol
+++ b/packages/rollup-contracts/contracts/RollupList.sol
@@ -107,7 +107,7 @@ contract RollupList {
   // dequeues all blocks including and before the given block index
   function dequeueBeforeInclusive(uint _blockIndex) public {
     //Check that msg.sender is authorized to delete
-    require(authenticateDequeue(msg.sender), "Message sender does not have permission to dequeue blocks");
+    require(authenticateDequeue(msg.sender), "Message sender does not have permission to dequeue");
     //blockIndex is between first and last blocks
     require(_blockIndex >= front && _blockIndex < blocks.length, "Cannot delete blocks outside of valid range");
     //delete all block headers before and including blockIndex

--- a/packages/rollup-contracts/test/rollup-list/L1ToL2TransactionQueue.spec.ts
+++ b/packages/rollup-contracts/test/rollup-list/L1ToL2TransactionQueue.spec.ts
@@ -80,15 +80,11 @@ describe('L1ToL2TransactionQueue', () => {
     })
     it('should not allow enqueue from other address', async () => {
       const block = ['0x1234']
-      try {
-        await l1ToL2TxQueue.enqueueBlock(block)
-      } catch (err) {
-        // Success we threw an error!
-        return
-      }
-      throw new Error(
-        'Allowed non-l1ToL2TransactionPasser account to enqueue block'
-      )
+      await l1ToL2TxQueue
+        .enqueueBlock(block)
+        .should.be.revertedWith(
+          'VM Exception while processing transaction: revert Message sender does not have permission to enqueue'
+        )
     })
   })
   /*
@@ -137,16 +133,11 @@ describe('L1ToL2TransactionQueue', () => {
         blockIndex,
         cumulativePrevElements
       )
-      try {
-        // delete the single appended block
-        await l1ToL2TxQueue.dequeueBeforeInclusive(blockIndex)
-      } catch (err) {
-        // Success we threw an error!
-        return
-      }
-      throw new Error(
-        'Allowed non-canonicalTransactionChain account to dequeue block'
-      )
+      await l1ToL2TxQueue
+        .dequeueBeforeInclusive(blockIndex)
+        .should.be.revertedWith(
+          'VM Exception while processing transaction: revert Message sender does not have permission to dequeue'
+        )
     })
   })
 })

--- a/packages/rollup-contracts/test/rollup-list/L1ToL2TransactionQueue.spec.ts
+++ b/packages/rollup-contracts/test/rollup-list/L1ToL2TransactionQueue.spec.ts
@@ -8,7 +8,7 @@ import { createMockProvider, deployContract, getWallets } from 'ethereum-waffle'
 import { DefaultRollupBlock } from './RLhelper'
 
 /* Logging */
-const log = getLogger('l1-to-l2-tx-queue')
+const log = getLogger('l1-to-l2-tx-queue', true)
 
 /* Contract Imports */
 import * as L1ToL2TransactionQueue from '../../build/L1ToL2TransactionQueue.json'

--- a/packages/rollup-contracts/test/rollup-list/L1ToL2TransactionQueue.spec.ts
+++ b/packages/rollup-contracts/test/rollup-list/L1ToL2TransactionQueue.spec.ts
@@ -15,7 +15,7 @@ import * as L1ToL2TransactionQueue from '../../build/L1ToL2TransactionQueue.json
 import * as RollupMerkleUtils from '../../build/RollupMerkleUtils.json'
 
 /* Begin tests */
-describe.only('L1ToL2TransactionQueue', () => {
+describe('L1ToL2TransactionQueue', () => {
   const provider = createMockProvider()
   const [
     wallet,

--- a/packages/rollup-contracts/test/rollup-list/L1ToL2TransactionQueue.spec.ts
+++ b/packages/rollup-contracts/test/rollup-list/L1ToL2TransactionQueue.spec.ts
@@ -1,0 +1,152 @@
+import '../setup'
+
+/* External Imports */
+import { getLogger } from '@eth-optimism/core-utils'
+import { createMockProvider, deployContract, getWallets } from 'ethereum-waffle'
+
+/* Internal Imports */
+import { DefaultRollupBlock } from './RLhelper'
+
+/* Logging */
+const log = getLogger('l1-to-l2-tx-queue')
+
+/* Contract Imports */
+import * as L1ToL2TransactionQueue from '../../build/L1ToL2TransactionQueue.json'
+import * as RollupMerkleUtils from '../../build/RollupMerkleUtils.json'
+
+/* Begin tests */
+describe.only('L1ToL2TransactionQueue', () => {
+  const provider = createMockProvider()
+  const [
+    wallet,
+    l1ToL2TransactionPasser,
+    canonicalTransactionChain,
+  ] = getWallets(provider)
+  let l1ToL2TxQueue
+  let rollupMerkleUtils
+
+  /* Link libraries before tests */
+  before(async () => {
+    rollupMerkleUtils = await deployContract(wallet, RollupMerkleUtils, [], {
+      gasLimit: 6700000,
+    })
+  })
+
+  /* Deploy a new RollupChain before each test */
+  beforeEach(async () => {
+    l1ToL2TxQueue = await deployContract(
+      wallet,
+      L1ToL2TransactionQueue,
+      [
+        rollupMerkleUtils.address,
+        l1ToL2TransactionPasser.address,
+        canonicalTransactionChain.address,
+      ],
+      {
+        gasLimit: 6700000,
+      }
+    )
+  })
+
+  const enqueueAndGenerateBlock = async (
+    block: string[],
+    blockIndex: number,
+    cumulativePrevElements: number
+  ): Promise<DefaultRollupBlock> => {
+    // Submit the rollup block on-chain
+    const enqueueTx = await l1ToL2TxQueue
+      .connect(l1ToL2TransactionPasser)
+      .enqueueBlock(block)
+    const txReceipt = await provider.getTransactionReceipt(enqueueTx.hash)
+    // Generate a local version of the rollup block
+    const ethBlockNumber = txReceipt.blockNumber
+    const localBlock = new DefaultRollupBlock(
+      ethBlockNumber,
+      blockIndex,
+      cumulativePrevElements,
+      block
+    )
+    await localBlock.generateTree()
+    return localBlock
+  }
+
+  /*
+   * Test enqueueBlock()
+   */
+  describe('enqueueBlock() ', async () => {
+    it('should allow enqueue from l1ToL2TransactionPasser', async () => {
+      const block = ['0x1234']
+      await l1ToL2TxQueue.connect(l1ToL2TransactionPasser).enqueueBlock(block) // Did not throw... success!
+    })
+    it('should not allow enqueue from other address', async () => {
+      const block = ['0x1234']
+      try {
+        await l1ToL2TxQueue.enqueueBlock(block)
+      } catch (err) {
+        // Success we threw an error!
+        return
+      }
+      throw new Error(
+        'Allowed non-l1ToL2TransactionPasser account to enqueue block'
+      )
+    })
+  })
+  /*
+   * Test dequeueBlock()
+   */
+  describe('dequeueBlock() ', async () => {
+    it('should allow dequeue from canonicalTransactionChain', async () => {
+      const block = ['0x1234']
+      const cumulativePrevElements = 0
+      const blockIndex = 0
+      const localBlock = await enqueueAndGenerateBlock(
+        block,
+        blockIndex,
+        cumulativePrevElements
+      )
+      let blocksLength = await l1ToL2TxQueue.getBlocksLength()
+      log.debug(`blocksLength before deletion: ${blocksLength}`)
+      let front = await l1ToL2TxQueue.front()
+      log.debug(`front before deletion: ${front}`)
+      let firstBlockHash = await l1ToL2TxQueue.blocks(0)
+      log.debug(`firstBlockHash before deletion: ${firstBlockHash}`)
+
+      // delete the single appended block
+      await l1ToL2TxQueue
+        .connect(canonicalTransactionChain)
+        .dequeueBeforeInclusive(blockIndex)
+
+      blocksLength = await l1ToL2TxQueue.getBlocksLength()
+      log.debug(`blocksLength after deletion: ${blocksLength}`)
+      blocksLength.should.equal(1)
+      firstBlockHash = await l1ToL2TxQueue.blocks(0)
+      log.debug(`firstBlockHash after deletion: ${firstBlockHash}`)
+      firstBlockHash.should.equal(
+        '0x0000000000000000000000000000000000000000000000000000000000000000'
+      )
+      front = await l1ToL2TxQueue.front()
+      log.debug(`front after deletion: ${front}`)
+      front.should.equal(1)
+    })
+    it('should not allow dequeue from other address', async () => {
+      const block = ['0x1234']
+      const cumulativePrevElements = 0
+      const blockIndex = 0
+      const localBlock = await enqueueAndGenerateBlock(
+        block,
+        blockIndex,
+        cumulativePrevElements
+      )
+      try {
+        // delete the single appended block
+        await l1ToL2TxQueue.dequeueBeforeInclusive(blockIndex)
+      } catch (err) {
+        // Success we threw an error!
+        return
+      }
+      throw new Error(
+        'Allowed non-canonicalTransactionChain account to dequeue block'
+      )
+    })
+  })
+})


### PR DESCRIPTION
## Description
Implementation of L1ToL2 Transaction Queue. I will eventually separate the RollupList into RollupQueue and RollupStack contracts to clean up this code, but will do so once I implement the rest of the queues/stacks and know what the best way to do that separation is.

## Questions
- Should we move the L1ToL2TransactionPasser into the `rollup-contracts` package?

### Fixes
- Fixes #YAS371

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [X] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
