### PR TITLE
Add geth dump input and optimize ExecutionManager

### DIFF
--- a/packages/contracts/test/deployment/deployment.spec.ts
+++ b/packages/contracts/test/deployment/deployment.spec.ts
@@ -9,7 +9,7 @@ import {
   RollupDeployConfig,
   factoryToContractName,
 } from '../../src/deployment/types'
-import { Signer } from 'ethers'
+import { Signer, Transaction } from 'ethers'
 import {
   GAS_LIMIT,
   DEFAULT_FORCE_INCLUSION_PERIOD_SECONDS,
@@ -44,6 +44,69 @@ describe('Contract Deployment', () => {
           true,
           `Contract ${contractName} was not deployed!`
         )
+      })
+    })
+
+    it.skip('write all the (simpilified) transactions to a file to be ingested into L2Geth', async () => {
+      const config: RollupDeployConfig = {
+        signer: wallet,
+        rollupOptions: {
+          gasLimit: GAS_LIMIT,
+          forceInclusionPeriodSeconds: DEFAULT_FORCE_INCLUSION_PERIOD_SECONDS,
+          ownerAddress: await wallet.getAddress(),
+          sequencerAddress: await sequencer.getAddress(),
+        },
+      }
+
+      const resolver = await deployAllContracts(config)
+
+      // Pull all blocks and transactions
+      const totalNumberOfBlocks = await wallet.provider.getBlockNumber()
+      const transactions = []
+      for (let i = 0; i < totalNumberOfBlocks; i++) {
+        const blockTransactions = (await wallet.provider.getBlockWithTransactions(i)).transactions
+        blockTransactions.map((tx) => transactions.push(tx))
+      }
+
+      // Declare types and helpers for the GethDumpInput
+      interface SimplifiedTx {
+        from: string
+        to: string
+        data: string
+      }
+      interface GethDumpInput {
+        simplifiedTxs: SimplifiedTx[]
+        walletAddress: string
+        executionManagerAddress: string
+        stateManagerAddress: string
+      }
+
+      const getSimplifiedTx = (tx: Transaction): SimplifiedTx => {
+        return {
+          from: tx.from,
+          to: (tx.to) ? tx.to : '0x' + '00'.repeat(20), // use ZERO_ADDRESS for null because that's the logic I wrote in geth
+          data: tx.data
+        }
+      }
+      const simplifiedTxs: SimplifiedTx[] = transactions.map((tx) => getSimplifiedTx(tx))
+
+      const gethDumpInput: GethDumpInput = {
+        simplifiedTxs,
+        walletAddress: await wallet.getAddress(),
+        executionManagerAddress: resolver.contracts.executionManager.address,
+        stateManagerAddress: resolver.contracts.stateManager.address,
+      }
+
+      // Write all the simplified transactions data to a file
+      const fs = require('fs')
+      const path = require('path')
+      const filename = 'deployment-tx-data.json'
+      fs.writeFile(filename, JSON.stringify(gethDumpInput), (err) => {
+        if (err) {
+          console.log(err)
+        } else {
+          console.log('Wrote deployment tx data to', filename)
+        }
       })
     })
   })

--- a/packages/contracts/test/deployment/deployment.spec.ts
+++ b/packages/contracts/test/deployment/deployment.spec.ts
@@ -9,7 +9,7 @@ import {
   RollupDeployConfig,
   factoryToContractName,
 } from '../../src/deployment/types'
-import { Signer, Transaction } from 'ethers'
+import { Signer } from 'ethers'
 import {
   GAS_LIMIT,
   DEFAULT_FORCE_INCLUSION_PERIOD_SECONDS,
@@ -44,73 +44,6 @@ describe('Contract Deployment', () => {
           true,
           `Contract ${contractName} was not deployed!`
         )
-      })
-    })
-
-    it.skip('write all the (simpilified) transactions to a file to be ingested into L2Geth', async () => {
-      const config: RollupDeployConfig = {
-        signer: wallet,
-        rollupOptions: {
-          gasLimit: GAS_LIMIT,
-          forceInclusionPeriodSeconds: DEFAULT_FORCE_INCLUSION_PERIOD_SECONDS,
-          ownerAddress: await wallet.getAddress(),
-          sequencerAddress: await sequencer.getAddress(),
-        },
-      }
-
-      const resolver = await deployAllContracts(config)
-
-      // Pull all blocks and transactions
-      const totalNumberOfBlocks = await wallet.provider.getBlockNumber()
-      const transactions = []
-      for (let i = 0; i < totalNumberOfBlocks; i++) {
-        const blockTransactions = (
-          await wallet.provider.getBlockWithTransactions(i)
-        ).transactions
-        blockTransactions.map((tx) => transactions.push(tx))
-      }
-
-      // Declare types and helpers for the GethDumpInput
-      interface SimplifiedTx {
-        from: string
-        to: string
-        data: string
-      }
-      interface GethDumpInput {
-        simplifiedTxs: SimplifiedTx[]
-        walletAddress: string
-        executionManagerAddress: string
-        stateManagerAddress: string
-      }
-
-      const getSimplifiedTx = (tx: Transaction): SimplifiedTx => {
-        return {
-          from: tx.from,
-          to: tx.to ? tx.to : '0x' + '00'.repeat(20), // use ZERO_ADDRESS for null because that's the logic I wrote in geth
-          data: tx.data,
-        }
-      }
-      const simplifiedTxs: SimplifiedTx[] = transactions.map((tx) =>
-        getSimplifiedTx(tx)
-      )
-
-      const gethDumpInput: GethDumpInput = {
-        simplifiedTxs,
-        walletAddress: await wallet.getAddress(),
-        executionManagerAddress: resolver.contracts.executionManager.address,
-        stateManagerAddress: resolver.contracts.stateManager.address,
-      }
-
-      // Write all the simplified transactions data to a file
-      const fs = require('fs')
-      const path = require('path')
-      const filename = 'deployment-tx-data.json'
-      fs.writeFile(filename, JSON.stringify(gethDumpInput), (err) => {
-        if (err) {
-          console.log(err)
-        } else {
-          console.log('Wrote deployment tx data to', filename)
-        }
       })
     })
   })

--- a/packages/contracts/test/deployment/deployment.spec.ts
+++ b/packages/contracts/test/deployment/deployment.spec.ts
@@ -64,7 +64,9 @@ describe('Contract Deployment', () => {
       const totalNumberOfBlocks = await wallet.provider.getBlockNumber()
       const transactions = []
       for (let i = 0; i < totalNumberOfBlocks; i++) {
-        const blockTransactions = (await wallet.provider.getBlockWithTransactions(i)).transactions
+        const blockTransactions = (
+          await wallet.provider.getBlockWithTransactions(i)
+        ).transactions
         blockTransactions.map((tx) => transactions.push(tx))
       }
 
@@ -84,11 +86,13 @@ describe('Contract Deployment', () => {
       const getSimplifiedTx = (tx: Transaction): SimplifiedTx => {
         return {
           from: tx.from,
-          to: (tx.to) ? tx.to : '0x' + '00'.repeat(20), // use ZERO_ADDRESS for null because that's the logic I wrote in geth
-          data: tx.data
+          to: tx.to ? tx.to : '0x' + '00'.repeat(20), // use ZERO_ADDRESS for null because that's the logic I wrote in geth
+          data: tx.data,
         }
       }
-      const simplifiedTxs: SimplifiedTx[] = transactions.map((tx) => getSimplifiedTx(tx))
+      const simplifiedTxs: SimplifiedTx[] = transactions.map((tx) =>
+        getSimplifiedTx(tx)
+      )
 
       const gethDumpInput: GethDumpInput = {
         simplifiedTxs,

--- a/packages/contracts/test/deployment/geth-input-dump.spec.ts
+++ b/packages/contracts/test/deployment/geth-input-dump.spec.ts
@@ -1,0 +1,92 @@
+import { expect } from '../setup'
+
+/* External Imports */
+import { ethers } from '@nomiclabs/buidler'
+
+/* Internal Imports */
+import { deployAllContracts } from '../../src'
+import {
+  RollupDeployConfig,
+  factoryToContractName,
+} from '../../src/deployment/types'
+import { Signer, Transaction } from 'ethers'
+import {
+  GAS_LIMIT,
+  DEFAULT_FORCE_INCLUSION_PERIOD_SECONDS,
+} from '../test-helpers'
+
+describe.skip('L2Geth Dumper Input Generator', () => {
+  let wallet: Signer
+  let sequencer: Signer
+  let l1ToL2TransactionPasser: Signer
+  before(async () => {
+    ;[wallet, sequencer, l1ToL2TransactionPasser] = await ethers.getSigners()
+  })
+
+  it('write all the (simpilified) transactions to a file to be ingested into L2Geth', async () => {
+    const config: RollupDeployConfig = {
+      signer: wallet,
+      rollupOptions: {
+        gasLimit: GAS_LIMIT,
+        forceInclusionPeriodSeconds: DEFAULT_FORCE_INCLUSION_PERIOD_SECONDS,
+        ownerAddress: await wallet.getAddress(),
+        sequencerAddress: await sequencer.getAddress(),
+      },
+    }
+
+    const resolver = await deployAllContracts(config)
+
+    // Pull all blocks and transactions
+    const totalNumberOfBlocks = await wallet.provider.getBlockNumber()
+    const transactions = []
+    for (let i = 0; i < totalNumberOfBlocks; i++) {
+      const blockTransactions = (
+        await wallet.provider.getBlockWithTransactions(i)
+      ).transactions
+      blockTransactions.map((tx) => transactions.push(tx))
+    }
+
+    // Declare types and helpers for the GethDumpInput
+    interface SimplifiedTx {
+      from: string
+      to: string
+      data: string
+    }
+    interface GethDumpInput {
+      simplifiedTxs: SimplifiedTx[]
+      walletAddress: string
+      executionManagerAddress: string
+      stateManagerAddress: string
+    }
+
+    const getSimplifiedTx = (tx: Transaction): SimplifiedTx => {
+      return {
+        from: tx.from,
+        to: tx.to ? tx.to : '0x' + '00'.repeat(20), // use ZERO_ADDRESS for null because that's the logic I wrote in geth
+        data: tx.data,
+      }
+    }
+    const simplifiedTxs: SimplifiedTx[] = transactions.map((tx) =>
+      getSimplifiedTx(tx)
+    )
+
+    const gethDumpInput: GethDumpInput = {
+      simplifiedTxs,
+      walletAddress: await wallet.getAddress(),
+      executionManagerAddress: resolver.contracts.executionManager.address,
+      stateManagerAddress: resolver.contracts.stateManager.address,
+    }
+
+    // Write all the simplified transactions data to a file
+    const fs = require('fs')
+    const path = require('path')
+    const filename = 'deployment-tx-data.json'
+    fs.writeFile(filename, JSON.stringify(gethDumpInput), (err) => {
+      if (err) {
+        console.log(err)
+      } else {
+        console.log('Wrote deployment tx data to', filename)
+      }
+    })
+  })
+})

--- a/packages/test-ERC20-Truffle/package.json
+++ b/packages/test-ERC20-Truffle/package.json
@@ -8,7 +8,7 @@
     "build": "truffle compile --config truffle-config-ovm.js",
     "build:regular": "truffle compile",
     "test:regular": "truffle test ./truffle-tests/test-erc20.js",
-    "test": "truffle test ./truffle-tests/test-erc20.js --config truffle-config-ovm.js",
+    "test": "truffle test ./truffle-tests/test-erc20.js --config truffle-config-ovm.js --timeout 5000",
     "all:regular": "yarn clean && yarn build:regular && yarn test:regular",
     "all": "yarn clean && yarn build && yarn test"
   },


### PR DESCRIPTION
## Description
Quick PR which adds a script (added in our test suite) for creating a state dump. Also, add in a quick fix which optimizes the ExecutionManager by caching the `StateManager` address.

### Fixes
- Partially fixes YAS 350

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
