### PR TITLE
Add L1RollupTxId to RollupTransaction

### DIFF
--- a/packages/rollup-core/src/app/data/consumers/queued-geth-submitter.ts
+++ b/packages/rollup-core/src/app/data/consumers/queued-geth-submitter.ts
@@ -54,12 +54,12 @@ export class QueuedGethSubmitter extends ScheduledTask {
 
     try {
       await this.l1DataService.markQueuedGethSubmissionSubmittedToGeth(
-        gethSubmission.batchNumber
+        gethSubmission.submissionNumber
       )
     } catch (e) {
       logError(
         log,
-        `Error marking Geth Submission submitted to Geth. L1 Batch Number: ${gethSubmission.batchNumber}`,
+        `Error marking Geth Submission submitted to Geth. L1 Batch Number: ${gethSubmission.submissionNumber}`,
         e
       )
       return

--- a/packages/rollup-core/src/app/data/consumers/queued-geth-submitter.ts
+++ b/packages/rollup-core/src/app/data/consumers/queued-geth-submitter.ts
@@ -7,7 +7,7 @@ import {
 
 /* Internal Imports */
 import { L1DataService } from '../../../types/data'
-import { BlockBatches, L2NodeService } from '../../../types'
+import { GethSubmission, L2NodeService } from '../../../types'
 
 const log = getLogger('l2-batch-submitter')
 
@@ -28,27 +28,25 @@ export class QueuedGethSubmitter extends ScheduledTask {
    * @inheritDoc
    */
   public async runTask(): Promise<void> {
-    let blockBatches: BlockBatches
+    let gethSubmission: GethSubmission
     try {
-      blockBatches = await this.l1DataService.getNextQueuedGethSubmission()
+      gethSubmission = await this.l1DataService.getNextQueuedGethSubmission()
     } catch (e) {
-      logError(log, `Error fetching next batch for L2 submission!`, e)
+      logError(log, `Error fetching next Geth Submission!`, e)
       return
     }
 
-    if (!blockBatches) {
-      log.debug(`No batches ready for submission to L2.`)
+    if (!gethSubmission) {
+      log.debug(`No Geth Submissions ready to be sent.`)
       return
     }
 
     try {
-      await this.l2NodeService.sendBlockBatches(blockBatches)
+      await this.l2NodeService.sendGethSubmission(gethSubmission)
     } catch (e) {
       logError(
         log,
-        `Error sending batch to BlockBatchSubmitter! Block Batches: ${JSON.stringify(
-          blockBatches
-        )}`,
+        `Error sending Geth Submission: ${JSON.stringify(gethSubmission)}`,
         e
       )
       return
@@ -56,12 +54,12 @@ export class QueuedGethSubmitter extends ScheduledTask {
 
     try {
       await this.l1DataService.markQueuedGethSubmissionSubmittedToGeth(
-        blockBatches.batchNumber
+        gethSubmission.batchNumber
       )
     } catch (e) {
       logError(
         log,
-        `Error marking L1 Batch as Submitted to L2. L1 Batch Number: ${blockBatches.batchNumber}`,
+        `Error marking Geth Submission submitted to Geth. L1 Batch Number: ${gethSubmission.batchNumber}`,
         e
       )
       return

--- a/packages/rollup-core/src/app/data/data-service.ts
+++ b/packages/rollup-core/src/app/data/data-service.ts
@@ -245,7 +245,7 @@ export class DefaultDataService implements DataService {
     const blockNumber = res[0]['block_number']
 
     return {
-      batchNumber: gethSubmissionNumber,
+      submissionNumber: gethSubmissionNumber,
       timestamp,
       blockNumber,
       rollupTransactions: res.map((row: Row, indexWithinSubmission: number) => {

--- a/packages/rollup-core/src/app/data/producers/l2-chain-data-persister.ts
+++ b/packages/rollup-core/src/app/data/producers/l2-chain-data-persister.ts
@@ -131,6 +131,9 @@ export class L2ChainDataPersister extends ChainDataProcessor {
     if (!!response['l1MessageSender']) {
       res.l1MessageSender = response['l1MessageSender']
     }
+    if (!!response['l1RollupTxId']) {
+      res.l1RollupTransactionId = response['l1RollupTxId']
+    }
     if (!!response.r && !!response.s && response.v !== undefined) {
       res.signature = `${response.r}${remove0x(
         response.s

--- a/packages/rollup-core/src/app/l2-node-service.ts
+++ b/packages/rollup-core/src/app/l2-node-service.ts
@@ -1,5 +1,10 @@
 /* External Imports */
-import { getLogger, Logger, numberToHexString } from '@eth-optimism/core-utils'
+import {
+  getLogger,
+  Logger,
+  numberToHexString,
+  strToHexStr,
+} from '@eth-optimism/core-utils'
 
 import { JsonRpcProvider } from 'ethers/providers'
 import { Wallet } from 'ethers'
@@ -50,10 +55,11 @@ export class DefaultL2NodeService implements L2NodeService {
       return v
     })
 
-    const signedPayload: string = await this.l2Wallet.signMessage(payload)
+    const hexPayload: string = strToHexStr(payload)
+    const signedPayload: string = await this.l2Wallet.signMessage(hexPayload)
+
     await this.l2Provider.send(DefaultL2NodeService.sendGethSubmission, [
-      payload,
-      signedPayload,
+      [hexPayload, signedPayload],
     ])
   }
 }

--- a/packages/rollup-core/src/types/data/l1-data-service.ts
+++ b/packages/rollup-core/src/types/data/l1-data-service.ts
@@ -2,7 +2,7 @@
 import { Block, TransactionResponse } from 'ethers/providers'
 
 /* Internal Imports */
-import { BlockBatches, RollupTransaction } from '../types'
+import { GethSubmission, RollupTransaction } from '../types'
 import { GethSubmissionRecord } from './types'
 
 export interface L1DataService {
@@ -88,7 +88,7 @@ export interface L1DataService {
    *
    * @returns The fetched Queued Geth Submission or undefined if one is not present in the DB.
    */
-  getNextQueuedGethSubmission(): Promise<BlockBatches>
+  getNextQueuedGethSubmission(): Promise<GethSubmission>
 
   /**
    * Marks the provided Queued Geth Submission as submitted to L2.

--- a/packages/rollup-core/src/types/l2-node-service.ts
+++ b/packages/rollup-core/src/types/l2-node-service.ts
@@ -1,4 +1,4 @@
-import { BlockBatches } from './types'
+import { GethSubmission } from './types'
 
 export interface L2NodeService {
   /**
@@ -6,5 +6,5 @@ export interface L2NodeService {
    *
    * @param blockBatches The block batches to send to L2
    */
-  sendBlockBatches(blockBatches: BlockBatches): Promise<void>
+  sendGethSubmission(blockBatches: GethSubmission): Promise<void>
 }

--- a/packages/rollup-core/src/types/types.ts
+++ b/packages/rollup-core/src/types/types.ts
@@ -73,7 +73,7 @@ export interface LogHandlerContext {
 }
 
 export interface GethSubmission {
-  batchNumber: number
+  submissionNumber: number
   timestamp: number
   blockNumber: number
   rollupTransactions: RollupTransaction[]

--- a/packages/rollup-core/src/types/types.ts
+++ b/packages/rollup-core/src/types/types.ts
@@ -18,6 +18,7 @@ export interface L2ToL1Message {
 }
 
 export interface RollupTransaction {
+  l1RollupTxId?: number
   indexWithinSubmission: number
   target: Address
   calldata: string
@@ -71,23 +72,11 @@ export interface LogHandlerContext {
   handleLog: LogHandler
 }
 
-export type L1Batch = RollupTransaction[]
-export interface BlockBatches {
+export interface GethSubmission {
   batchNumber: number
   timestamp: number
   blockNumber: number
-  batches: L1Batch[]
-}
-
-export type L1BatchParser = (
-  l: Log,
-  transaction: TransactionResponse
-) => Promise<L1Batch>
-
-export interface BatchLogParserContext {
-  topic: string
-  contractAddress: Address
-  parseL1Batch: L1BatchParser
+  rollupTransactions: RollupTransaction[]
 }
 
 /* Types */

--- a/packages/rollup-core/test/app/l2-chain-data-persister.spec.ts
+++ b/packages/rollup-core/test/app/l2-chain-data-persister.spec.ts
@@ -81,6 +81,7 @@ const getTransactionResponse = (
     value: undefined,
     chainId: CHAIN_ID,
     l1MessageSender: ZERO_ADDRESS,
+    l1RollupTxId: 1,
     wait: (confirmations) => {
       return undefined
     },

--- a/packages/rollup-core/test/app/l2-node-service.spec.ts
+++ b/packages/rollup-core/test/app/l2-node-service.spec.ts
@@ -3,6 +3,7 @@ import '../setup'
 /* External Imports */
 import {
   hexStrToNumber,
+  hexStrToString,
   keccak256FromUtf8,
   TestUtils,
 } from '@eth-optimism/core-utils'
@@ -83,8 +84,8 @@ const rollupTx2: RollupTransaction = {
   queueOrigin: QueueOrigin.SAFETY_QUEUE,
 }
 
-const deserializeBlockBatches = (serialized: string): GethSubmission => {
-  return JSON.parse(serialized, (k, v) => {
+const deserializeRollupTransactions = (serialized: string): GethSubmission => {
+  return JSON.parse(hexStrToString(serialized), (k, v) => {
     switch (k) {
       case 'blockNumber':
       case 'timestamp':
@@ -168,18 +169,24 @@ describe('L2 Node Service', () => {
       'Incorrect params type!'
     )
     const paramsArray = mockedSendProvider.sent[0].params as string[]
-    paramsArray.length.should.equal(2, 'Incorrect params length')
-    const [payloadStr, signature] = paramsArray
+    paramsArray.length.should.equal(1, 'Incorrect params length')
+    paramsArray[0].length.should.equal(2, 'Incorrect params array length')
+    const [payloadStr, signature] = paramsArray[0]
 
-    const blockBatches: GethSubmission = deserializeBlockBatches(payloadStr)
+    const gethSubmission: GethSubmission = deserializeRollupTransactions(
+      payloadStr
+    )
 
-    blockBatches.timestamp.should.equal(timestamp, 'Incorrect timestamp!')
-    blockBatches.rollupTransactions.length.should.equal(
+    gethSubmission.timestamp.should.equal(timestamp, 'Incorrect timestamp!')
+    gethSubmission.rollupTransactions.length.should.equal(
       1,
       'Incorrect num batches!'
     )
-    blockBatches.rollupTransactions.length.should.equal(1, 'Incorrect num txs!')
-    blockBatches.rollupTransactions[0].should.deep.equal(
+    gethSubmission.rollupTransactions.length.should.equal(
+      1,
+      'Incorrect num txs!'
+    )
+    gethSubmission.rollupTransactions[0].should.deep.equal(
       rollupTx,
       'Incorrect transaction received!'
     )
@@ -208,22 +215,25 @@ describe('L2 Node Service', () => {
       'Incorrect params type!'
     )
     const paramsArray = mockedSendProvider.sent[0].params as string[]
-    paramsArray.length.should.equal(2, 'Incorrect params length')
-    const [payloadStr, signature] = paramsArray
+    paramsArray.length.should.equal(1, 'Incorrect params length')
+    paramsArray[0].length.should.equal(2, 'Incorrect params array length')
+    const [payloadStr, signature] = paramsArray[0]
 
-    const blockBatches: GethSubmission = deserializeBlockBatches(payloadStr)
+    const gethSubmission: GethSubmission = deserializeRollupTransactions(
+      payloadStr
+    )
 
-    blockBatches.timestamp.should.equal(timestamp, 'Incorrect timestamp!')
-    blockBatches.rollupTransactions.length.should.equal(
+    gethSubmission.timestamp.should.equal(timestamp, 'Incorrect timestamp!')
+    gethSubmission.rollupTransactions.length.should.equal(
       2,
       'Incorrect num transactions!'
     )
-    blockBatches.rollupTransactions[0].should.deep.equal(
+    gethSubmission.rollupTransactions[0].should.deep.equal(
       rollupTx,
       'Incorrect transaction received!'
     )
 
-    blockBatches.rollupTransactions[1].should.deep.equal(
+    gethSubmission.rollupTransactions[1].should.deep.equal(
       rollupTx2,
       'Incorrect transaction 2 received!'
     )

--- a/packages/rollup-core/test/app/l2-node-service.spec.ts
+++ b/packages/rollup-core/test/app/l2-node-service.spec.ts
@@ -124,7 +124,7 @@ describe('L2 Node Service', () => {
 
   it('should handle batch with undefined transactions properly', async () => {
     await l2NodeService.sendGethSubmission({
-      batchNumber,
+      submissionNumber: batchNumber,
       timestamp,
       blockNumber,
       rollupTransactions: undefined,
@@ -138,7 +138,7 @@ describe('L2 Node Service', () => {
 
   it('should handle batch with empty transactions properly', async () => {
     await l2NodeService.sendGethSubmission({
-      batchNumber,
+      submissionNumber: batchNumber,
       timestamp,
       blockNumber,
       rollupTransactions: [],
@@ -152,7 +152,7 @@ describe('L2 Node Service', () => {
 
   it('should send single-tx batch properly', async () => {
     await l2NodeService.sendGethSubmission({
-      batchNumber,
+      submissionNumber: batchNumber,
       timestamp,
       blockNumber,
       rollupTransactions: [rollupTx],
@@ -192,7 +192,7 @@ describe('L2 Node Service', () => {
 
   it('should send multi-tx batch properly', async () => {
     await l2NodeService.sendGethSubmission({
-      batchNumber,
+      submissionNumber: batchNumber,
       timestamp,
       blockNumber,
       rollupTransactions: [rollupTx, rollupTx2],

--- a/packages/rollup-core/test/app/queued-geth-submitter.spec.ts
+++ b/packages/rollup-core/test/app/queued-geth-submitter.spec.ts
@@ -64,7 +64,7 @@ describe('Optimistic Canonical Chain Batch Submitter', () => {
 
   it('should send a batch if a fitting one exists', async () => {
     const blockBatches: GethSubmission = {
-      batchNumber: 1,
+      submissionNumber: 1,
       timestamp: 1,
       blockNumber: 1,
       rollupTransactions: [

--- a/packages/rollup-core/test/app/queued-geth-submitter.spec.ts
+++ b/packages/rollup-core/test/app/queued-geth-submitter.spec.ts
@@ -4,36 +4,36 @@ import { Wallet } from 'ethers'
 /* Internal Imports */
 import { DefaultDataService, QueuedGethSubmitter } from '../../src/app/data'
 import { DefaultL2NodeService } from '../../src/app'
-import { BlockBatches } from '../../src/types'
+import { GethSubmission } from '../../src/types'
 import { keccak256FromUtf8 } from '@eth-optimism/core-utils/build'
 
 class MockL2NodeService extends DefaultL2NodeService {
-  public readonly sentBlockBatches: BlockBatches[] = []
+  public readonly sentSubmissions: GethSubmission[] = []
 
   constructor() {
     super(Wallet.createRandom())
   }
 
-  public async sendBlockBatches(blockBatches: BlockBatches): Promise<void> {
-    this.sentBlockBatches.push(blockBatches)
+  public async sendGethSubmission(blockBatches: GethSubmission): Promise<void> {
+    this.sentSubmissions.push(blockBatches)
   }
 }
 
 class MockL1DataService extends DefaultDataService {
-  public readonly blockBatchesToReturn: BlockBatches[] = []
-  public readonly batchesMarkedSubmitted: number[] = []
+  public readonly submissionsToReturn: GethSubmission[] = []
+  public readonly submissionsMarkedSubmitted: number[] = []
   constructor() {
     super(undefined)
   }
 
-  public async getNextQueuedGethSubmission(): Promise<BlockBatches> {
-    return this.blockBatchesToReturn.shift()
+  public async getNextQueuedGethSubmission(): Promise<GethSubmission> {
+    return this.submissionsToReturn.shift()
   }
 
   public async markQueuedGethSubmissionSubmittedToGeth(
     batchNumber: number
   ): Promise<void> {
-    this.batchesMarkedSubmitted.push(batchNumber)
+    this.submissionsMarkedSubmitted.push(batchNumber)
   }
 }
 
@@ -51,60 +51,58 @@ describe('Optimistic Canonical Chain Batch Submitter', () => {
   it('should not submit batch if no fitting L1 batch exists', async () => {
     await batchSubmitter.runTask()
 
-    l1DatService.batchesMarkedSubmitted.length.should.equal(
+    l1DatService.submissionsMarkedSubmitted.length.should.equal(
       0,
       `No Batches should have been marked as sent!`
     )
 
-    l2NodeService.sentBlockBatches.length.should.equal(
+    l2NodeService.sentSubmissions.length.should.equal(
       0,
       `No Batches should have been sent!`
     )
   })
 
   it('should send a batch if a fitting one exists', async () => {
-    const blockBatches: BlockBatches = {
+    const blockBatches: GethSubmission = {
       batchNumber: 1,
       timestamp: 1,
       blockNumber: 1,
-      batches: [
-        [
-          {
-            indexWithinSubmission: 1,
-            gasLimit: 0,
-            nonce: 0,
-            sender: Wallet.createRandom().address,
-            target: Wallet.createRandom().address,
-            calldata: keccak256FromUtf8('calldata'),
-            l1Timestamp: 1,
-            l1BlockNumber: 1,
-            l1TxHash: keccak256FromUtf8('tx hash'),
-            l1TxIndex: 0,
-            l1TxLogIndex: 0,
-            queueOrigin: 1,
-          },
-        ],
+      rollupTransactions: [
+        {
+          indexWithinSubmission: 1,
+          gasLimit: 0,
+          nonce: 0,
+          sender: Wallet.createRandom().address,
+          target: Wallet.createRandom().address,
+          calldata: keccak256FromUtf8('calldata'),
+          l1Timestamp: 1,
+          l1BlockNumber: 1,
+          l1TxHash: keccak256FromUtf8('tx hash'),
+          l1TxIndex: 0,
+          l1TxLogIndex: 0,
+          queueOrigin: 1,
+        },
       ],
     }
 
-    l1DatService.blockBatchesToReturn.push(blockBatches)
+    l1DatService.submissionsToReturn.push(blockBatches)
     await batchSubmitter.runTask()
 
-    l2NodeService.sentBlockBatches.length.should.equal(
+    l2NodeService.sentSubmissions.length.should.equal(
       1,
       `1 BlockBatches object should have been submitted!`
     )
-    l2NodeService.sentBlockBatches[0].should.deep.equal(
+    l2NodeService.sentSubmissions[0].should.deep.equal(
       blockBatches,
       `Sent BlockBatches object doesn't match!`
     )
 
-    l1DatService.batchesMarkedSubmitted.length.should.equal(
+    l1DatService.submissionsMarkedSubmitted.length.should.equal(
       1,
       `1 batch should have been marked submitted!`
     )
 
-    l1DatService.batchesMarkedSubmitted[0].should.equal(
+    l1DatService.submissionsMarkedSubmitted[0].should.equal(
       1,
       `1 batch should have been marked submitted!`
     )

--- a/packages/rollup-core/test/integration/geth-submitter-integration.spec.ts
+++ b/packages/rollup-core/test/integration/geth-submitter-integration.spec.ts
@@ -1,0 +1,50 @@
+/* External Imports */
+import { Wallet } from 'ethers'
+
+/* Internal Imports */
+import { DefaultDataService, QueuedGethSubmitter } from '../../src/app/data'
+import { CHAIN_ID, DefaultL2NodeService } from '../../src/app'
+import { GethSubmission, L2NodeService } from '../../src/types'
+import { keccak256FromUtf8 } from '@eth-optimism/core-utils/build'
+import { JsonRpcProvider } from 'ethers/providers'
+
+// TODO: Can be used to submit Rollup Transactions to geth.
+describe.skip('Optimistic Canonical Chain Batch Submitter', () => {
+  let l2NodeService: L2NodeService
+
+  beforeEach(async () => {
+    // Address for wallet: 0x6a399F0A626A505e2F6C2b5Da181d98D722dC86D
+    const wallet = new Wallet(
+      'efb6aa1f37082ac40884a340684672ccbb5a4e6000860953afcf73c90c33e4f9',
+      new JsonRpcProvider('http://127.0.0.1:8545', CHAIN_ID)
+    )
+    l2NodeService = new DefaultL2NodeService(wallet)
+  })
+
+  it('should send a batch to Geth', async () => {
+    const gethSubmission: GethSubmission = {
+      submissionNumber: 1,
+      timestamp: 1,
+      blockNumber: 1,
+      rollupTransactions: [
+        {
+          l1RollupTxId: 2,
+          indexWithinSubmission: 1,
+          gasLimit: 0,
+          nonce: 0,
+          sender: Wallet.createRandom().address,
+          target: Wallet.createRandom().address,
+          calldata: keccak256FromUtf8('calldata'),
+          l1Timestamp: 1,
+          l1BlockNumber: 1,
+          l1TxHash: keccak256FromUtf8('tx hash'),
+          l1TxIndex: 0,
+          l1TxLogIndex: 0,
+          queueOrigin: 1,
+        },
+      ],
+    }
+
+    await l2NodeService.sendGethSubmission(gethSubmission)
+  })
+})


### PR DESCRIPTION
## Description
Adds L1RollupTxId to RollupTransactions so it can be passed in submissions to geth.

Also renames BlockBatches and decreases their size from all of the batches that were in one L1 block to a single batch from a single event log from an L1 block.

## Metadata
### Fixes
- Fixes # [YAS-550](https://optimists.atlassian.net/browse/YAS-550)

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
