### PR TITLE
Add native solc option

### DIFF
--- a/packages/ovm-toolchain/package.json
+++ b/packages/ovm-toolchain/package.json
@@ -71,6 +71,7 @@
     "@eth-optimism/solc-transpiler": "^0.0.1-alpha.28",
     "@nomiclabs/buidler": "^1.4.4",
     "bn.js": "^5.1.3",
+    "child_process": "^1.0.2",
     "ethereum-waffle-v2": "npm:ethereum-waffle@2",
     "ethereum-waffle-v3": "npm:ethereum-waffle@3",
     "ethereumjs-ovm": "git+https://github.com/ethereum-optimism/ethereumjs-vm",

--- a/packages/ovm-toolchain/src/buidler-plugins/buidler-ovm-compiler.ts
+++ b/packages/ovm-toolchain/src/buidler-plugins/buidler-ovm-compiler.ts
@@ -4,6 +4,7 @@ import { internalTask } from '@nomiclabs/buidler/config'
 import { SolcInput } from '@nomiclabs/buidler/types'
 import { Compiler } from '@nomiclabs/buidler/internal/solidity/compiler'
 import { TASK_COMPILE_RUN_COMPILER } from '@nomiclabs/buidler/builtin-tasks/task-names'
+import { execSync } from 'child_process'
 
 internalTask(TASK_COMPILE_RUN_COMPILER).setAction(
   async ({ input }: { input: SolcInput }, { config }) => {
@@ -22,7 +23,14 @@ internalTask(TASK_COMPILE_RUN_COMPILER).setAction(
         return customCompiler
       }
     }
-
-    return compiler.compile(input)
+    if ((config as any).solc.native === true) {
+      console.log(`Using native solidity compiler`)
+      const output = execSync(`solc --standard-json`, {
+        input: JSON.stringify(input, undefined, 2),
+      })
+      return JSON.parse(output.toString('utf8'))
+    } else {
+      return compiler.compile(input)
+    }
   }
 )

--- a/yarn.lock
+++ b/yarn.lock
@@ -39,42 +39,6 @@
   resolved "https://registry.yarnpkg.com/@ensdomains/resolver/-/resolver-0.2.4.tgz#c10fe28bf5efbf49bff4666d909aed0265efbc89"
   integrity sha512-bvaTH34PMCbv6anRa9I/0zjLJgY4EuznbEMgbV77JBCQ9KNC46rzi0avuxpOfu+xDjPEtSFGqVEOr5GlUSGudA==
 
-"@eth-optimism/core-db@^0.0.1-alpha.27":
-  version "0.0.1-alpha.27"
-  resolved "https://registry.yarnpkg.com/@eth-optimism/core-db/-/core-db-0.0.1-alpha.27.tgz#c1b5bab856d5bca44d26de9685e2fa9f1b48b579"
-  integrity sha512-kKkGvss/w7q57NTTFWbY1B3VKI0soClBHDvcP1t5CJrNw7ggkSrlgEbx+LsriTd/vn+fL5iUgwCIcUJn711A0Q==
-  dependencies:
-    "@eth-optimism/core-utils" "^0.0.1-alpha.27"
-    abstract-leveldown "^6.2.2"
-    async-lock "^1.2.2"
-    chai "^4.2.0"
-    chai-as-promised "^7.1.1"
-    debug "^4.1.1"
-    ethers "^4.0.39"
-    level "^6.0.0"
-    memdown "^4.0.0"
-
-"@eth-optimism/core-utils@^0.0.1-alpha.27":
-  version "0.0.1-alpha.27"
-  resolved "https://registry.yarnpkg.com/@eth-optimism/core-utils/-/core-utils-0.0.1-alpha.27.tgz#b43c8b5cd8ee89de7294c5f93aef5c47ee846cf5"
-  integrity sha512-OLQONkCevn6xaAyFlxOrL5BkE8BycvicBk0+RDL13g4OXSl/WkLaAjzUJcxYsGDzDUaB7yPUcwLQwUaT6xmcww==
-  dependencies:
-    abstract-leveldown "^6.2.2"
-    async-lock "^1.2.2"
-    axios "^0.19.0"
-    bn.js "^4.11.8"
-    body-parser "^1.19.0"
-    chai "^4.2.0"
-    chai-as-promised "^7.1.1"
-    debug "^4.1.1"
-    dotenv "^8.2.0"
-    ethereumjs-util "^6.2.0"
-    ethers "^4.0.37"
-    express "^4.17.1"
-    memdown "^4.0.0"
-    ts-md5 "^1.2.4"
-    uuid "^3.3.3"
-
 "@eth-optimism/rollup-core@^0.0.1-alpha.28":
   version "0.0.1-alpha.28"
   resolved "https://registry.yarnpkg.com/@eth-optimism/rollup-core/-/rollup-core-0.0.1-alpha.28.tgz#845de41ed266e0f1fd738776cb68bfe1fa391104"
@@ -3639,6 +3603,11 @@ checkpoint-store@^1.1.0:
   integrity sha1-BOTLUWuRQziTWB5tRgGnjpVS6gY=
   dependencies:
     functional-red-black-tree "^1.0.1"
+
+child_process@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/child_process/-/child_process-1.0.2.tgz#b1f7e7fc73d25e7fd1d455adc94e143830182b5a"
+  integrity sha1-sffn/HPSXn/R1FWtyU4UODAYK1o=
 
 chokidar@3.3.0:
   version "3.3.0"


### PR DESCRIPTION
## Description
Adds a config option:
``` 
config: {
  solc: {
    native: true
  }
}
```
That will use the native `solc` compiler. This is necessary to quickly test changes to the solidity compiler, as compiling to `solcjs` take ~25 minutes.


## Questions
None

## Metadata
### Fixes
- Fixes #YAS-636

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [X] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
