### PR TITLE
Sequencer Batch Submitter

### DIFF
--- a/packages/rollup-contracts/contracts/SequencerBatchSubmitter.sol
+++ b/packages/rollup-contracts/contracts/SequencerBatchSubmitter.sol
@@ -31,7 +31,7 @@ contract SequencerBatchSubmitter {
   ) public onlySequencer {
     require(_stateBatch.length == _txBatch.length,
       "Must append the same number of state roots and transactions");
-    canonicalTransactionChain.appendTransactionBatch(_txBatch, _txBatchTimestamp);
+    canonicalTransactionChain.appendSequencerBatch(_txBatch, _txBatchTimestamp);
     stateCommitmentChain.appendStateBatch(_stateBatch);
   }
 

--- a/packages/rollup-contracts/contracts/SequencerBatchSubmitter.sol
+++ b/packages/rollup-contracts/contracts/SequencerBatchSubmitter.sol
@@ -7,6 +7,11 @@ import {RollupMerkleUtils} from "./RollupMerkleUtils.sol";
 import {CanonicalTransactionChain} from "./CanonicalTransactionChain.sol";
 import {StateCommitmentChain} from "./StateCommitmentChain.sol";
 
+/**
+ * @title SequencerBatchSubmitter
+ * @notice Helper contract that allows the sequencer to submit both a state commitment batch and tx batch in a single transaction.
+ *         This ensures that # state roots == # of txs, preventing other users from submitting state batches to the state chain.
+ */
 contract SequencerBatchSubmitter {
   CanonicalTransactionChain canonicalTransactionChain;
   StateCommitmentChain stateCommitmentChain;
@@ -24,6 +29,12 @@ contract SequencerBatchSubmitter {
     stateCommitmentChain = StateCommitmentChain(_stateCommitmentChain);
   }
 
+  /**
+   * @notice Append equal sized batches of transactions and state roots to their respective chains
+   * @param _txBatch An array of transactions - // *TODO specify transaction format*
+   * @param _txBatchTimestamp The timestamp that will be submitted with the tx batch - this timestamp will likely lag behind the actual time by a few minutes
+   * @param _stateBatch An array of 32 byte state roots
+   */
   function appendTransitionBatch(
     bytes[] memory _txBatch,
     uint _txBatchTimestamp,

--- a/packages/rollup-contracts/contracts/SequencerBatchSubmitter.sol
+++ b/packages/rollup-contracts/contracts/SequencerBatchSubmitter.sol
@@ -1,0 +1,42 @@
+pragma solidity ^0.5.0;
+pragma experimental ABIEncoderV2;
+
+/* Internal Imports */
+import {DataTypes as dt} from "./DataTypes.sol";
+import {RollupMerkleUtils} from "./RollupMerkleUtils.sol";
+import {CanonicalTransactionChain} from "./CanonicalTransactionChain.sol";
+import {StateCommitmentChain} from "./StateCommitmentChain.sol";
+
+contract SequencerBatchSubmitter {
+  CanonicalTransactionChain canonicalTransactionChain;
+  StateCommitmentChain stateCommitmentChain;
+  address public sequencer;
+
+  constructor(address _sequencer) public {
+    sequencer = _sequencer;
+  }
+
+  function initialize(
+    address _canonicalTransactionChain,
+    address _stateCommitmentChain
+  ) public onlySequencer {
+    canonicalTransactionChain = CanonicalTransactionChain(_canonicalTransactionChain);
+    stateCommitmentChain = StateCommitmentChain(_stateCommitmentChain);
+  }
+
+  function appendTransitionBatch(
+    bytes[] memory _txBatch,
+    uint _txBatchTimestamp,
+    bytes[] memory _stateBatch
+  ) public onlySequencer {
+    require(_stateBatch.length == _txBatch.length,
+      "Must append the same number of state roots and transactions");
+    canonicalTransactionChain.appendTransactionBatch(_txBatch, _txBatchTimestamp);
+    stateCommitmentChain.appendStateBatch(_stateBatch);
+  }
+
+  modifier onlySequencer () {
+    require(msg.sender == sequencer, "Only the sequencer may perform this action");
+    _;
+  }
+}

--- a/packages/rollup-contracts/test/rollup-list/SequencerBatchSubmitter.spec.ts
+++ b/packages/rollup-contracts/test/rollup-list/SequencerBatchSubmitter.spec.ts
@@ -1,0 +1,168 @@
+import '../setup'
+
+/* External Imports */
+import { getLogger, TestUtils } from '@eth-optimism/core-utils'
+import { createMockProvider, deployContract, getWallets } from 'ethereum-waffle'
+import { Contract } from 'ethers'
+
+/* Internal Imports */
+import { StateChainBatch, TxChainBatch } from './RLhelper'
+
+/* Logging */
+const log = getLogger('batch-submitter', true)
+
+/* Contract Imports */
+import * as StateCommitmentChain from '../../build/StateCommitmentChain.json'
+import * as CanonicalTransactionChain from '../../build/CanonicalTransactionChain.json'
+import * as RollupMerkleUtils from '../../build/RollupMerkleUtils.json'
+import * as SequencerBatchSubmitter from '../../build/SequencerBatchSubmitter.json'
+
+/* Begin tests */
+describe('SequencerBatchSubmitter', () => {
+  const provider = createMockProvider()
+  const [
+    wallet,
+    sequencer,
+    l1ToL2TransactionPasser,
+    fraudVerifier,
+    randomWallet,
+  ] = getWallets(provider)
+  let stateChain
+  let canonicalTxChain
+  let rollupMerkleUtils
+  let sequencerBatchSubmitter
+  const DEFAULT_STATE_BATCH = ['0x1234', '0x5678']
+  const DEFAULT_TX_BATCH = ['0xabcd', '0xef12']
+  const FORCE_INCLUSION_PERIOD = 600
+
+  const generateStateBatch = async (
+    batch: string[],
+    batchIndex: number = 0,
+    cumulativePrevElements: number = 0
+  ): Promise<StateChainBatch> => {
+    const localBatch = new StateChainBatch(
+      batchIndex,
+      cumulativePrevElements,
+      batch
+    )
+    await localBatch.generateTree()
+    return localBatch
+  }
+
+  const generateTxBatch = async (
+    batch: string[],
+    timestamp: number,
+    batchIndex: number = 0,
+    cumulativePrevElements: number = 0
+  ): Promise<TxChainBatch> => {
+    const localBatch = new TxChainBatch(
+      timestamp,
+      false,
+      batchIndex,
+      cumulativePrevElements,
+      batch
+    )
+    await localBatch.generateTree()
+    return localBatch
+  }
+
+  before(async () => {
+    rollupMerkleUtils = await deployContract(wallet, RollupMerkleUtils, [], {
+      gasLimit: 6700000,
+    })
+  })
+
+  beforeEach(async () => {
+    sequencerBatchSubmitter = await deployContract(
+      wallet,
+      SequencerBatchSubmitter,
+      [sequencer.address],
+      {
+        gasLimit: 6700000,
+      }
+    )
+
+    canonicalTxChain = await deployContract(
+      wallet,
+      CanonicalTransactionChain,
+      [
+        rollupMerkleUtils.address,
+        sequencerBatchSubmitter.address,
+        l1ToL2TransactionPasser.address,
+        FORCE_INCLUSION_PERIOD,
+      ],
+      {
+        gasLimit: 6700000,
+      }
+    )
+
+    stateChain = await deployContract(
+      wallet,
+      StateCommitmentChain,
+      [
+        rollupMerkleUtils.address,
+        canonicalTxChain.address,
+        fraudVerifier.address,
+      ],
+      {
+        gasLimit: 6700000,
+      }
+    )
+
+    await sequencerBatchSubmitter
+      .connect(sequencer)
+      .initialize(canonicalTxChain.address, stateChain.address)
+  })
+
+  describe('appendTransitionBatch()', async () => {
+    it('should reject appending of transition batches from non-sequencer', async () => {
+      const timestamp = Math.floor(Date.now() / 1000)
+      await TestUtils.assertRevertsAsync(
+        'Only the sequencer may perform this action',
+        async () => {
+          await sequencerBatchSubmitter
+            .connect(randomWallet)
+            .appendTransitionBatch(
+              DEFAULT_TX_BATCH,
+              timestamp,
+              DEFAULT_STATE_BATCH
+            )
+        }
+      )
+    })
+
+    it('should not allow appending differently sized tx and state batches', async () => {
+      const alteredTxBatch = ['0xabcd', '0xef12', '0x3456']
+      const timestamp = Math.floor(Date.now() / 1000)
+      await TestUtils.assertRevertsAsync(
+        'Must append the same number of state roots and transactions',
+        async () => {
+          await sequencerBatchSubmitter
+            .connect(sequencer)
+            .appendTransitionBatch(
+              alteredTxBatch,
+              timestamp,
+              DEFAULT_STATE_BATCH
+            )
+        }
+      )
+    })
+
+    it('should successfully append transition batch from the sequencer', async () => {
+      const timestamp = Math.floor(Date.now() / 1000)
+      const localTxBatch = await generateTxBatch(DEFAULT_TX_BATCH, timestamp)
+      const localStateBatch = await generateStateBatch(DEFAULT_STATE_BATCH)
+      await sequencerBatchSubmitter
+        .connect(sequencer)
+        .appendTransitionBatch(DEFAULT_TX_BATCH, timestamp, DEFAULT_STATE_BATCH)
+
+      const expectedTxBatchHeaderHash = await localTxBatch.hashBatchHeader()
+      const calculatedTxBatchHeaderHash = await canonicalTxChain.batches(0)
+      calculatedTxBatchHeaderHash.should.equal(expectedTxBatchHeaderHash)
+
+      const expectedStateBatchHeaderHash = await localStateBatch.hashBatchHeader()
+      const calculatedStateBatchHeaderHash = await stateChain.batches(0)
+      calculatedStateBatchHeaderHash.should.equal(expectedStateBatchHeaderHash)
+    })
+  })
+})


### PR DESCRIPTION
## Description
Helper contract that allows the sequencer to submit both a state commitment batch and tx batch in a single transaction. This is the contract that will be whitelisted for instant submission to the CanonicalTransactionChain.

NOTE: This PR builds off of #143  

### Fixes
- Fixes #YAS-408

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [X] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
