### PR TITLE
Update Buidler OVM node plugin to work within tasks

### DIFF
--- a/packages/ovm-toolchain/buidler.config.ts
+++ b/packages/ovm-toolchain/buidler.config.ts
@@ -1,11 +1,24 @@
 import path from 'path'
-import { usePlugin } from '@nomiclabs/buidler/config'
+import { usePlugin, task } from '@nomiclabs/buidler/config'
 
 usePlugin('@nomiclabs/buidler-ethers')
 usePlugin('@nomiclabs/buidler-waffle')
 
 import './src/buidler-plugins/buidler-ovm-compiler'
 import './src/buidler-plugins/buidler-ovm-node'
+
+task('test')
+  .addFlag('ovm', 'Run tests on the OVM using a custom OVM provider')
+  .setAction(async (taskArguments, bre: any, runSuper) => {
+    if (taskArguments.ovm) {
+      console.log('Compiling and running tests in the OVM...')
+      bre.config.solc = {
+        path: path.resolve(__dirname, '../../node_modules/@eth-optimism/solc'),
+      }
+      await bre.config.startOvmNode()
+    }
+    await runSuper(taskArguments)
+  })
 
 const config: any = {
   networks: {
@@ -23,9 +36,8 @@ const config: any = {
     timeout: 50000,
   },
   solc: {
-    path: path.resolve(__dirname, '../../node_modules/@eth-optimism/solc'),
+    version: '0.5.16',
   },
-  useOvm: true,
 }
 
 export default config

--- a/packages/ovm-toolchain/package.json
+++ b/packages/ovm-toolchain/package.json
@@ -25,10 +25,10 @@
     "build:waffle": "waffle \"test/config/waffle-config.json\"",
     "build:typescript": "tsc -p .",
     "clean": "rimraf build/",
-    "test": "yarn run test:truffle && yarn run test:waffle-v2",
+    "test": "yarn run test:truffle && yarn run test:waffle-v2 && yarn run test:buidler",
     "test:truffle": "truffle test \"test/test-truffle/erc20.spec.js\" --config \"test/config/truffle-config.js\"",
     "test:waffle-v2": "waffle \"test/config/waffle-config.json\" && mocha --require source-map-support/register --require ts-node/register \"test/test-waffle-v2/**/*.spec.ts\" --timeout 10000",
-    "test:buidler": "buidler test"
+    "test:buidler": "buidler test --ovm"
   },
   "keywords": [
     "optimistic",

--- a/packages/ovm-toolchain/src/buidler-plugins/buidler-ovm-node.ts
+++ b/packages/ovm-toolchain/src/buidler-plugins/buidler-ovm-node.ts
@@ -6,7 +6,7 @@ const BN = require('bn.js')
 
 extendEnvironment(async (bre) => {
   const config: any = bre.config
-  if (config.useOvm) {
+  config.startOvmNode = async (): Promise<void> => {
     const gasLimit = 100_000_000
 
     // Initialize the provider so it has a VM instance ready to copy.


### PR DESCRIPTION
## Description
Updates the buidler ovm node plugin to expose a function `startOvmNode` that can be called within a task based on an `ovm` flag. This is needed for how Synthetix has their Buidler config set up.

## Questions
None
## Metadata
### Fixes
- Fixes #YAS-634

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [X] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
