### PR TITLE
Fixed issues with gas estimation in ovm-toolchain

### DIFF
--- a/packages/ovm-toolchain/buidler.config.ts
+++ b/packages/ovm-toolchain/buidler.config.ts
@@ -10,7 +10,7 @@ import './src/buidler-plugins/buidler-ovm-node'
 const config: any = {
   networks: {
     buidlerevm: {
-      blockGasLimit: 100000000,
+      blockGasLimit: 100_000_000,
     },
   },
   paths: {

--- a/packages/ovm-toolchain/package.json
+++ b/packages/ovm-toolchain/package.json
@@ -70,6 +70,7 @@
     "@eth-optimism/core-utils": "^0.0.1-alpha.27",
     "@eth-optimism/solc-transpiler": "^0.0.1-alpha.28",
     "@nomiclabs/buidler": "^1.4.4",
+    "bn.js": "^5.1.3",
     "ethereum-waffle-v2": "npm:ethereum-waffle@2",
     "ethereum-waffle-v3": "npm:ethereum-waffle@3",
     "ethereumjs-ovm": "git+https://github.com/ethereum-optimism/ethereumjs-vm",

--- a/packages/ovm-toolchain/src/buidler-plugins/buidler-ovm-node.ts
+++ b/packages/ovm-toolchain/src/buidler-plugins/buidler-ovm-node.ts
@@ -1,10 +1,14 @@
 import { extendEnvironment } from '@nomiclabs/buidler/config'
 // tslint:disable-next-line
 const VM = require('ethereumjs-ovm').default
+// tslint:disable-next-line
+const BN = require('bn.js')
 
 extendEnvironment(async (bre) => {
   const config: any = bre.config
   if (config.useOvm) {
+    const gasLimit = 100_000_000
+
     // Initialize the provider so it has a VM instance ready to copy.
     await bre.network.provider['_init' as any]()
     const node = bre.network.provider['_node' as any]
@@ -14,9 +18,16 @@ extendEnvironment(async (bre) => {
     const ovm = new VM({
       ...vm.opts,
       stateManager: vm.stateManager,
-      emGasLimit: 100_000_000,
+      emGasLimit: gasLimit,
     })
     node['_vm' as any] = ovm
+
+    // Hijack the gas estimation function.
+    node.estimateGas = async (txParams: any): Promise<{ estimation: any }> => {
+      return {
+        estimation: new BN(gasLimit),
+      }
+    }
 
     // Reset the vm tracer to avoid other buidler errors.
     const vmTracer = node['_vmTracer' as any]

--- a/packages/ovm-toolchain/src/ganache.ts
+++ b/packages/ovm-toolchain/src/ganache.ts
@@ -1,6 +1,7 @@
 import * as eGanache from 'ganache-core'
 // tslint:disable-next-line
 const VM = require('ethereumjs-ovm').default
+// tslint:disable-next-line
 const BN = require('bn.js')
 
 // tslint:disable-next-line:no-shadowed-variable

--- a/packages/ovm-toolchain/src/ganache.ts
+++ b/packages/ovm-toolchain/src/ganache.ts
@@ -1,12 +1,16 @@
 import * as eGanache from 'ganache-core'
 // tslint:disable-next-line
 const VM = require('ethereumjs-ovm').default
+const BN = require('bn.js')
 
 // tslint:disable-next-line:no-shadowed-variable
 const wrap = (provider: any, opts: any) => {
+  const gasLimit = opts.gasLimit || 100_000_000
   const blockchain = provider.engine.manager.state.blockchain
-  let ovm: any
 
+  blockchain.blockGasLimit = '0x' + new BN(gasLimit).toString('hex')
+
+  let ovm: any
   const _original = blockchain.createVMFromStateTrie.bind(blockchain)
   // tslint:disable-next-line:only-arrow-functions
   blockchain.createVMFromStateTrie = function(
@@ -18,7 +22,7 @@ const wrap = (provider: any, opts: any) => {
       ovm = new VM({
         ...vm.opts,
         stateManager: vm.stateManager,
-        emGasLimit: opts.gasLimit || 100_000_000,
+        emGasLimit: gasLimit,
       })
       return ovm
     } else {
@@ -32,6 +36,13 @@ const wrap = (provider: any, opts: any) => {
         contracts: ovm._contracts,
       })
     }
+  }
+
+  // tslint:disable-next-line:only-arrow-functions
+  blockchain.estimateGas = function(tx: any, blockNumber: any, callback: any) {
+    callback(null, {
+      gasEstimate: new BN(gasLimit),
+    })
   }
 
   const _send = provider.send.bind(provider)

--- a/packages/ovm-toolchain/test/test-buidler/erc20.spec.ts
+++ b/packages/ovm-toolchain/test/test-buidler/erc20.spec.ts
@@ -5,10 +5,6 @@ import { expect } from '../common/setup'
 const { ethers } = require('@nomiclabs/buidler')
 import { Contract, Signer } from 'ethers-v5'
 
-const overrides = {
-  gasLimit: 10000000,
-}
-
 describe('ERC20 smart contract', () => {
   let wallet1: Signer
   let wallet2: Signer
@@ -29,8 +25,7 @@ describe('ERC20 smart contract', () => {
       10000,
       COIN_NAME,
       NUM_DECIMALS,
-      TICKER,
-      overrides
+      TICKER
     )
   })
 
@@ -51,7 +46,7 @@ describe('ERC20 smart contract', () => {
   })
 
   it('transfers: should transfer 10000 to walletTo with wallet having 10000', async () => {
-    await ERC20Token.transfer(await wallet2.getAddress(), 10000, overrides)
+    await ERC20Token.transfer(await wallet2.getAddress(), 10000)
     const walletToBalance = await ERC20Token.balanceOf(
       await wallet2.getAddress()
     )

--- a/packages/ovm-toolchain/test/test-waffle-v2/core/create2.spec.ts
+++ b/packages/ovm-toolchain/test/test-waffle-v2/core/create2.spec.ts
@@ -23,9 +23,6 @@ const getCreate2Address = (
   return getAddress(`0x${keccak256(sanitizedInputs).slice(-40)}`)
 }
 
-const overrides = {
-  gasLimit: 20000000,
-}
 const DEFAULT_SALT =
   '0x1234123412341234123412341234123412341234123412341234123412341234'
 
@@ -33,20 +30,20 @@ describe('Create2 Support', () => {
   let wallet: Wallet
   let provider: any
   before(async () => {
-    provider = new waffleV2.MockProvider(overrides)
+    provider = new waffleV2.MockProvider()
     ;[wallet] = provider.getWallets()
   })
 
   let simpleCreate2: Contract
   beforeEach(async () => {
-    simpleCreate2 = await deployContract(wallet, SimpleCreate2, [], overrides)
+    simpleCreate2 = await deployContract(wallet, SimpleCreate2, [])
   })
 
   it('should calculate address correctly for invalid bytecode', async () => {
     const bytecode = '0x00'
     const salt = DEFAULT_SALT
 
-    await simpleCreate2.create2(bytecode, salt, overrides)
+    await simpleCreate2.create2(bytecode, salt)
     const address = await simpleCreate2.contractAddress()
     const expectedAddress = getCreate2Address(
       simpleCreate2.address,
@@ -61,7 +58,7 @@ describe('Create2 Support', () => {
     const bytecode = add0x(SimpleStorage.bytecode)
     const salt = DEFAULT_SALT
 
-    await simpleCreate2.create2(bytecode, salt, overrides)
+    await simpleCreate2.create2(bytecode, salt)
     const address = await simpleCreate2.contractAddress()
     const expectedAddress = getCreate2Address(
       simpleCreate2.address,

--- a/packages/ovm-toolchain/test/test-waffle-v2/core/libraries.spec.ts
+++ b/packages/ovm-toolchain/test/test-waffle-v2/core/libraries.spec.ts
@@ -12,17 +12,13 @@ import * as SimpleSafeMathJSON from '../../temp/build/waffle/SimpleSafeMath.json
 import * as SimpleUnsafeMathJSON from '../../temp/build/waffle/SimpleUnsafeMath.json'
 import * as SafeMathUserJSON from '../../temp/build/waffle/SafeMathUser.json'
 
-const overrides = {
-  gasLimit: 100000000,
-}
-
 const CONTRACT_PATH_PREFIX = 'test/common/contracts/libraries/'
 
 describe('Library Support', () => {
   let provider: any
   let wallet: Wallet
   before(async () => {
-    provider = new waffleV2.MockProvider(overrides)
+    provider = new waffleV2.MockProvider()
     ;[wallet] = provider.getWallets()
   })
 
@@ -31,8 +27,7 @@ describe('Library Support', () => {
     const deployedSafeMath = await deployContract(
       wallet,
       SimpleSafeMathJSON,
-      [],
-      overrides
+      []
     )
     link(
       SafeMathUserJSON,
@@ -43,8 +38,7 @@ describe('Library Support', () => {
     const deployedUnsafeMath = await deployContract(
       wallet,
       SimpleUnsafeMathJSON,
-      [],
-      overrides
+      []
     )
     link(
       SafeMathUserJSON,
@@ -52,12 +46,7 @@ describe('Library Support', () => {
       deployedUnsafeMath.address
     )
 
-    deployedLibUser = await deployContract(
-      wallet,
-      SafeMathUserJSON,
-      [],
-      overrides
-    )
+    deployedLibUser = await deployContract(wallet, SafeMathUserJSON, [])
   })
 
   it('should allow us to transpile, link, and query contract methods which use a single library', async () => {

--- a/packages/ovm-toolchain/test/test-waffle-v2/core/precompiles.spec.ts
+++ b/packages/ovm-toolchain/test/test-waffle-v2/core/precompiles.spec.ts
@@ -12,21 +12,17 @@ import { waffleV2 } from '../../../src/waffle/waffle-v2'
 /* Contract Imports */
 import * as Precompiles from '../../temp/build/waffle/Precompiles.json'
 
-const overrides = {
-  gasLimit: 20000000,
-}
-
 describe('Precompile Support', () => {
   let wallet: Wallet
   let provider: any
   beforeEach(async () => {
-    provider = new waffleV2.MockProvider(overrides)
+    provider = new waffleV2.MockProvider()
     ;[wallet] = provider.getWallets()
   })
 
   let precompiles: Contract
   beforeEach(async () => {
-    precompiles = await deployContract(wallet, Precompiles, [], overrides)
+    precompiles = await deployContract(wallet, Precompiles, [])
   })
 
   it('should correctly ecrecover signer address', async () => {

--- a/packages/ovm-toolchain/test/test-waffle-v2/core/timestamps.spec.ts
+++ b/packages/ovm-toolchain/test/test-waffle-v2/core/timestamps.spec.ts
@@ -10,22 +10,17 @@ import { waffleV2 } from '../../../src/waffle/waffle-v2'
 /* Contract Imports */
 import * as TimestampCheckerContract from '../../temp/build/waffle/TimestampChecker.json'
 
-const overrides = {
-  gasLimit: 100000000,
-}
-
 describe('Timestamp Manipulation Support', () => {
   let provider: any
   let wallet: Wallet
   let timestampChecker: Contract
   beforeEach(async () => {
-    provider = new waffleV2.MockProvider(overrides)
+    provider = new waffleV2.MockProvider()
     ;[wallet] = provider.getWallets()
     timestampChecker = await deployContract(
       wallet,
       TimestampCheckerContract,
-      [],
-      overrides
+      []
     )
   })
 

--- a/packages/ovm-toolchain/test/test-waffle-v2/erc20.spec.ts
+++ b/packages/ovm-toolchain/test/test-waffle-v2/erc20.spec.ts
@@ -10,18 +10,12 @@ import { waffleV2 } from '../../src/waffle/waffle-v2'
 /* Contract Imports */
 import * as ERC20 from '../temp/build/waffle/ERC20.json'
 
-const overrides = {
-  gasLimit: 10000000,
-}
-
 describe('ERC20 smart contract', () => {
   let provider: any
   let wallet1: Wallet
   let wallet2: Wallet
   before(async () => {
-    provider = new waffleV2.MockProvider({
-      gasLimit: 10000000,
-    })
+    provider = new waffleV2.MockProvider()
     ;[wallet1, wallet2] = provider.getWallets()
   })
 
@@ -33,12 +27,12 @@ describe('ERC20 smart contract', () => {
   /* Deploy a new ERC20 Token before each test */
   let ERC20Token: Contract
   beforeEach(async () => {
-    ERC20Token = await deployContract(
-      wallet1,
-      ERC20,
-      [10000, COIN_NAME, NUM_DECIMALS, TICKER],
-      overrides
-    )
+    ERC20Token = await deployContract(wallet1, ERC20, [
+      10000,
+      COIN_NAME,
+      NUM_DECIMALS,
+      TICKER,
+    ])
   })
 
   it('creation: should create an initial balance of 10000 for the creator', async () => {
@@ -58,7 +52,7 @@ describe('ERC20 smart contract', () => {
   })
 
   it('transfers: should transfer 10000 to walletTo with wallet having 10000', async () => {
-    await ERC20Token.transfer(wallet2.address, 10000, overrides)
+    await ERC20Token.transfer(wallet2.address, 10000)
     const walletToBalance = await ERC20Token.balanceOf(wallet2.address)
     const walletFromBalance = await ERC20Token.balanceOf(wallet1.address)
     expect(walletToBalance.toNumber()).to.equal(10000)

--- a/yarn.lock
+++ b/yarn.lock
@@ -3145,7 +3145,7 @@ bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.10.0, bn.js@^4.11.0, bn.js@^4.11.1, bn.js@^
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.9.tgz#26d556829458f9d1e81fc48952493d0ba3507828"
   integrity sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==
 
-bn.js@^5.1.1, bn.js@^5.1.2:
+bn.js@^5.1.1, bn.js@^5.1.2, bn.js@^5.1.3:
   version "5.1.3"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.1.3.tgz#beca005408f642ebebea80b042b4d18d2ac0ee6b"
   integrity sha512-GkTiFpjFtUzU9CbMeJ5iazkCzGL3jrhzerzZIuqLABjbwRaFt33I9tUdSNryIptM+RxDet6OKm2WnLXzW51KsQ==


### PR DESCRIPTION
## Description
This is a patch for the `ovm-toolchain` package that "fixes" issues with gas estimation in `ganache` and `buidler`. I hijacked the `estimateGas` functions of each to simply return the block gas limit because (for whatever reason) gas estimation doesn't work.

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
