### PR TITLE
Add CHAINID and SELFBALANCE opcodes

### DIFF
--- a/packages/ovm/config/.env.example
+++ b/packages/ovm/config/.env.example
@@ -24,7 +24,7 @@ DEPLOY_LOCAL_URL='http://127.0.0.1:8545'
 ### OPTIONAL ###
 
 # Will be defaulted to this value if not overridden -- you should not set this unless you know what you're doing.
-OPCODE_WHITELIST_MASK='0x600a0000000000000000001fffffffffffffffff0fcf000063f000013fff0fff'
+OPCODE_WHITELIST_MASK='0x600a0000000000000000001fffffffffffffffff0fcf004063f000013fff0fff'
 # Default whitelist config whitelists all opcodes EXCEPT:
 #    ADDRESS, BALANCE, BLOCKHASH, CALLCODE, CALLER, COINBASE,
 #    CREATE, CREATE2, DELEGATECALL, DIFFICULTY, EXTCODECOPY, EXTCODESIZE,

--- a/packages/ovm/deploy/safety-checker.ts
+++ b/packages/ovm/deploy/safety-checker.ts
@@ -17,8 +17,7 @@ const safetyCheckerDeploymentFunction = async (
     console.log(`\nDeploying Safety Checker!\n`)
 
     // See test/contracts/whitelist-mask-generator.spec.ts for more info
-    const whitelistMask =
-      process.env.OPCODE_WHITELIST_MASK
+    const whitelistMask = process.env.OPCODE_WHITELIST_MASK
 
     const executionManagerAddress =
       process.env.EXECUTION_MANAGER_ADDRESS || add0x('12'.repeat(20))

--- a/packages/ovm/deploy/safety-checker.ts
+++ b/packages/ovm/deploy/safety-checker.ts
@@ -16,15 +16,9 @@ const safetyCheckerDeploymentFunction = async (
   if (!safetyCheckerContractAddress) {
     console.log(`\nDeploying Safety Checker!\n`)
 
-    // Default config whitelists all opcodes EXCEPT:
-    //    ADDRESS, BALANCE, BLOCKHASH, CALLCODE, CALLER, COINBASE,
-    //    CREATE, CREATE2, DELEGATECALL, DIFFICULTY, EXTCODECOPY, EXTCODESIZE,
-    //    GASLIMIT, GASPRICE, NUMBER, ORIGIN, SELFDESTRUCT, SLOAD, SSTORE,
-    //    STATICCALL, TIMESTAMP
     // See test/contracts/whitelist-mask-generator.spec.ts for more info
     const whitelistMask =
-      process.env.OPCODE_WHITELIST_MASK ||
-      '0x600a0000000000000000001fffffffffffffffff0fcf000063f000013fff0fff'
+      process.env.OPCODE_WHITELIST_MASK
 
     const executionManagerAddress =
       process.env.EXECUTION_MANAGER_ADDRESS || add0x('12'.repeat(20))

--- a/packages/ovm/test/contracts/whitelist-mask-generator.spec.ts
+++ b/packages/ovm/test/contracts/whitelist-mask-generator.spec.ts
@@ -2,35 +2,14 @@
 import { BigNumber, ZERO } from '@eth-optimism/core-utils'
 
 /* Internal Imports */
-import { EVMOpcode, Opcode } from '@eth-optimism/rollup-core'
-
-const excludedOpCodes: EVMOpcode[] = [
-  Opcode.ADDRESS,
-  Opcode.BALANCE,
-  Opcode.BLOCKHASH,
-  Opcode.CALLCODE,
-  Opcode.CALLER,
-  Opcode.COINBASE,
-  Opcode.CREATE,
-  Opcode.CREATE2,
-  Opcode.DELEGATECALL,
-  Opcode.DIFFICULTY,
-  Opcode.EXTCODESIZE,
-  Opcode.EXTCODECOPY,
-  Opcode.EXTCODEHASH,
-  Opcode.GASLIMIT,
-  Opcode.GASPRICE,
-  Opcode.NUMBER,
-  Opcode.ORIGIN,
-  Opcode.SELFDESTRUCT,
-  Opcode.SLOAD,
-  Opcode.SSTORE,
-  Opcode.STATICCALL,
-  Opcode.TIMESTAMP,
-]
+import {
+  EVMOpcode,
+  Opcode,
+  DEFAULT_UNSAFE_OPCODES,
+} from '@eth-optimism/rollup-core'
 
 const whitelistedOpcodes: EVMOpcode[] = Opcode.ALL_OP_CODES.filter(
-  (x) => excludedOpCodes.indexOf(x) < 0
+  (x) => DEFAULT_UNSAFE_OPCODES.indexOf(x) < 0
 )
 
 // TODO: Uncomment this to generate a new whitelist mask

--- a/packages/rollup-core/src/app/constants.ts
+++ b/packages/rollup-core/src/app/constants.ts
@@ -1,14 +1,43 @@
-export const L1ToL2TransactionEventName = 'L1ToL2Transaction'
-
 import { ZERO_ADDRESS } from '@eth-optimism/core-utils'
+import { EVMOpcode, Opcode } from '../types'
+
+export const L1ToL2TransactionEventName = 'L1ToL2Transaction'
 
 export const CREATOR_CONTRACT_ADDRESS = ZERO_ADDRESS
 export const GAS_LIMIT = 1_000_000_000
 export const DEFAULT_ETHNODE_GAS_LIMIT = 9_000_000
 
 export const CHAIN_ID = 108
+
+export const DEFAULT_UNSAFE_OPCODES: EVMOpcode[] = [
+  Opcode.ADDRESS,
+  Opcode.BALANCE,
+  Opcode.BLOCKHASH,
+  Opcode.CALLCODE,
+  Opcode.CALLER,
+  Opcode.COINBASE,
+  Opcode.CREATE,
+  Opcode.CREATE2,
+  Opcode.DELEGATECALL,
+  Opcode.DIFFICULTY,
+  Opcode.EXTCODESIZE,
+  Opcode.EXTCODECOPY,
+  Opcode.EXTCODEHASH,
+  Opcode.GASLIMIT,
+  Opcode.GASPRICE,
+  Opcode.NUMBER,
+  Opcode.ORIGIN,
+  Opcode.SELFBALANCE,
+  Opcode.SELFDESTRUCT,
+  Opcode.SLOAD,
+  Opcode.SSTORE,
+  Opcode.STATICCALL,
+  Opcode.TIMESTAMP,
+]
+
+// use whitelist-mask-generator.spec.ts to re-generate this
 export const DEFAULT_OPCODE_WHITELIST_MASK =
-  '0x600a0000000000000000001fffffffffffffffff0fcf000063f000013fff0fff'
+  '0x600a0000000000000000001fffffffffffffffff0fcf004063f000013fff0fff'
 
 export const L2_TO_L1_MESSAGE_PASSER_OVM_ADDRESS =
   '0x4200000000000000000000000000000000000000'

--- a/packages/rollup-core/src/types/opcodes.ts
+++ b/packages/rollup-core/src/types/opcodes.ts
@@ -285,6 +285,16 @@ export class Opcode {
     name: 'GASLIMIT',
     programBytesConsumed: 0,
   }
+  public static readonly CHAINID: EVMOpcode = {
+    code: Buffer.from('46', 'hex'),
+    name: 'CHAINID',
+    programBytesConsumed: 0,
+  }
+  public static readonly SELFBALANCE: EVMOpcode = {
+    code: Buffer.from('47', 'hex'),
+    name: 'SELFBALANCE',
+    programBytesConsumed: 0,
+  }
 
   // gap
 
@@ -812,6 +822,8 @@ export class Opcode {
     Opcode.NUMBER,
     Opcode.DIFFICULTY,
     Opcode.GASLIMIT,
+    Opcode.CHAINID,
+    Opcode.SELFBALANCE,
 
     Opcode.POP,
     Opcode.MLOAD,

--- a/packages/rollup-dev-tools/src/tools/transpiler/opcode-whitelist.ts
+++ b/packages/rollup-dev-tools/src/tools/transpiler/opcode-whitelist.ts
@@ -45,6 +45,7 @@ const defaultWhitelist: EVMOpcode[] = [
   Opcode.CALLDATASIZE,
   Opcode.CALLER,
   Opcode.CALLVALUE,
+  Opcode.CHAINID,
   Opcode.CODECOPY,
   Opcode.CODESIZE,
   Opcode.CREATE,


### PR DESCRIPTION
## Description
`CHAINID`, opcode `0x46` was added in the Istanbul hard fork and is used in Uniswap V2- update opcode types to add this opcode and whitelist it in both the SafetyChecker and Transpiler. Also adds the other opcode added in the hard fork, `SELFBALANCE`, `0x47` - this should be blacklisted for both the Transpiler and SafetyChecker

## Metadata
Note, CHAINID still needs to be transpiled - this is listed as YAS-414
### Fixes
- Fixes #YAS-413

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [X] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
