### PR TITLE
fixing missing block_number in view

### DIFF
--- a/db/scripts/4_create_views.sql
+++ b/db/scripts/4_create_views.sql
@@ -20,7 +20,7 @@ ORDER BY
 CREATE OR REPLACE VIEW next_queued_geth_submission
 AS
 
-SELECT r.*, b.block_timestamp
+SELECT r.*, b.block_timestamp, b.block_number
 FROM l1_rollup_tx r
   INNER JOIN l1_tx t ON r.l1_tx_hash = t.tx_hash
   INNER JOIN l1_block b ON b.block_number = t.block_number


### PR DESCRIPTION
## Description
Adding `block_number` to fields in the `next_queued_geth_submission` view to fix a dependent query.

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
