### PR TITLE
Don't submit batches that will fail smart contract validation

### DIFF
--- a/packages/rollup-core/src/app/data/consumers/canonical-chain-batch-submitter.ts
+++ b/packages/rollup-core/src/app/data/consumers/canonical-chain-batch-submitter.ts
@@ -14,6 +14,7 @@ import {
   BatchSubmissionStatus,
   L2DataService,
   StateCommitmentBatchSubmission,
+  BatchSubmission,
 } from '../../../types/data'
 import { TransactionReceipt, TransactionResponse } from 'ethers/providers'
 import { UnexpectedBatchStatus } from '../../../types'
@@ -27,6 +28,8 @@ export class CanonicalChainBatchSubmitter extends ScheduledTask {
   constructor(
     private readonly dataService: L2DataService,
     private readonly canonicalTransactionChain: Contract,
+    private readonly l1ToL2QueueContract: Contract,
+    private readonly safetyQueueContract: Contract,
     periodMilliseconds = 10_000
   ) {
     super(periodMilliseconds)
@@ -69,8 +72,13 @@ export class CanonicalChainBatchSubmitter extends ScheduledTask {
       throw new UnexpectedBatchStatus(msg)
     }
 
+    const batchBlockNumber = await this.getBatchSubmissionBlockNumber()
+
+    this.validateBatchSubmission(batchSubmission, batchBlockNumber)
+
     const txHash: string = await this.buildAndSendRollupBatchTransaction(
-      batchSubmission
+      batchSubmission,
+      batchBlockNumber
     )
     if (!txHash) {
       return false
@@ -82,10 +90,12 @@ export class CanonicalChainBatchSubmitter extends ScheduledTask {
    * Builds and sends a Rollup Batch transaction to L1, returning its tx hash.
    *
    * @param l2Batch The L2 batch to send to L1.
+   * @param batchBlockNumber The BlockNumber for this batch
    * @returns The L1 tx hash.
    */
   private async buildAndSendRollupBatchTransaction(
-    l2Batch: TransactionBatchSubmission
+    l2Batch: TransactionBatchSubmission,
+    batchBlockNumber: number
   ): Promise<string> {
     let txHash: string
     try {
@@ -93,8 +103,6 @@ export class CanonicalChainBatchSubmitter extends ScheduledTask {
 
       // TODO: update this to work with geth-persisted timestamp/block number that updates based on L1 actions
       const timestamp = l2Batch.transactions[0].timestamp
-      const blockNumber =
-        (await this.canonicalTransactionChain.provider.getBlockNumber()) - 10 // broken for any prod setting but works for now
 
       log.debug(
         `Submitting tx batch ${l2Batch.batchNumber} with ${l2Batch.transactions.length} transactions to canonical chain. Timestamp: ${timestamp}`
@@ -102,7 +110,7 @@ export class CanonicalChainBatchSubmitter extends ScheduledTask {
       const txRes: TransactionResponse = await this.canonicalTransactionChain.appendSequencerBatch(
         txsCalldata,
         timestamp,
-        blockNumber
+        batchBlockNumber
       )
       log.debug(
         `Tx batch ${l2Batch.batchNumber} appended with at least one confirmation! Tx Hash: ${txRes.hash}`
@@ -196,5 +204,166 @@ export class CanonicalChainBatchSubmitter extends ScheduledTask {
       return false
     }
     return true
+  }
+
+  private async getBatchSubmissionBlockNumber(): Promise<number> {
+    // TODO: This is bad. Make this not suck.
+    return (await this.getL1BlockNumber()) - 10
+  }
+
+  private async validateBatchSubmission(
+    batchSubmission: TransactionBatchSubmission,
+    batchBlockNumber: number
+  ): Promise<void> {
+    let forceInclusionSeconds: number
+    let forceInclusionBlocks: number
+    let blockNumber: number
+    let safetyQueueTimestampSeconds: number
+    let safetyQueueBlockNumber: number
+    let l1ToL2QueueTimestampSeconds: number
+    let l1ToL2QueueBlockNumber: number
+    let lastOvmTimestampSeconds: number
+    let lastOvmBlockNumber: number
+    ;[
+      forceInclusionSeconds,
+      forceInclusionBlocks,
+      blockNumber,
+      safetyQueueTimestampSeconds,
+      safetyQueueBlockNumber,
+      l1ToL2QueueTimestampSeconds,
+      l1ToL2QueueBlockNumber,
+      lastOvmTimestampSeconds,
+      lastOvmBlockNumber,
+    ] = await Promise.all([
+      this.getForceInclusionPeriodSeconds(),
+      this.getForceInclusionPeriodBlocks(),
+      this.getL1BlockNumber(),
+      this.getMaxSafetyQueueTimestampSeconds(),
+      this.getMaxSafetyQueueBlockNumber(),
+      this.getMaxL1ToL2QueueTimestampSeconds(),
+      this.getMaxL1ToL2QueueBlockNumber(),
+      this.getLastOvmTimestampSeconds(),
+      this.getLastOvmBlockNumber(),
+    ])
+
+    const nowSeconds = Math.round(new Date().getTime() / 1000)
+    const batchTimestamp = batchSubmission.transactions[0].timestamp
+
+    if (batchBlockNumber > blockNumber) {
+      throw Error(
+        `Batch block number cannot be in the future. Batch block number is ${batchBlockNumber} and block number: ${blockNumber}.`
+      )
+    }
+
+    if (batchTimestamp > nowSeconds) {
+      throw Error(
+        `Batch timestamp cannot be in the future. Batch timestamp is ${batchTimestamp} and current timestamp is ${nowSeconds}.`
+      )
+    }
+
+    if (batchTimestamp + forceInclusionSeconds <= nowSeconds) {
+      throw Error(
+        `Batch is too old. Batch timestamp is ${batchTimestamp}, force inclusion period is ${forceInclusionSeconds}, now is ${nowSeconds}`
+      )
+    }
+
+    if (batchBlockNumber + forceInclusionBlocks <= blockNumber) {
+      throw Error(
+        `Batch is too old. Batch Block # is ${batchTimestamp}, force inclusion blocks is ${forceInclusionBlocks}, L1 block number is ${blockNumber}`
+      )
+    }
+
+    if (
+      safetyQueueTimestampSeconds !== 0 &&
+      batchTimestamp > safetyQueueTimestampSeconds
+    ) {
+      throw Error(
+        `Safety Queue tx must come first. Safety queue timestamp is ${safetyQueueTimestampSeconds}, batch timestamp is ${batchTimestamp}`
+      )
+    }
+
+    if (
+      safetyQueueBlockNumber !== 0 &&
+      batchBlockNumber > safetyQueueBlockNumber
+    ) {
+      throw Error(
+        `Safety Queue tx must come first. Safety queue blockNumber is ${safetyQueueBlockNumber}, batch blockNumber is ${batchBlockNumber}`
+      )
+    }
+
+    if (
+      l1ToL2QueueTimestampSeconds !== 0 &&
+      batchTimestamp > l1ToL2QueueTimestampSeconds
+    ) {
+      throw Error(
+        `L1 to L2 Queue tx must come first. L1 to L2 Queue timestamp is ${l1ToL2QueueTimestampSeconds}, batch timestamp is ${batchTimestamp}`
+      )
+    }
+
+    if (
+      l1ToL2QueueBlockNumber !== 0 &&
+      batchBlockNumber > l1ToL2QueueBlockNumber
+    ) {
+      throw Error(
+        `L1 to L2 Queue tx must come first. L1 to L2 Queue blockNumber is ${l1ToL2QueueBlockNumber}, batch blockNumber is ${batchBlockNumber}`
+      )
+    }
+
+    if (batchTimestamp < lastOvmTimestampSeconds) {
+      throw Error(
+        `Batch timestamp must be > last OVM Timestamp. Batch timestamp is ${batchTimestamp}, last OVM timestamp is ${lastOvmTimestampSeconds}`
+      )
+    }
+
+    if (batchBlockNumber < lastOvmBlockNumber) {
+      throw Error(
+        `Batch block number must be > last OVM block number. Batch block number is ${batchBlockNumber}, last OVM block number is ${lastOvmBlockNumber}`
+      )
+    }
+  }
+
+  private forceInclusionPeriodSeconds: number
+  private async getForceInclusionPeriodSeconds(): Promise<number> {
+    if (this.forceInclusionPeriodSeconds === undefined) {
+      const num = await this.canonicalTransactionChain.forceInclusionPeriodSeconds()
+      this.forceInclusionPeriodSeconds = num.toNumber
+    }
+    return this.forceInclusionPeriodSeconds
+  }
+
+  private forceInclusionPeriodBlocks: number
+  private async getForceInclusionPeriodBlocks(): Promise<number> {
+    if (this.forceInclusionPeriodBlocks === undefined) {
+      this.forceInclusionPeriodBlocks = await this.canonicalTransactionChain.forceInclusionPeriodBlocks()
+    }
+    return this.forceInclusionPeriodBlocks
+  }
+
+  private async getL1BlockNumber(): Promise<number> {
+    return this.canonicalTransactionChain.provider.getBlockNumber()
+  }
+
+  private async getMaxSafetyQueueTimestampSeconds(): Promise<number> {
+    return this.safetyQueueContract.peekTimestamp()
+  }
+
+  private async getMaxSafetyQueueBlockNumber(): Promise<number> {
+    return this.safetyQueueContract.peekBlockNumber()
+  }
+
+  private async getMaxL1ToL2QueueTimestampSeconds(): Promise<number> {
+    return this.l1ToL2QueueContract.peekTimestamp()
+  }
+
+  private async getMaxL1ToL2QueueBlockNumber(): Promise<number> {
+    return this.l1ToL2QueueContract.peekBlockNumber()
+  }
+
+  private async getLastOvmTimestampSeconds(): Promise<number> {
+    return this.canonicalTransactionChain.lastOVMTimestamp()
+  }
+
+  private async getLastOvmBlockNumber(): Promise<number> {
+    return this.canonicalTransactionChain.lastOVMBlockNumber()
   }
 }

--- a/packages/rollup-core/src/types/errors.ts
+++ b/packages/rollup-core/src/types/errors.ts
@@ -58,3 +58,67 @@ export class NotSyncedError extends Error {
     )
   }
 }
+
+/***************************
+ * Batch Submission Errors *
+ ***************************/
+
+export class FutureRollupBatchNumberError extends Error {
+  constructor(msg: string) {
+    super(msg)
+  }
+}
+
+export class FutureRollupBatchTimestampError extends Error {
+  constructor(msg: string) {
+    super(msg)
+  }
+}
+
+export class RollupBatchBlockNumberTooOldError extends Error {
+  constructor(msg: string) {
+    super(msg)
+  }
+}
+
+export class RollupBatchTimestampTooOldError extends Error {
+  constructor(msg: string) {
+    super(msg)
+  }
+}
+
+export class RollupBatchSafetyQueueBlockNumberError extends Error {
+  constructor(msg: string) {
+    super(msg)
+  }
+}
+
+export class RollupBatchSafetyQueueBlockTimestampError extends Error {
+  constructor(msg: string) {
+    super(msg)
+  }
+}
+
+export class RollupBatchL1ToL2QueueBlockNumberError extends Error {
+  constructor(msg: string) {
+    super(msg)
+  }
+}
+
+export class RollupBatchL1ToL2QueueBlockTimestampError extends Error {
+  constructor(msg: string) {
+    super(msg)
+  }
+}
+
+export class RollupBatchOvmBlockNumberError extends Error {
+  constructor(msg: string) {
+    super(msg)
+  }
+}
+
+export class RollupBatchOvmTimestampError extends Error {
+  constructor(msg: string) {
+    super(msg)
+  }
+}

--- a/packages/rollup-core/test/app/canonical-chain-batch-submitter.spec.ts
+++ b/packages/rollup-core/test/app/canonical-chain-batch-submitter.spec.ts
@@ -88,11 +88,26 @@ class MockCanonicalTransactionChain {
   }
 }
 
+class MockQueue {
+  public timestamp: number = 0
+  public blockNumber: number = 0
+
+  public async peekBlockNumber(): Promise<number> {
+    return this.blockNumber
+  }
+
+  public async peekTimestamp(): Promise<number> {
+    return this.blockNumber
+  }
+}
+
 describe('Canonical Chain Batch Submitter', () => {
   let batchSubmitter: CanonicalChainBatchSubmitter
   let dataService: MockDataService
   let canonicalProvider: MockProvider
   let canonicalTransactionChain: MockCanonicalTransactionChain
+  let l1ToL2TransactionQueue: MockQueue
+  let safetyQueue: MockQueue
 
   beforeEach(async () => {
     dataService = new MockDataService()
@@ -100,9 +115,13 @@ describe('Canonical Chain Batch Submitter', () => {
     canonicalTransactionChain = new MockCanonicalTransactionChain(
       canonicalProvider
     )
+    l1ToL2TransactionQueue = new MockQueue()
+    safetyQueue = new MockQueue()
     batchSubmitter = new CanonicalChainBatchSubmitter(
       dataService,
-      canonicalTransactionChain as any
+      canonicalTransactionChain as any,
+      l1ToL2TransactionQueue as any,
+      safetyQueue as any
     )
   })
 

--- a/packages/rollup-services/src/exec/services.ts
+++ b/packages/rollup-services/src/exec/services.ts
@@ -293,23 +293,47 @@ const createCanonicalChainBatchCreator = (): CanonicalChainBatchCreator => {
  * @returns The CanonicalChainBatchSubmitter.
  */
 const createCanonicalChainBatchSubmitter = (): CanonicalChainBatchSubmitter => {
-  const contractAddress: string = Environment.getOrThrow(
+  const canonicalTxChainAddress: string = Environment.getOrThrow(
     Environment.canonicalTransactionChainContractAddress
+  )
+  const l1ToL2TransactionQueueAddress: string = Environment.getOrThrow(
+    Environment.l1ToL2TransactionQueueContractAddress
+  )
+  const safetyQueueAddress: string = Environment.getOrThrow(
+    Environment.safetyTransactionQueueContractAddress
   )
   const period: number = Environment.getOrThrow(
     Environment.canonicalChainBatchSubmitterPeriodMillis
   )
   log.info(
-    `Creating CanonicalChainBatchSubmitter with the canonical chain contract address of ${contractAddress}, and period of ${period} millis.`
+    `Creating CanonicalChainBatchSubmitter with the canonical chain contract address of ${canonicalTxChainAddress}, l1 to l2 contract address of ${l1ToL2TransactionQueueAddress}, safety queue contract address of ${safetyQueueAddress}, and period of ${period} millis.`
   )
 
-  const contract: Contract = new Contract(
-    contractAddress,
+  const canonicalTxChainContract: Contract = new Contract(
+    canonicalTxChainAddress,
     getContractDefinition('CanonicalTransactionChain').abi,
     getSequencerWallet()
   )
 
-  return new CanonicalChainBatchSubmitter(getDataService(), contract, period)
+  const l1ToL2TransactionChainContract: Contract = new Contract(
+    l1ToL2TransactionQueueAddress,
+    getContractDefinition('L1ToL2TransactionQueue').abi,
+    getSequencerWallet()
+  )
+
+  const safetyQueueContract: Contract = new Contract(
+    safetyQueueAddress,
+    getContractDefinition('SafetyTransactionQueue').abi,
+    getSequencerWallet()
+  )
+
+  return new CanonicalChainBatchSubmitter(
+    getDataService(),
+    canonicalTxChainContract,
+    l1ToL2TransactionChainContract,
+    safetyQueueContract,
+    period
+  )
 }
 
 /**


### PR DESCRIPTION
## Description
Adds validation that matches smart contract validation to Batch Submitter jobs to not submit (and pay for) transactions that will predictably fail.


## Metadata
### Fixes
- Fixes # [YAS-593](https://optimists.atlassian.net/browse/YAS-593)

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
