### PR TITLE
rollup-full-node: fix wallet init from mnemonic

### DIFF
--- a/packages/rollup-full-node/src/app/util/l2-node.ts
+++ b/packages/rollup-full-node/src/app/util/l2-node.ts
@@ -127,7 +127,7 @@ function getL2Wallet(provider: JsonRpcProvider): Wallet {
     log.info(`Initialized wallet from private key. Address: ${wallet.address}`)
   } else if (!!Environment.l2WalletMnemonic()) {
     wallet = Wallet.fromMnemonic(Environment.l2WalletMnemonic())
-    wallet.connect(provider)
+    wallet = wallet.connect(provider)
     log.info(`Initialized wallet from mnemonic. Address: ${wallet.address}`)
   } else if (!!Environment.l2WalletPrivateKeyPath()) {
     try {


### PR DESCRIPTION
## Description

Closes https://github.com/ethereum-optimism/optimism-monorepo/issues/136

Confirmed the bug as described in #136, implemented the given solution and confirmed that it fixes the problem.
To reproduce, be sure to rebuild the typescript and the `optimism-monorepo_rollup-full-node` docker image so that the changes are included in the container. In the `docker-compose.yml` file, comment out the `L2_WALLET_PRIVATE_KEY` environment variable and add the `L2_WALLET_MNEMONIC` environment variable like so:

```
- L2_WALLET_MNEMONIC=abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about
```
Run `docker-compose up` and you should be able to see the logline from the rollup full node: `Initialized wallet from mnemonic. Address: 0x...`.

## Questions
- I think that part of the deploy process assumes that the contracts don't exist yet, as running consecutive `docker-compose up` commands would fail the second time. This can be fixed by removing the docker volumes and then running `docker-compose up` again. It would be nice to add a `try/catch` wherever this problem is happening to remove the need to do this.

## Metadata
### Fixes
- Fixes #136

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
