### PR TITLE
Better utils for creating OVM Providers

### DIFF
--- a/packages/rollup-full-node/src/app/utils.ts
+++ b/packages/rollup-full-node/src/app/utils.ts
@@ -66,9 +66,8 @@ export async function addHandlerToProvider(provider: any): Promise<any> {
   return provider
 }
 
-export async function createMockProvider(
-  messageSubmitter: L2ToL1MessageSubmitter = new NoOpL2ToL1MessageSubmitter()
-) {
+export async function createMockProvider() {
+  const messageSubmitter = new NoOpL2ToL1MessageSubmitter()
   const fullnodeHandler = await DefaultWeb3Handler.create(messageSubmitter)
   const web3Provider = createProviderForHandler(fullnodeHandler)
 

--- a/packages/rollup-full-node/src/app/utils.ts
+++ b/packages/rollup-full-node/src/app/utils.ts
@@ -46,11 +46,11 @@ export const createProviderForHandler = (
  * @param provider The provider to modify
  * @return The provider with modified `send`s
  */
-export async function addHandlerToProvider(
-  provider: any,
-): Promise<any> {
+export async function addHandlerToProvider(provider: any): Promise<any> {
   const messageSubmitter: L2ToL1MessageSubmitter = new NoOpL2ToL1MessageSubmitter()
-  const fullnodeHandler: FullnodeHandler = await DefaultWeb3Handler.create(messageSubmitter)
+  const fullnodeHandler: FullnodeHandler = await DefaultWeb3Handler.create(
+    messageSubmitter
+  )
   // Then we replace `send()` with our modified send that uses the execution manager as a proxy
   provider.send = async (method: string, params: any) => {
     log.debug('Sending -- Method:', method, 'Params:', params)

--- a/packages/rollup-full-node/src/app/utils.ts
+++ b/packages/rollup-full-node/src/app/utils.ts
@@ -13,6 +13,24 @@ import { FullnodeRpcServer } from './fullnode-rpc-server'
 
 const log = getLogger('utils')
 
+const balance = '10000000000000000000000000000000000';
+
+const privateKeys = [
+  '0x29f3edee0ad3abf8e2699402e0e28cd6492c9be7eaab00d732a791c33552f797',
+  '0x5c8b9227cd5065c7e3f6b73826b8b42e198c4497f6688e3085d5ab3a6d520e74',
+  '0x50c8b3fc81e908501c8cd0a60911633acaca1a567d1be8e769c5ae7007b34b23',
+  '0x706618637b8ca922f6290ce1ecd4c31247e9ab75cf0530a0ac95c0332173d7c5',
+  '0xe217d63f0be63e8d127815c7f26531e649204ab9486b134ec1a0ae9b0fee6bcf',
+  '0x8101cca52cd2a6d8def002ffa2c606f05e109716522ca2440b2cc84e4d49700b',
+  '0x837fd366bc7402b65311de9940de0d6c0ba3125629b8509aebbfb057ebeaaa25',
+  '0xba35c32f7cbda6a6cedeea5f73ff928d1e41557eddfd457123f6426a43adb1e4',
+  '0x71f7818582e55456cb575eea3d0ce408dcf4cbbc3d845e86a7936d2f48f74035',
+  '0x03c909455dcef4e1e981a21ffb14c1c51214906ce19e8e7541921b758221b5ae'
+];
+
+const defaultAccounts = privateKeys
+  .map(secretKey => ({balance, secretKey}));
+
 /**
  * Creates a Provider that uses the provided handler to handle `send`s.
  *
@@ -40,6 +58,22 @@ export const createProviderForHandler = (
   return provider
 }
 
+class MockProvider extends providers.Web3Provider {
+  private fullnodeRpcServer
+  constructor(httpProvider, _fullnodeRpcServer) {
+    super(httpProvider);
+    this.fullnodeRpcServer = _fullnodeRpcServer
+  }
+
+  getWallets() {
+    const items = defaultAccounts;
+    return items.map((x: any) => new Wallet(x.secretKey, this));
+  }
+  closeOVM() {
+    if (!!this.fullnodeRpcServer) this.fullnodeRpcServer.close()
+  }
+}
+
 export async function createMockProvider(
   port: number = 9999,
   messageSubmitter: L2ToL1MessageSubmitter = new NoOpL2ToL1MessageSubmitter()
@@ -50,12 +84,9 @@ export async function createMockProvider(
   fullnodeRpcServer.listen()
   const baseUrl = `http://${host}:${port}`
   const httpProvider = new providers.JsonRpcProvider(baseUrl)
-  httpProvider['closeOVM'] = () => {
-    if (!!fullnodeRpcServer) {
-      fullnodeRpcServer.close()
-    }
-  }
-  return httpProvider
+  const web3Provider = new MockProvider(httpProvider, fullnodeRpcServer)
+
+  return web3Provider
 }
 
 const defaultDeployOptions = {

--- a/packages/rollup-full-node/src/app/utils.ts
+++ b/packages/rollup-full-node/src/app/utils.ts
@@ -13,24 +13,6 @@ import { FullnodeRpcServer } from './fullnode-rpc-server'
 
 const log = getLogger('utils')
 
-const balance = '10000000000000000000000000000000000';
-
-const privateKeys = [
-  '0x29f3edee0ad3abf8e2699402e0e28cd6492c9be7eaab00d732a791c33552f797',
-  '0x5c8b9227cd5065c7e3f6b73826b8b42e198c4497f6688e3085d5ab3a6d520e74',
-  '0x50c8b3fc81e908501c8cd0a60911633acaca1a567d1be8e769c5ae7007b34b23',
-  '0x706618637b8ca922f6290ce1ecd4c31247e9ab75cf0530a0ac95c0332173d7c5',
-  '0xe217d63f0be63e8d127815c7f26531e649204ab9486b134ec1a0ae9b0fee6bcf',
-  '0x8101cca52cd2a6d8def002ffa2c606f05e109716522ca2440b2cc84e4d49700b',
-  '0x837fd366bc7402b65311de9940de0d6c0ba3125629b8509aebbfb057ebeaaa25',
-  '0xba35c32f7cbda6a6cedeea5f73ff928d1e41557eddfd457123f6426a43adb1e4',
-  '0x71f7818582e55456cb575eea3d0ce408dcf4cbbc3d845e86a7936d2f48f74035',
-  '0x03c909455dcef4e1e981a21ffb14c1c51214906ce19e8e7541921b758221b5ae'
-];
-
-const defaultAccounts = privateKeys
-  .map(secretKey => ({balance, secretKey}));
-
 /**
  * Creates a Provider that uses the provided handler to handle `send`s.
  *
@@ -58,33 +40,13 @@ export const createProviderForHandler = (
   return provider
 }
 
-class MockProvider extends providers.Web3Provider {
-  private fullnodeRpcServer
-  constructor(httpProvider, _fullnodeRpcServer) {
-    super(httpProvider);
-    this.fullnodeRpcServer = _fullnodeRpcServer
-  }
-
-  getWallets() {
-    const items = defaultAccounts;
-    return items.map((x: any) => new Wallet(x.secretKey, this));
-  }
-  closeOVM() {
-    if (!!this.fullnodeRpcServer) this.fullnodeRpcServer.close()
-  }
-}
-
 export async function createMockProvider(
   port: number = 9999,
   messageSubmitter: L2ToL1MessageSubmitter = new NoOpL2ToL1MessageSubmitter()
 ) {
   const host = '0.0.0.0'
   const fullnodeHandler = await DefaultWeb3Handler.create(messageSubmitter)
-  const fullnodeRpcServer = new FullnodeRpcServer(fullnodeHandler, host, port)
-  fullnodeRpcServer.listen()
-  const baseUrl = `http://${host}:${port}`
-  const httpProvider = new providers.JsonRpcProvider(baseUrl)
-  const web3Provider = new MockProvider(httpProvider, fullnodeRpcServer)
+  const web3Provider = createProviderForHandler(fullnodeHandler)
 
   return web3Provider
 }

--- a/packages/test-ERC20-Waffle/test/erc20.spec.js
+++ b/packages/test-ERC20-Waffle/test/erc20.spec.js
@@ -15,7 +15,6 @@ describe('ERC20 smart contract', () => {
     wallet = wallets[0]
     walletTo = wallets[1]
   })
-  after(() => {provider.closeOVM()}) 
   // parameters to use for our test coin
   const COIN_NAME = 'OVM Test Coin'
   const TICKER = 'OVM'

--- a/packages/test-ovm-full-node/test/library-support.spec.ts
+++ b/packages/test-ovm-full-node/test/library-support.spec.ts
@@ -58,7 +58,7 @@ describe('Library usage tests', () => {
   beforeEach(async function() {
     // NOTE: if we run this test in isolation on default port, it works, but in multi-package tests it fails.
     // Hypothesis for why this is: multi-package tests are run in parallel, so we need to use a separate port per package.
-    provider = await createMockProvider(9998)
+    provider = await createMockProvider()
     const wallets = getWallets(provider)
     wallet = wallets[0]
 
@@ -103,9 +103,6 @@ describe('Library usage tests', () => {
     // Deploy library user
     deployedLibUser = await deployContract(wallet, libUserJSON, [], [])
     log.debug(`deployed library user to: ${deployedLibUser.address}`)
-  })
-  afterEach(async () => {
-    await provider.closeOVM()
   })
 
   it('should allow us to transpile, link, and query contract methods which use a single library', async () => {


### PR DESCRIPTION
## Description
Adds a function `addHandlerToProvider`, which allows the shimming of `send` of any provider, so they are processed by the OVM `fullNodeHandler`. 
Also, cleans up the `createMockProvider` function.

## Questions
We could just get rid of createMockProvider and instead enforce anyone who uses waffle to just create their own provider and call `addHandlerToProvider(provider)`. Thoughts?

## Metadata
### Fixes
- Fixes #YAS-419

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [X] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
