### PR TITLE
Re-enabling FraudTester deployment check

### DIFF
--- a/packages/contracts/contracts/test-helpers/FraudTester.sol
+++ b/packages/contracts/contracts/test-helpers/FraudTester.sol
@@ -32,10 +32,9 @@ contract FraudTester is BaseFraudTester {
         assembly {
             let newContractAddress := create(0, add(_initcode, 0x20), mload(_initcode))
 
-            // TODO: add back this check
-            // if iszero(extcodesize(newContractAddress)) {
-            //     revert(0, 0)
-            // }
+            if iszero(extcodesize(newContractAddress)) {
+                revert(0, 0)
+            }
         }
     }
 


### PR DESCRIPTION
## Description
This ticket covers YAS 618, which was a bug in our fraud tester.  Somehow, upon revisiting, the bug appears gone.  Woo!
## Questions
N/A

## Metadata
### Fixes
- Fixes YAS 618
## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
