### PR TITLE
Ensuring sufficient gas for L1 determinism

### DIFF
--- a/packages/contracts/contracts/optimistic-ethereum/ovm/StateTransitioner.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/ovm/StateTransitioner.sol
@@ -35,6 +35,8 @@ contract StateTransitioner is IStateTransitioner, ContractResolver {
 
     bytes32 constant private BYTES32_NULL = bytes32('');
     uint256 constant private UINT256_NULL = uint256(0);
+    // Max gas overhead that executeTransaction(...) can consume outside of the metered code contract execution.  TODO: parameterize
+    uint constant private MAX_EXECUTE_TRANSACTION_GAS_OVERHEAD = 500000;
 
 
     /*
@@ -229,8 +231,15 @@ contract StateTransitioner is IStateTransitioner, ContractResolver {
         stateManager.initNewTransactionExecution();
         executionManager.setStateManager(address(stateManager));
 
+        // Make sure we were given sufficient gas, accounting for EIP 150, +10000 to account for gas cost of prepping executeTransaction calldata
+        uint gasLeft = gasleft();
+        require(
+            gasLeft > ((_transactionData.gasLimit + MAX_EXECUTE_TRANSACTION_GAS_OVERHEAD + 10000) * 64 / 63),
+            "Insufficient gas supplied to ensure L1 execution will not run out of gas before OVM transaction gas limit."
+        );
+
         // Execute the transaction via the execution manager.
-        executionManager.executeTransaction(
+        executionManager.executeTransaction.gas(gasLeft)(
             _transactionData.timestamp,
             _transactionData.blockNumber,
             _transactionData.queueOrigin,

--- a/packages/contracts/test/contracts/ovm/StateTransitioner.spec.ts
+++ b/packages/contracts/test/contracts/ovm/StateTransitioner.spec.ts
@@ -51,7 +51,7 @@ const DUMMY_ACCOUNT_ADDRESSES = [
 // gas metering always causes some storage slots to be updated
 const DEFAULT_TX_NUM_STORAGE_UPDATES: number = 4
 
-const SUFFICIENT_APPLY_TRANSACTION_GAS = GAS_LIMIT*2
+const SUFFICIENT_APPLY_TRANSACTION_GAS = GAS_LIMIT * 2
 
 interface OVMTransactionData {
   timestamp: number
@@ -515,29 +515,24 @@ describe('StateTransitioner', () => {
       fraudTester.address,
       DUMMY_ACCOUNT_STORAGE()[0].key
     )
-    ;[stateTransitioner, stateManager, dummyTransactionData] = await initStateTransitioner(
+    ;[
+      stateTransitioner,
+      stateManager,
+      dummyTransactionData,
+    ] = await initStateTransitioner(
       StateTransitioner,
       StateManager,
       resolver.addressResolver,
       stateTrie,
       makeDummyTransaction('0x00')
     )
-    initializedDummyTxSnapshot = await ethers.provider.send(
-      'evm_snapshot',
-      []
-    )
+    initializedDummyTxSnapshot = await ethers.provider.send('evm_snapshot', [])
   })
 
   const revertToDummyTxSnapshot = async () => {
-    await ethers.provider.send(
-      'evm_revert',
-      [initializedDummyTxSnapshot]
-    )
+    await ethers.provider.send('evm_revert', [initializedDummyTxSnapshot])
     // evm_revert deletes the snapshot so reset it right after
-    initializedDummyTxSnapshot = await ethers.provider.send(
-      'evm_snapshot',
-      []
-    )
+    initializedDummyTxSnapshot = await ethers.provider.send('evm_snapshot', [])
   }
 
   let transactionData: OVMTransactionData
@@ -568,10 +563,7 @@ describe('StateTransitioner', () => {
       })
 
       it('should correctly reject inclusion of a contract with an invalid nonce', async () => {
-        await ethers.provider.send(
-          'evm_revert',
-          [initializedDummyTxSnapshot]
-        )
+        await ethers.provider.send('evm_revert', [initializedDummyTxSnapshot])
         await TestUtils.assertRevertsAsync(
           'Invalid account state provided.',
           async () => {
@@ -651,7 +643,9 @@ describe('StateTransitioner', () => {
       TestUtils.assertRevertsAsync(
         'Insufficient gas supplied to ensure L1 execution will not run out of gas before OVM transaction gas limit.',
         async () => {
-          await stateTransitioner.applyTransaction(dummyTransactionData, {gasLimit: GAS_LIMIT/2})
+          await stateTransitioner.applyTransaction(dummyTransactionData, {
+            gasLimit: GAS_LIMIT / 2,
+          })
         }
       )
     })
@@ -681,7 +675,9 @@ describe('StateTransitioner', () => {
         test.stateTrieWitness
       )
 
-      await stateTransitioner.applyTransaction(transactionData, {gasLimit: SUFFICIENT_APPLY_TRANSACTION_GAS})
+      await stateTransitioner.applyTransaction(transactionData, {
+        gasLimit: SUFFICIENT_APPLY_TRANSACTION_GAS,
+      })
       expect(await stateTransitioner.currentTransitionPhase()).to.equal(
         STATE_TRANSITIONER_PHASES.POST_EXECUTION
       )
@@ -742,7 +738,9 @@ describe('StateTransitioner', () => {
         accessTest.storageTrieWitness
       )
 
-      await stateTransitioner.applyTransaction(transactionData, {gasLimit: SUFFICIENT_APPLY_TRANSACTION_GAS})
+      await stateTransitioner.applyTransaction(transactionData, {
+        gasLimit: SUFFICIENT_APPLY_TRANSACTION_GAS,
+      })
       expect(await stateTransitioner.currentTransitionPhase()).to.equal(
         STATE_TRANSITIONER_PHASES.POST_EXECUTION
       )
@@ -775,7 +773,9 @@ describe('StateTransitioner', () => {
         test.stateTrieWitness
       )
 
-      await stateTransitioner.applyTransaction(transactionData, {gasLimit: SUFFICIENT_APPLY_TRANSACTION_GAS})
+      await stateTransitioner.applyTransaction(transactionData, {
+        gasLimit: SUFFICIENT_APPLY_TRANSACTION_GAS,
+      })
       expect(await stateTransitioner.currentTransitionPhase()).to.equal(
         STATE_TRANSITIONER_PHASES.POST_EXECUTION
       )
@@ -811,7 +811,9 @@ describe('StateTransitioner', () => {
       await TestUtils.assertRevertsAsync(
         'Detected an invalid state access.',
         async () => {
-          await stateTransitioner.applyTransaction(transactionData, {gasLimit: SUFFICIENT_APPLY_TRANSACTION_GAS})
+          await stateTransitioner.applyTransaction(transactionData, {
+            gasLimit: SUFFICIENT_APPLY_TRANSACTION_GAS,
+          })
         }
       )
 
@@ -842,7 +844,9 @@ describe('StateTransitioner', () => {
       await TestUtils.assertRevertsAsync(
         'Detected an invalid state access.',
         async () => {
-          await stateTransitioner.applyTransaction(transactionData, {gasLimit: SUFFICIENT_APPLY_TRANSACTION_GAS})
+          await stateTransitioner.applyTransaction(transactionData, {
+            gasLimit: SUFFICIENT_APPLY_TRANSACTION_GAS,
+          })
         }
       )
 
@@ -880,7 +884,9 @@ describe('StateTransitioner', () => {
           test.stateTrieWitness
         )
 
-        await stateTransitioner.applyTransaction(transactionData, {gasLimit: SUFFICIENT_APPLY_TRANSACTION_GAS})
+        await stateTransitioner.applyTransaction(transactionData, {
+          gasLimit: SUFFICIENT_APPLY_TRANSACTION_GAS,
+        })
 
         expect(await stateManager.updatedStorageSlotCounter()).to.equal(
           DEFAULT_TX_NUM_STORAGE_UPDATES + 1
@@ -926,7 +932,9 @@ describe('StateTransitioner', () => {
           test.stateTrieWitness
         )
 
-        await stateTransitioner.applyTransaction(transactionData, {gasLimit: SUFFICIENT_APPLY_TRANSACTION_GAS})
+        await stateTransitioner.applyTransaction(transactionData, {
+          gasLimit: SUFFICIENT_APPLY_TRANSACTION_GAS,
+        })
 
         expect(await stateManager.updatedStorageSlotCounter()).to.equal(
           DEFAULT_TX_NUM_STORAGE_UPDATES + 3
@@ -972,7 +980,9 @@ describe('StateTransitioner', () => {
           test.stateTrieWitness
         )
 
-        await stateTransitioner.applyTransaction(transactionData, {gasLimit: SUFFICIENT_APPLY_TRANSACTION_GAS})
+        await stateTransitioner.applyTransaction(transactionData, {
+          gasLimit: SUFFICIENT_APPLY_TRANSACTION_GAS,
+        })
 
         expect(await stateManager.updatedStorageSlotCounter()).to.equal(
           DEFAULT_TX_NUM_STORAGE_UPDATES + 1
@@ -1016,7 +1026,9 @@ describe('StateTransitioner', () => {
           test.stateTrieWitness
         )
 
-        await stateTransitioner.applyTransaction(transactionData, {gasLimit: SUFFICIENT_APPLY_TRANSACTION_GAS})
+        await stateTransitioner.applyTransaction(transactionData, {
+          gasLimit: SUFFICIENT_APPLY_TRANSACTION_GAS,
+        })
 
         // One update for each new contract, plus one nonce update for the creating contract.
         expect(await stateManager.updatedContractsCounter()).to.equal(2)
@@ -1060,7 +1072,9 @@ describe('StateTransitioner', () => {
           test.stateTrieWitness
         )
 
-        await stateTransitioner.applyTransaction(transactionData, {gasLimit: SUFFICIENT_APPLY_TRANSACTION_GAS})
+        await stateTransitioner.applyTransaction(transactionData, {
+          gasLimit: SUFFICIENT_APPLY_TRANSACTION_GAS,
+        })
 
         // One update for each new contract, plus one nonce update for the creating contract.
         expect(await stateManager.updatedContractsCounter()).to.equal(4)
@@ -1136,7 +1150,9 @@ describe('StateTransitioner', () => {
           accessTest.storageTrieWitness
         )
 
-        await stateTransitioner.applyTransaction(transactionData, {gasLimit: SUFFICIENT_APPLY_TRANSACTION_GAS})
+        await stateTransitioner.applyTransaction(transactionData, {
+          gasLimit: SUFFICIENT_APPLY_TRANSACTION_GAS,
+        })
         expect(await stateManager.updatedStorageSlotCounter()).to.equal(
           DEFAULT_TX_NUM_STORAGE_UPDATES + 0
         )
@@ -1175,7 +1191,9 @@ describe('StateTransitioner', () => {
           test.stateTrieWitness
         )
 
-        await stateTransitioner.applyTransaction(transactionData, {gasLimit: SUFFICIENT_APPLY_TRANSACTION_GAS})
+        await stateTransitioner.applyTransaction(transactionData, {
+          gasLimit: SUFFICIENT_APPLY_TRANSACTION_GAS,
+        })
         expect(await stateManager.updatedStorageSlotCounter()).to.equal(
           DEFAULT_TX_NUM_STORAGE_UPDATES + 1
         )


### PR DESCRIPTION
## Description
This ticket was originally to cover preventing max call depth inconsistency between L1 and L2.  However, it turns out due to [EIP 150](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-150.md), there is already an implicit upper bound on the call stack due to an exponential dropoff of max allottable gas per CALL.

This ticket enforces that sufficient gas is provided to the fraud proof so that EIP150 does not allow for multiple execution results based on input gas.

Note: this logic might be better off directly within `executeTransaction` (would remove the need for `MAX_EXECUTE_TRANSACTION_OVERHEAD` in STioner), but that breaks a ton of tests.  We can revisit next time tests get an overhaul.

## Metadata
### Fixes
- Fixes YAS 562

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
