### PR TITLE
Fix Event Parsing

### DIFF
--- a/packages/contracts/contracts/optimistic-ethereum/ovm/ExecutionManager.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/ovm/ExecutionManager.sol
@@ -734,7 +734,7 @@ contract ExecutionManager {
 
         // switch the context to the _targetOvmContractAddress
         (address oldMsgSender, address oldActiveContract) = switchActiveContract(_targetOvmContractAddress);
-        address codeAddress = stateManager.getCodeContractAddress(_targetOvmContractAddress);
+        address codeAddress = stateManager.getCodeContractAddressFromOvmAddress(_targetOvmContractAddress);
 
         bytes memory returnData;
         uint returnSize;
@@ -804,7 +804,7 @@ contract ExecutionManager {
 
         // switch the context to the _targetOvmContractAddress
         (address oldMsgSender, address oldActiveContract) = switchActiveContract(_targetOvmContractAddress);
-        address codeAddress = stateManager.getCodeContractAddress(_targetOvmContractAddress);
+        address codeAddress = stateManager.getCodeContractAddressFromOvmAddress(_targetOvmContractAddress);
 
         bytes memory returnData;
         uint returnSize;
@@ -869,7 +869,7 @@ contract ExecutionManager {
 
         address _targetOvmContractAddress = address(bytes20(_targetOvmContractAddressBytes));
         // NOTE: WE DO NOT SWITCH CONTEXTS HERE.
-        address codeAddress = stateManager.getCodeContractAddress(_targetOvmContractAddress);
+        address codeAddress = stateManager.getCodeContractAddressFromOvmAddress(_targetOvmContractAddress);
 
         // make the call
         assembly {
@@ -971,7 +971,7 @@ contract ExecutionManager {
         }
 
         address _targetOvmContractAddress = address(bytes20(_targetAddressBytes));
-        address codeContractAddress = stateManager.getCodeContractAddress(_targetOvmContractAddress);
+        address codeContractAddress = stateManager.getCodeContractAddressFromOvmAddress(_targetOvmContractAddress);
 
         assembly {
             let sizeBytes := mload(0x40)
@@ -997,7 +997,7 @@ contract ExecutionManager {
         }
 
         address _targetOvmContractAddress = address(bytes20(_targetAddressBytes));
-        address codeContractAddress = stateManager.getCodeContractAddress(_targetOvmContractAddress);
+        address codeContractAddress = stateManager.getCodeContractAddressFromOvmAddress(_targetOvmContractAddress);
 
         // TODO: Replace `getCodeContractHash(...) with `getOvmContractHash(...)
         bytes32 hash = stateManager.getCodeContractHash(codeContractAddress);
@@ -1034,7 +1034,7 @@ contract ExecutionManager {
         }
 
         address _targetOvmContractAddress = address(bytes20(_targetAddressBytes));
-        address codeContractAddress = stateManager.getCodeContractAddress(_targetOvmContractAddress);
+        address codeContractAddress = stateManager.getCodeContractAddressFromOvmAddress(_targetOvmContractAddress);
 
         assembly {
             let codeContractBytecode := mload(0x40)

--- a/packages/contracts/contracts/optimistic-ethereum/ovm/FullStateManager.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/ovm/FullStateManager.sol
@@ -19,8 +19,8 @@ contract FullStateManager is StateManager {
 
     mapping(address=>mapping(bytes32=>bytes32)) ovmContractStorage;
     mapping(address=>uint) ovmContractNonces;
-    mapping(address=>address) codeContractOf;
-    mapping(address=>address) ovmContractOf;
+    mapping(address=>address) ovmAddressToCodeContractAddress;
+    mapping(address=>address) codeContractAddressToOvmAddress;
 
 
     /*
@@ -112,8 +112,8 @@ contract FullStateManager is StateManager {
         address _ovmContractAddress,
         address _codeContractAddress
     ) public {
-        codeContractOf[_ovmContractAddress] = _codeContractAddress;
-        ovmContractOf[_codeContractAddress] = _ovmContractAddress;
+        ovmAddressToCodeContractAddress[_ovmContractAddress] = _codeContractAddress;
+        codeContractAddressToOvmAddress[_codeContractAddress] = _ovmContractAddress;
     }
 
     /**
@@ -121,10 +121,10 @@ contract FullStateManager is StateManager {
      * @param _ovmContractAddress The address of the OVM contract.
      * @return The associated code contract address.
      */
-    function getCodeContractAddress(
+    function getCodeContractAddressFromOvmAddress(
         address _ovmContractAddress
     ) public view returns (address) {
-        return codeContractOf[_ovmContractAddress];
+        return ovmAddressToCodeContractAddress[_ovmContractAddress];
     }
 
     /**
@@ -132,10 +132,10 @@ contract FullStateManager is StateManager {
      * @param _codeContractAddress The address of the code contract.
      * @return The associated OVM contract address.
      */
-    function getOvmContractAddress(
+    function getOvmAddressFromCodeContractAddress(
         address _codeContractAddress
     ) public view returns (address) {
-        return ovmContractOf[_codeContractAddress];
+        return codeContractAddressToOvmAddress[_codeContractAddress];
     }
 
     /**

--- a/packages/contracts/contracts/optimistic-ethereum/ovm/FullStateManager.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/ovm/FullStateManager.sol
@@ -19,7 +19,8 @@ contract FullStateManager is StateManager {
 
     mapping(address=>mapping(bytes32=>bytes32)) ovmContractStorage;
     mapping(address=>uint) ovmContractNonces;
-    mapping(address=>address) ovmCodeContracts;
+    mapping(address=>address) codeContractOf;
+    mapping(address=>address) ovmContractOf;
 
 
     /*
@@ -111,7 +112,8 @@ contract FullStateManager is StateManager {
         address _ovmContractAddress,
         address _codeContractAddress
     ) public {
-        ovmCodeContracts[_ovmContractAddress] = _codeContractAddress;
+        codeContractOf[_ovmContractAddress] = _codeContractAddress;
+        ovmContractOf[_codeContractAddress] = _ovmContractAddress;
     }
 
     /**
@@ -122,7 +124,18 @@ contract FullStateManager is StateManager {
     function getCodeContractAddress(
         address _ovmContractAddress
     ) public view returns (address) {
-        return ovmCodeContracts[_ovmContractAddress];
+        return codeContractOf[_ovmContractAddress];
+    }
+
+    /**
+     * @notice Lookup the OVM contract for some code contract
+     * @param _codeContractAddress The address of the code contract.
+     * @return The associated OVM contract address.
+     */
+    function getOvmContractAddress(
+        address _codeContractAddress
+    ) public view returns (address) {
+        return ovmContractOf[_codeContractAddress];
     }
 
     /**

--- a/packages/contracts/contracts/optimistic-ethereum/ovm/PartialStateManager.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/ovm/PartialStateManager.sol
@@ -19,7 +19,7 @@ contract PartialStateManager {
 
     mapping(address=>mapping(bytes32=>bytes32)) ovmContractStorage;
     mapping(address=>uint) ovmContractNonces;
-    mapping(address=>address) codeContractOf;
+    mapping(address=>address) ovmAddressToCodeContractAddress;
 
     bool public existsInvalidStateAccessFlag;
 
@@ -90,7 +90,7 @@ contract PartialStateManager {
     ) external onlyStateTransitioner {
         isVerifiedContract[_ovmContractAddress] = true;
         ovmContractNonces[_ovmContractAddress] = _nonce;
-        codeContractOf[_ovmContractAddress] = _codeContractAddress;
+        ovmAddressToCodeContractAddress[_ovmContractAddress] = _codeContractAddress;
     }
 
     /*****************
@@ -243,7 +243,7 @@ contract PartialStateManager {
         address _ovmContractAddress,
         address _codeContractAddress
     ) onlyExecutionManager public {
-        codeContractOf[_ovmContractAddress] = _codeContractAddress;
+        ovmAddressToCodeContractAddress[_ovmContractAddress] = _codeContractAddress;
     }
 
     /**
@@ -251,12 +251,12 @@ contract PartialStateManager {
      * @param _ovmContractAddress The address of the OVM contract.
      * @return The associated code contract address.
      */
-    function getCodeContractAddress(
+    function getCodeContractAddressFromOvmAddress(
         address _ovmContractAddress
     ) onlyExecutionManager public returns(address) {
         flagIfNotVerifiedContract(_ovmContractAddress);
 
-        return codeContractOf[_ovmContractAddress];
+        return ovmAddressToCodeContractAddress[_ovmContractAddress];
     }
 
     /**
@@ -270,7 +270,7 @@ contract PartialStateManager {
     ) public view returns (bytes memory codeContractBytecode) {
         // NOTE: We don't need to verify that this is an authenticated contract
         // because this will always be proceeded by a call to
-        // getCodeContractAddress(address _ovmContractAddress) in the EM which does this check.
+        // getCodeContractAddressFromOvmAddress(address _ovmContractAddress) in the EM which does this check.
 
         assembly {
             // retrieve the size of the code
@@ -297,7 +297,7 @@ contract PartialStateManager {
     ) public view returns (bytes32 _codeContractHash) {
         // NOTE: We don't need to verify that this is an authenticated contract
         // because this will always be proceeded by a call to
-        // getCodeContractAddress(address _ovmContractAddress) in the EM which does this check.
+        // getCodeContractAddressFromOvmAddress(address _ovmContractAddress) in the EM which does this check.
 
         // TODO: Use EXTCODEHASH instead of this really inefficient stuff.
         bytes memory codeContractBytecode = getCodeContractBytecode(_codeContractAddress);

--- a/packages/contracts/contracts/optimistic-ethereum/ovm/PartialStateManager.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/ovm/PartialStateManager.sol
@@ -19,7 +19,7 @@ contract PartialStateManager {
 
     mapping(address=>mapping(bytes32=>bytes32)) ovmContractStorage;
     mapping(address=>uint) ovmContractNonces;
-    mapping(address=>address) ovmCodeContracts;
+    mapping(address=>address) codeContractOf;
 
     bool public existsInvalidStateAccessFlag;
 
@@ -90,7 +90,7 @@ contract PartialStateManager {
     ) external onlyStateTransitioner {
         isVerifiedContract[_ovmContractAddress] = true;
         ovmContractNonces[_ovmContractAddress] = _nonce;
-        ovmCodeContracts[_ovmContractAddress] = _codeContractAddress;
+        codeContractOf[_ovmContractAddress] = _codeContractAddress;
     }
 
     /*****************
@@ -243,7 +243,7 @@ contract PartialStateManager {
         address _ovmContractAddress,
         address _codeContractAddress
     ) onlyExecutionManager public {
-        ovmCodeContracts[_ovmContractAddress] = _codeContractAddress;
+        codeContractOf[_ovmContractAddress] = _codeContractAddress;
     }
 
     /**
@@ -256,7 +256,7 @@ contract PartialStateManager {
     ) onlyExecutionManager public returns(address) {
         flagIfNotVerifiedContract(_ovmContractAddress);
 
-        return ovmCodeContracts[_ovmContractAddress];
+        return codeContractOf[_ovmContractAddress];
     }
 
     /**

--- a/packages/contracts/contracts/optimistic-ethereum/ovm/StateManager.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/ovm/StateManager.sol
@@ -19,8 +19,8 @@ contract StateManager {
 
     // Contract code storage / contract address retrieval
     function associateCodeContract(address _ovmContractAddress, address _codeContractAddress) public;
-    function getCodeContractAddress(address _ovmContractAddress) external view returns(address);
-    function getOvmContractAddress(address _codeContractAddress) external view returns(address);
+    function getCodeContractAddressFromOvmAddress(address _ovmContractAddress) external view returns(address);
+    function getOvmAddressFromCodeContractAddress(address _codeContractAddress) external view returns(address);
     function getCodeContractBytecode(
         address _codeContractAddress
     ) public view returns (bytes memory codeContractBytecode);

--- a/packages/contracts/contracts/optimistic-ethereum/ovm/StateManager.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/ovm/StateManager.sol
@@ -20,6 +20,7 @@ contract StateManager {
     // Contract code storage / contract address retrieval
     function associateCodeContract(address _ovmContractAddress, address _codeContractAddress) public;
     function getCodeContractAddress(address _ovmContractAddress) external view returns(address);
+    function getOvmContractAddress(address _codeContractAddress) external view returns(address);
     function getCodeContractBytecode(
         address _codeContractAddress
     ) public view returns (bytes memory codeContractBytecode);

--- a/packages/rollup-full-node/src/app/utils.ts
+++ b/packages/rollup-full-node/src/app/utils.ts
@@ -176,7 +176,7 @@ export const convertInternalLogsToOvmLogs = async (
         )
       }
     } else {
-      const ovmContractAddress = await context.stateManager.getOvmContractAddress(
+      const ovmContractAddress = await context.stateManager.getOvmAddressFromCodeContractAddress(
         log.address
       )
       const newIndex = log.logIndex - numberOfEMLogs

--- a/packages/rollup-full-node/src/app/utils.ts
+++ b/packages/rollup-full-node/src/app/utils.ts
@@ -161,8 +161,7 @@ export const convertInternalLogsToOvmLogs = async (
   const ovmLogs = []
   let numberOfEMLogs = 0
   let prevEMLogIndex = 0
-  for (let i = 0; i < logs.length; i++){
-    const log: Log = logs[i]
+  for (const log of logs) {
     if (log.address.toUpperCase() === uppercaseExecutionMangerAddress) {
       if (log.logIndex <= prevEMLogIndex) {
         // This indicates a new TX, so reset number of EM logs to 0
@@ -177,7 +176,9 @@ export const convertInternalLogsToOvmLogs = async (
         )
       }
     } else {
-      const ovmContractAddress = await context.stateManager.getOvmContractAddress(log.address)
+      const ovmContractAddress = await context.stateManager.getOvmContractAddress(
+        log.address
+      )
       const newIndex = log.logIndex - numberOfEMLogs
       ovmLogs.push({
         ...log,

--- a/packages/rollup-full-node/src/app/web3-rpc-handler.ts
+++ b/packages/rollup-full-node/src/app/web3-rpc-handler.ts
@@ -550,9 +550,7 @@ export class DefaultWeb3Handler implements Web3Handler, FullnodeHandler {
     ])
 
     let logs = JSON.parse(
-      JSON.stringify(
-        convertInternalLogsToOvmLogs(res, this.context.executionManager.address)
-      )
+      JSON.stringify(await convertInternalLogsToOvmLogs(res, this.context))
     )
     log.debug(
       `Log result: [${JSON.stringify(logs)}], filter: [${JSON.stringify(

--- a/packages/rollup-full-node/src/app/web3-rpc-handler.ts
+++ b/packages/rollup-full-node/src/app/web3-rpc-handler.ts
@@ -490,7 +490,7 @@ export class DefaultWeb3Handler implements Web3Handler, FullnodeHandler {
       `Getting code for address: [${address}], defaultBlock: [${defaultBlock}]`
     )
     // First get the code contract address at the requested OVM address
-    const codeContractAddress = await this.context.stateManager.getCodeContractAddress(
+    const codeContractAddress = await this.context.stateManager.getCodeContractAddressFromOvmAddress(
       address
     )
     const response = await this.context.provider.send(Web3RpcMethods.getCode, [
@@ -517,7 +517,9 @@ export class DefaultWeb3Handler implements Web3Handler, FullnodeHandler {
       const codeContractAddresses = []
       for (const address of filter['address']) {
         codeContractAddresses.push(
-          await this.context.stateManager.getCodeContractAddress(address)
+          await this.context.stateManager.getCodeContractAddressFromOvmAddress(
+            address
+          )
         )
       }
       filter['address'] = [

--- a/packages/rollup-full-node/src/app/web3-rpc-handler.ts
+++ b/packages/rollup-full-node/src/app/web3-rpc-handler.ts
@@ -659,7 +659,7 @@ export class DefaultWeb3Handler implements Web3Handler, FullnodeHandler {
       )
       ovmTxReceipt = await internalTxReceiptToOvmTxReceipt(
         internalTxReceipt,
-        this.context.executionManager.address,
+        this.context,
         ovmTxHash
       )
     } else {


### PR DESCRIPTION
## Description
Fixes issues with events not having the correct address by simply storing a reverse mapping of code contract address -> ovm contract address and mapping event/log code contract addresses to ovm addresses when parsing.

## Questions
- Should we completely remove event emissions from the Execution Manager? (this would probably require a new ticket)

## Metadata
### Fixes
- Fixes #YAS-488

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [X] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
