### PR TITLE
fixing issue where we can silently fail and stall block processing

### DIFF
--- a/packages/core-db/src/app/ethereum/ethereum-block-processor.ts
+++ b/packages/core-db/src/app/ethereum/ethereum-block-processor.ts
@@ -114,9 +114,8 @@ export class EthereumBlockProcessor {
           `Error waiting for ${this.confirmsUntilFinal} confirms on block ${blockNumber}`,
           e
         )
-        // TODO: If this is not a re-org, this may require a restart or some other action.
-        //  Monitor what actually happens and re-throw here if necessary.
-        return
+        // Cannot silently fail here because syncing will move on as if this block was processed.
+        throw e
       }
 
       log.debug(
@@ -131,7 +130,13 @@ export class EthereumBlockProcessor {
         // purposefully ignore promise
         h.handle(block)
       } catch (e) {
-        // should be logged in handler
+        // Cannot silently fail here because syncing will move on as if the block was processed
+        logError(
+          log,
+          `Error in subscriber handling block number ${blockNumber}. Re-throwing because we cannot proceed skipping a block.`,
+          e
+        )
+        throw e
       }
     })
   }


### PR DESCRIPTION
## Description
Fixes issue where we don't re-throw when block subscription errors are caught, causing us to move on with block syncing and not re-fetch.


## Metadata

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
