### PR TITLE
Adding startsAtIndex to sequencer batch appending

### DIFF
--- a/packages/contracts/contracts/optimistic-ethereum/chain/CanonicalTransactionChain.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/chain/CanonicalTransactionChain.sol
@@ -184,9 +184,10 @@ contract CanonicalTransactionChain is ContractResolver {
             else if (safetyQueueIsEmpty) {
                 appendL1ToL2Batch();
             }
-            else if (safetyQueue.peekTimestamp() < l1ToL2Queue.peekTimestamp()) {
+            else if (safetyQueue.peekTimestamp() <= l1ToL2Queue.peekTimestamp()) {
                 appendSafetyBatch();
-            } else {
+            }
+            else {
                 appendL1ToL2Batch();
             }
         }

--- a/packages/contracts/contracts/optimistic-ethereum/chain/StateCommitmentChain.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/chain/StateCommitmentChain.sol
@@ -114,6 +114,9 @@ contract StateCommitmentChain is ContractResolver {
 
         bytes32[] memory batchToAppend;
         if (_startsAtRootIndex < cumulativeNumElements) {
+            // TODO: This can be made much more efficient later by just making
+            // TODO: merkleUtils.getMerkleRootFrom32ByteLeafData take an index
+            // TODO: indicating the start of the array instead of creating a new one
             uint elementsToSkip = cumulativeNumElements - _startsAtRootIndex;
             batchToAppend = new bytes32[](_stateBatch.length - elementsToSkip);
             for (uint i = 0; i < batchToAppend.length; i++) {

--- a/packages/contracts/contracts/optimistic-ethereum/chain/StateCommitmentChain.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/chain/StateCommitmentChain.sol
@@ -102,6 +102,11 @@ contract StateCommitmentChain is ContractResolver {
             "Cannot submit an empty state commitment batch"
         );
 
+        require(
+            _startsAtRootIndex <= cumulativeNumElements,
+            "_startsAtRootIndex index indicates future state root"
+        );
+
         if (cumulativeNumElements >= _startsAtRootIndex + _stateBatch.length) {
             // This means all the roots in this batch were already appended. Don't fail, but don't change state.
             return;

--- a/packages/contracts/contracts/optimistic-ethereum/chain/StateCommitmentChain.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/chain/StateCommitmentChain.sol
@@ -102,7 +102,7 @@ contract StateCommitmentChain is ContractResolver {
             "Cannot submit an empty state commitment batch"
         );
 
-        if (_startsAtRootIndex + _stateBatch.length >= cumulativeNumElements) {
+        if (cumulativeNumElements >= _startsAtRootIndex + _stateBatch.length) {
             // This means all the roots in this batch were already appended. Don't fail, but don't change state.
             return;
         }

--- a/packages/contracts/test/contracts/chain/CanonicalTransactionChain.spec.ts
+++ b/packages/contracts/test/contracts/chain/CanonicalTransactionChain.spec.ts
@@ -723,7 +723,8 @@ describe('CanonicalTransactionChain', () => {
 
     describe('when the txs in the batch are not the next index', () => {
       it('reverts if starts at index is less than canonical chain length', async () => {
-        const blockNumber = 1
+        const blockNumber =
+          (await canonicalTxChain.provider.getBlockNumber()) - 1
         const timestamp = Math.round(new Date().getTime() / 1000) - 5
         const startsAtIndex = 0
         await canonicalTxChain
@@ -749,7 +750,8 @@ describe('CanonicalTransactionChain', () => {
       })
 
       it('reverts if starts at index is greater than canonical chain length and there are no queued batches', async () => {
-        const blockNumber = 1
+        const blockNumber =
+          (await canonicalTxChain.provider.getBlockNumber()) - 1
         const timestamp = Math.round(new Date().getTime() / 1000) - 5
         const startsAtIndex = 1
         // Should fail because the index needs to be 1

--- a/packages/contracts/test/contracts/chain/StateCommitmentChain.spec.ts
+++ b/packages/contracts/test/contracts/chain/StateCommitmentChain.spec.ts
@@ -147,12 +147,9 @@ describe('StateCommitmentChain', () => {
 
     it('should throw if submitting an empty batch', async () => {
       const emptyBatch = []
-      await TestUtils.assertRevertsAsync(
-        'Cannot submit an empty state commitment batch',
-        async () => {
-          await stateChain.appendStateBatch(emptyBatch, 0)
-        }
-      )
+      await TestUtils.assertRevertsAsync(async () => {
+        await stateChain.appendStateBatch(emptyBatch, 0)
+      }, 'Cannot submit an empty state commitment batch')
     })
 
     it('should add to batches array', async () => {
@@ -204,15 +201,12 @@ describe('StateCommitmentChain', () => {
           i * DEFAULT_STATE_BATCH.length
         )
       }
-      await TestUtils.assertRevertsAsync(
-        'Cannot append more state commitments than total number of transactions in CanonicalTransactionChain',
-        async () => {
-          await stateChain.appendStateBatch(
-            DEFAULT_STATE_BATCH,
-            numBatches * DEFAULT_STATE_BATCH.length
-          )
-        }
-      )
+      await TestUtils.assertRevertsAsync(async () => {
+        await stateChain.appendStateBatch(
+          DEFAULT_STATE_BATCH,
+          numBatches * DEFAULT_STATE_BATCH.length
+        )
+      }, 'Cannot append more state commitments than total number of transactions in CanonicalTransactionChain')
     })
   })
 
@@ -317,15 +311,12 @@ describe('StateCommitmentChain', () => {
         numElementsInBatch: DEFAULT_STATE_BATCH.length,
         cumulativePrevElements,
       }
-      await TestUtils.assertRevertsAsync(
-        'Only FraudVerifier has permission to delete state batches',
-        async () => {
-          await stateChain.connect(randomWallet).deleteAfterInclusive(
-            batchIndex, // delete the single appended batch
-            batchHeader
-          )
-        }
-      )
+      await TestUtils.assertRevertsAsync(async () => {
+        await stateChain.connect(randomWallet).deleteAfterInclusive(
+          batchIndex, // delete the single appended batch
+          batchHeader
+        )
+      }, 'Only FraudVerifier has permission to delete state batches')
     })
     describe('when a single batch is deleted', async () => {
       beforeEach(async () => {
@@ -395,15 +386,12 @@ describe('StateCommitmentChain', () => {
         numElementsInBatch: DEFAULT_STATE_BATCH.length + 1, // increment to make header incorrect
         cumulativePrevElements,
       }
-      await TestUtils.assertRevertsAsync(
-        'Calculated batch header is different than expected batch header',
-        async () => {
-          await stateChain.connect(fraudVerifier).deleteAfterInclusive(
-            batchIndex, // delete the single appended batch
-            batchHeader
-          )
-        }
-      )
+      await TestUtils.assertRevertsAsync(async () => {
+        await stateChain.connect(fraudVerifier).deleteAfterInclusive(
+          batchIndex, // delete the single appended batch
+          batchHeader
+        )
+      }, 'Calculated batch header is different than expected batch header')
     })
 
     it('should revert if trying to delete a batch outside of valid range', async () => {
@@ -415,14 +403,11 @@ describe('StateCommitmentChain', () => {
         numElementsInBatch: DEFAULT_STATE_BATCH.length + 1, // increment to make header incorrect
         cumulativePrevElements,
       }
-      await TestUtils.assertRevertsAsync(
-        'Cannot delete batches outside of valid range',
-        async () => {
-          await stateChain
-            .connect(fraudVerifier)
-            .deleteAfterInclusive(batchIndex, batchHeader)
-        }
-      )
+      await TestUtils.assertRevertsAsync(async () => {
+        await stateChain
+          .connect(fraudVerifier)
+          .deleteAfterInclusive(batchIndex, batchHeader)
+      }, 'Cannot delete batches outside of valid range')
     })
   })
 

--- a/packages/contracts/test/contracts/chain/StateCommitmentChain.spec.ts
+++ b/packages/contracts/test/contracts/chain/StateCommitmentChain.spec.ts
@@ -228,7 +228,9 @@ describe('StateCommitmentChain', () => {
       )
       const secondBatchHeaderHashExpected = await secondLocalBatch.hashBatchHeader()
       const calculatedSecondBatchHeaderHash = await stateChain.batches(1)
-      calculatedSecondBatchHeaderHash.should.equal(secondBatchHeaderHashExpected)
+      calculatedSecondBatchHeaderHash.should.equal(
+        secondBatchHeaderHashExpected
+      )
 
       const cumulativeNumElements = await stateChain.cumulativeNumElements.call()
       cumulativeNumElements.toNumber().should.equal(5)

--- a/packages/contracts/test/contracts/ovm/FraudVerifier.spec.ts
+++ b/packages/contracts/test/contracts/ovm/FraudVerifier.spec.ts
@@ -299,18 +299,15 @@ describe('FraudVerifier', () => {
         0
       )
 
-      await TestUtils.assertRevertsAsync(
-        'Provided pre-state root inclusion proof is invalid.',
-        async () => {
-          await fraudVerifier.initializeFraudVerification(
-            transactionIndex,
-            preStateRoot,
-            preStateRootProof,
-            transaction,
-            transactionProof
-          )
-        }
-      )
+      await TestUtils.assertRevertsAsync(async () => {
+        await fraudVerifier.initializeFraudVerification(
+          transactionIndex,
+          preStateRoot,
+          preStateRootProof,
+          transaction,
+          transactionProof
+        )
+      }, 'Provided pre-state root inclusion proof is invalid.')
 
       expect(
         await fraudVerifier.hasStateTransitioner(transactionIndex, preStateRoot)
@@ -328,18 +325,15 @@ describe('FraudVerifier', () => {
         0
       )
 
-      await TestUtils.assertRevertsAsync(
-        'Provided transaction data is invalid.',
-        async () => {
-          await fraudVerifier.initializeFraudVerification(
-            transactionIndex,
-            preStateRoot,
-            preStateRootProof,
-            transaction,
-            transactionProof
-          )
-        }
-      )
+      await TestUtils.assertRevertsAsync(async () => {
+        await fraudVerifier.initializeFraudVerification(
+          transactionIndex,
+          preStateRoot,
+          preStateRootProof,
+          transaction,
+          transactionProof
+        )
+      }, 'Provided transaction data is invalid.')
 
       expect(
         await fraudVerifier.hasStateTransitioner(transactionIndex, preStateRoot)
@@ -414,18 +408,15 @@ describe('FraudVerifier', () => {
 
       expect(await stateCommitmentChain.getBatchesLength()).to.equal(1)
 
-      await TestUtils.assertRevertsAsync(
-        'State transition process has not been completed.',
-        async () => {
-          await fraudVerifier.finalizeFraudVerification(
-            transactionIndex,
-            preStateRoot,
-            preStateRootProof,
-            postStateRoot,
-            postStateRootProof
-          )
-        }
-      )
+      await TestUtils.assertRevertsAsync(async () => {
+        await fraudVerifier.finalizeFraudVerification(
+          transactionIndex,
+          preStateRoot,
+          preStateRootProof,
+          postStateRoot,
+          postStateRootProof
+        )
+      }, 'State transition process has not been completed.')
 
       expect(await stateCommitmentChain.getBatchesLength()).to.equal(1)
     })
@@ -445,18 +436,15 @@ describe('FraudVerifier', () => {
 
       expect(await stateCommitmentChain.getBatchesLength()).to.equal(1)
 
-      await TestUtils.assertRevertsAsync(
-        'Provided pre-state root does not match StateTransitioner.',
-        async () => {
-          await fraudVerifier.finalizeFraudVerification(
-            transactionIndex,
-            preStateRoot,
-            preStateRootProof,
-            postStateRoot,
-            postStateRootProof
-          )
-        }
-      )
+      await TestUtils.assertRevertsAsync(async () => {
+        await fraudVerifier.finalizeFraudVerification(
+          transactionIndex,
+          preStateRoot,
+          preStateRootProof,
+          postStateRoot,
+          postStateRootProof
+        )
+      }, 'Provided pre-state root does not match StateTransitioner.')
 
       expect(await stateCommitmentChain.getBatchesLength()).to.equal(1)
     })
@@ -476,18 +464,15 @@ describe('FraudVerifier', () => {
 
       expect(await stateCommitmentChain.getBatchesLength()).to.equal(1)
 
-      await TestUtils.assertRevertsAsync(
-        'Provided pre-state root inclusion proof is invalid.',
-        async () => {
-          await fraudVerifier.finalizeFraudVerification(
-            transactionIndex,
-            preStateRoot,
-            preStateRootProof,
-            postStateRoot,
-            postStateRootProof
-          )
-        }
-      )
+      await TestUtils.assertRevertsAsync(async () => {
+        await fraudVerifier.finalizeFraudVerification(
+          transactionIndex,
+          preStateRoot,
+          preStateRootProof,
+          postStateRoot,
+          postStateRootProof
+        )
+      }, 'Provided pre-state root inclusion proof is invalid.')
 
       expect(await stateCommitmentChain.getBatchesLength()).to.equal(1)
     })
@@ -507,18 +492,15 @@ describe('FraudVerifier', () => {
 
       expect(await stateCommitmentChain.getBatchesLength()).to.equal(1)
 
-      await TestUtils.assertRevertsAsync(
-        'Provided post-state root inclusion proof is invalid.',
-        async () => {
-          await fraudVerifier.finalizeFraudVerification(
-            transactionIndex,
-            preStateRoot,
-            preStateRootProof,
-            postStateRoot,
-            postStateRootProof
-          )
-        }
-      )
+      await TestUtils.assertRevertsAsync(async () => {
+        await fraudVerifier.finalizeFraudVerification(
+          transactionIndex,
+          preStateRoot,
+          preStateRootProof,
+          postStateRoot,
+          postStateRootProof
+        )
+      }, 'Provided post-state root inclusion proof is invalid.')
 
       expect(await stateCommitmentChain.getBatchesLength()).to.equal(1)
     })
@@ -538,18 +520,15 @@ describe('FraudVerifier', () => {
 
       expect(await stateCommitmentChain.getBatchesLength()).to.equal(1)
 
-      await TestUtils.assertRevertsAsync(
-        'State transition has not been proven fraudulent.',
-        async () => {
-          await fraudVerifier.finalizeFraudVerification(
-            transactionIndex,
-            preStateRoot,
-            preStateRootProof,
-            postStateRoot,
-            postStateRootProof
-          )
-        }
-      )
+      await TestUtils.assertRevertsAsync(async () => {
+        await fraudVerifier.finalizeFraudVerification(
+          transactionIndex,
+          preStateRoot,
+          preStateRootProof,
+          postStateRoot,
+          postStateRootProof
+        )
+      }, 'State transition has not been proven fraudulent.')
 
       expect(await stateCommitmentChain.getBatchesLength()).to.equal(1)
     })

--- a/packages/contracts/test/contracts/ovm/FraudVerifier.spec.ts
+++ b/packages/contracts/test/contracts/ovm/FraudVerifier.spec.ts
@@ -64,14 +64,15 @@ const encodeTransaction = (transaction: OVMTransactionData): string => {
 const appendTransactionBatch = async (
   canonicalTransactionChain: Contract,
   sequencer: Signer,
-  batch: string[]
+  batch: string[],
+  txStartIndex: number
 ): Promise<number[]> => {
   const blockNumber = await canonicalTransactionChain.provider.getBlockNumber()
   const timestamp = Math.floor(Date.now() / 1000)
 
   await canonicalTransactionChain
     .connect(sequencer)
-    .appendSequencerBatch(batch, timestamp, blockNumber)
+    .appendSequencerBatch(batch, timestamp, blockNumber, txStartIndex)
 
   return [timestamp, blockNumber]
 }
@@ -86,7 +87,8 @@ const appendAndGenerateTransactionBatch = async (
   const [timestamp, blockNumber] = await appendTransactionBatch(
     canonicalTransactionChain,
     sequencer,
-    batch
+    batch,
+    cumulativePrevElements
   )
 
   const localBatch = new TxChainBatch(
@@ -109,7 +111,7 @@ const appendAndGenerateStateBatch = async (
   batchIndex: number = 0,
   cumulativePrevElements: number = 0
 ): Promise<StateChainBatch> => {
-  await stateCommitmentChain.appendStateBatch(batch)
+  await stateCommitmentChain.appendStateBatch(batch, cumulativePrevElements)
 
   const localBatch = new StateChainBatch(
     batchIndex,

--- a/packages/contracts/test/contracts/ovm/StateTransitioner.spec.ts
+++ b/packages/contracts/test/contracts/ovm/StateTransitioner.spec.ts
@@ -564,17 +564,14 @@ describe('StateTransitioner', () => {
 
       it('should correctly reject inclusion of a contract with an invalid nonce', async () => {
         await ethers.provider.send('evm_revert', [initializedDummyTxSnapshot])
-        await TestUtils.assertRevertsAsync(
-          'Invalid account state provided.',
-          async () => {
-            await stateTransitioner.proveContractInclusion(
-              fraudTester.address,
-              fraudTester.address,
-              123, // Wrong nonce.
-              test.stateTrieWitness
-            )
-          }
-        )
+        await TestUtils.assertRevertsAsync(async () => {
+          await stateTransitioner.proveContractInclusion(
+            fraudTester.address,
+            fraudTester.address,
+            123, // Wrong nonce.
+            test.stateTrieWitness
+          )
+        }, 'Invalid account state provided.')
 
         expect(
           await stateManager.isVerifiedContract(fraudTester.address)
@@ -615,18 +612,15 @@ describe('StateTransitioner', () => {
           test.stateTrieWitness
         )
 
-        await TestUtils.assertRevertsAsync(
-          'Invalid account state provided.',
-          async () => {
-            await stateTransitioner.proveStorageSlotInclusion(
-              fraudTester.address,
-              DUMMY_ACCOUNT_STORAGE()[0].key,
-              DUMMY_ACCOUNT_STORAGE()[1].val, // Different value.
-              test.stateTrieWitness,
-              test.storageTrieWitness
-            )
-          }
-        )
+        await TestUtils.assertRevertsAsync(async () => {
+          await stateTransitioner.proveStorageSlotInclusion(
+            fraudTester.address,
+            DUMMY_ACCOUNT_STORAGE()[0].key,
+            DUMMY_ACCOUNT_STORAGE()[1].val, // Different value.
+            test.stateTrieWitness,
+            test.storageTrieWitness
+          )
+        }, 'Invalid account state provided.')
 
         expect(
           await stateManager.isVerifiedStorage(
@@ -640,14 +634,11 @@ describe('StateTransitioner', () => {
 
   describe('applyTransaction(...)', async () => {
     it('should fail if supplied less gas than might be needed to executeTransaction(...)', async () => {
-      TestUtils.assertRevertsAsync(
-        'Insufficient gas supplied to ensure L1 execution will not run out of gas before OVM transaction gas limit.',
-        async () => {
-          await stateTransitioner.applyTransaction(dummyTransactionData, {
-            gasLimit: GAS_LIMIT / 2,
-          })
-        }
-      )
+      TestUtils.assertRevertsAsync(async () => {
+        await stateTransitioner.applyTransaction(dummyTransactionData, {
+          gasLimit: GAS_LIMIT / 2,
+        })
+      }, 'Insufficient gas supplied to ensure L1 execution will not run out of gas before OVM transaction gas limit.')
     })
     it('should succeed if no state is accessed', async () => {
       ;[
@@ -808,14 +799,11 @@ describe('StateTransitioner', () => {
         test.stateTrieWitness
       )
 
-      await TestUtils.assertRevertsAsync(
-        'Detected an invalid state access.',
-        async () => {
-          await stateTransitioner.applyTransaction(transactionData, {
-            gasLimit: SUFFICIENT_APPLY_TRANSACTION_GAS,
-          })
-        }
-      )
+      await TestUtils.assertRevertsAsync(async () => {
+        await stateTransitioner.applyTransaction(transactionData, {
+          gasLimit: SUFFICIENT_APPLY_TRANSACTION_GAS,
+        })
+      }, 'Detected an invalid state access.')
 
       expect(await stateTransitioner.currentTransitionPhase()).to.equal(
         STATE_TRANSITIONER_PHASES.PRE_EXECUTION
@@ -841,14 +829,11 @@ describe('StateTransitioner', () => {
         )
       )
 
-      await TestUtils.assertRevertsAsync(
-        'Detected an invalid state access.',
-        async () => {
-          await stateTransitioner.applyTransaction(transactionData, {
-            gasLimit: SUFFICIENT_APPLY_TRANSACTION_GAS,
-          })
-        }
-      )
+      await TestUtils.assertRevertsAsync(async () => {
+        await stateTransitioner.applyTransaction(transactionData, {
+          gasLimit: SUFFICIENT_APPLY_TRANSACTION_GAS,
+        })
+      }, 'Detected an invalid state access.')
 
       expect(await stateTransitioner.currentTransitionPhase()).to.equal(
         STATE_TRANSITIONER_PHASES.PRE_EXECUTION

--- a/packages/contracts/test/contracts/ovm/execution-manager/ExecutionManager.create-opcodes.spec.ts
+++ b/packages/contracts/test/contracts/ovm/execution-manager/ExecutionManager.create-opcodes.spec.ts
@@ -117,16 +117,13 @@ describe('ExecutionManager -- Create opcodes', () => {
       const data = add0x(
         methodIds.ovmCREATE + encodeRawArguments([deployInvalidTx.data])
       )
-      await TestUtils.assertRevertsAsync(
-        'Contract init (creation) code is not safe',
-        async () => {
-          await executionManager.provider.call({
-            to: executionManager.address,
-            data,
-            gasLimit: GAS_LIMIT,
-          })
-        }
-      )
+      await TestUtils.assertRevertsAsync(async () => {
+        await executionManager.provider.call({
+          to: executionManager.address,
+          data,
+          gasLimit: GAS_LIMIT,
+        })
+      }, 'Contract init (creation) code is not safe')
     })
   })
 
@@ -165,16 +162,13 @@ describe('ExecutionManager -- Create opcodes', () => {
         methodIds.ovmCREATE2 + encodeRawArguments([0, deployInvalidTx.data])
       )
 
-      await TestUtils.assertRevertsAsync(
-        'Contract init (creation) code is not safe',
-        async () => {
-          await executionManager.provider.call({
-            to: executionManager.address,
-            data,
-            gasLimit: GAS_LIMIT,
-          })
-        }
-      )
+      await TestUtils.assertRevertsAsync(async () => {
+        await executionManager.provider.call({
+          to: executionManager.address,
+          data,
+          gasLimit: GAS_LIMIT,
+        })
+      }, 'Contract init (creation) code is not safe')
     })
   })
 })

--- a/packages/contracts/test/contracts/ovm/execution-manager/ExecutionManager.executeCall.spec.ts
+++ b/packages/contracts/test/contracts/ovm/execution-manager/ExecutionManager.executeCall.spec.ts
@@ -111,24 +111,21 @@ describe('Execution Manager -- TX/Call Execution Functions', () => {
       const signedMessage = await signTransaction(wallet, transaction)
       const [v, r, s] = getSignedComponents(signedMessage)
 
-      await TestUtils.assertRevertsAsync(
-        'Timestamp must be greater than 0',
-        async () => {
-          // Call using Ethers
-          const tx = await executionManager.executeEOACall(
-            0,
-            0,
-            transaction.nonce,
-            transaction.to,
-            transaction.data,
-            GAS_LIMIT,
-            padToLength(v, 4),
-            padToLength(r, 64),
-            padToLength(s, 64)
-          )
-          await provider.waitForTransaction(tx.hash)
-        }
-      )
+      await TestUtils.assertRevertsAsync(async () => {
+        // Call using Ethers
+        const tx = await executionManager.executeEOACall(
+          0,
+          0,
+          transaction.nonce,
+          transaction.to,
+          transaction.data,
+          GAS_LIMIT,
+          padToLength(v, 4),
+          padToLength(r, 64),
+          padToLength(s, 64)
+        )
+        await provider.waitForTransaction(tx.hash)
+      }, 'Timestamp must be greater than 0')
     })
 
     it('properly executes a raw call -- 0 param', async () => {

--- a/packages/contracts/test/contracts/queue/L1ToL2TransactionQueue.spec.ts
+++ b/packages/contracts/test/contracts/queue/L1ToL2TransactionQueue.spec.ts
@@ -148,12 +148,9 @@ describe('L1ToL2TransactionQueue', () => {
       await l1ToL2TxQueue
         .connect(otherWallet)
         .enqueueL1ToL2Message(...defaultL1ToL2Params)
-      await TestUtils.assertRevertsAsync(
-        'Only the canonical transaction chain can dequeue L1->L2 queue transactions.',
-        async () => {
-          await l1ToL2TxQueue.dequeue()
-        }
-      )
+      await TestUtils.assertRevertsAsync(async () => {
+        await l1ToL2TxQueue.dequeue()
+      }, 'Only the canonical transaction chain can dequeue L1->L2 queue transactions.')
     })
   })
 })

--- a/packages/contracts/test/contracts/queue/RollupQueue.spec.ts
+++ b/packages/contracts/test/contracts/queue/RollupQueue.spec.ts
@@ -129,12 +129,9 @@ describe('RollupQueue', () => {
     })
 
     it('should revert if dequeueing from empty queue', async () => {
-      await TestUtils.assertRevertsAsync(
-        'Cannot dequeue from an empty queue',
-        async () => {
-          await rollupQueue.dequeue()
-        }
-      )
+      await TestUtils.assertRevertsAsync(async () => {
+        await rollupQueue.dequeue()
+      }, 'Cannot dequeue from an empty queue')
     })
 
     it('should revert if dequeueing from a once populated, now empty queue', async () => {
@@ -143,12 +140,9 @@ describe('RollupQueue', () => {
         await enqueueAndGenerateBatch(DEFAULT_TX)
         await rollupQueue.dequeue()
       }
-      await TestUtils.assertRevertsAsync(
-        'Cannot dequeue from an empty queue',
-        async () => {
-          await rollupQueue.dequeue()
-        }
-      )
+      await TestUtils.assertRevertsAsync(async () => {
+        await rollupQueue.dequeue()
+      }, 'Cannot dequeue from an empty queue')
     })
   })
 
@@ -168,18 +162,12 @@ describe('RollupQueue', () => {
     })
 
     it('should revert when peeking at an empty queue', async () => {
-      await TestUtils.assertRevertsAsync(
-        'Queue is empty, no element to peek at',
-        async () => {
-          await rollupQueue.peek()
-        }
-      )
-      await TestUtils.assertRevertsAsync(
-        'Queue is empty, no element to peek at',
-        async () => {
-          await rollupQueue.peekTimestamp()
-        }
-      )
+      await TestUtils.assertRevertsAsync(async () => {
+        await rollupQueue.peek()
+      }, 'Queue is empty, no element to peek at')
+      await TestUtils.assertRevertsAsync(async () => {
+        await rollupQueue.peekTimestamp()
+      }, 'Queue is empty, no element to peek at')
     })
   })
 })

--- a/packages/contracts/test/contracts/queue/SafetyTransactionQueue.spec.ts
+++ b/packages/contracts/test/contracts/queue/SafetyTransactionQueue.spec.ts
@@ -86,12 +86,9 @@ describe('SafetyTransactionQueue', () => {
         '0x1234123412341234',
       ])
 
-      TestUtils.assertRevertsAsync(
-        'Only EOAs can enqueue rollup transactions to the safety queue.',
-        async () => {
-          await simpleProxy.callContractWithData(safetyTxQueue.address, data)
-        }
-      )
+      TestUtils.assertRevertsAsync(async () => {
+        await simpleProxy.callContractWithData(safetyTxQueue.address, data)
+      }, 'Only EOAs can enqueue rollup transactions to the safety queue.')
     })
 
     it('should emit the right event on enqueue', async () => {
@@ -154,12 +151,9 @@ describe('SafetyTransactionQueue', () => {
 
     it('should not allow dequeue from other address', async () => {
       await safetyTxQueue.enqueueTx(defaultTx)
-      await TestUtils.assertRevertsAsync(
-        'Only the canonical transaction chain can dequeue safety queue transactions.',
-        async () => {
-          await safetyTxQueue.dequeue()
-        }
-      )
+      await TestUtils.assertRevertsAsync(async () => {
+        await safetyTxQueue.dequeue()
+      }, 'Only the canonical transaction chain can dequeue safety queue transactions.')
     })
   })
 })

--- a/packages/contracts/test/test-helpers/types/batch.ts
+++ b/packages/contracts/test/test-helpers/types/batch.ts
@@ -143,7 +143,7 @@ export class TxChainBatch extends ChainBatch {
     timestamp: number, // Ethereum timestamp this batch was submitted in
     blockNumber: number, // Same as above w/ blockNumber
     isL1ToL2Tx: boolean,
-    batchIndex: number, // index in batchs array (first batch has batchIndex of 0)
+    batchIndex: number, // index in batches array (first batch has batchIndex of 0)
     cumulativePrevElements: number,
     elements: any[],
     sender?: string

--- a/packages/core-db/src/app/ethereum/ethereum-block-processor.ts
+++ b/packages/core-db/src/app/ethereum/ethereum-block-processor.ts
@@ -173,7 +173,13 @@ export class EthereumBlockProcessor {
     }
 
     for (let i = syncStart; i <= blockNumber; i++) {
-      await this.fetchAndDisseminateBlock(provider, i)
+      try {
+        await this.fetchAndDisseminateBlock(provider, i)
+      } catch (e) {
+        logError(log, `Error fetching and disseminating block. Retrying...`, e)
+        i--
+        continue
+      }
       await this.storeLastProcessedBlockNumber(i)
     }
 

--- a/packages/core-utils/src/app/test-utils.ts
+++ b/packages/core-utils/src/app/test-utils.ts
@@ -56,8 +56,8 @@ export class TestUtils {
   }
 
   public static async assertRevertsAsync(
-    revertMessage: string,
-    func: () => Promise<any>
+    func: () => Promise<any>,
+    revertMessage: string
   ): Promise<void> {
     let succeeded = true
     try {
@@ -65,9 +65,10 @@ export class TestUtils {
       succeeded = false
     } catch (e) {
       if (e instanceof Error) {
-        assert.equal(
-          e.message,
-          `VM Exception while processing transaction: revert ${revertMessage}`
+        const expectedMessage: string = `VM Exception while processing transaction: revert ${revertMessage}`
+        assert(
+          e.message.startsWith(expectedMessage),
+          `Function did not throw expected error. Expected: ${expectedMessage}*, Received: ${e.message}`
         )
       } else {
         succeeded = false

--- a/packages/rollup-core/src/app/data/consumers/canonical-chain-batch-submitter.ts
+++ b/packages/rollup-core/src/app/data/consumers/canonical-chain-batch-submitter.ts
@@ -261,7 +261,7 @@ export class CanonicalChainBatchSubmitter extends ScheduledTask {
       this.getMaxL1ToL2QueueTimestampSeconds(),
       this.getMaxL1ToL2QueueBlockNumber(),
       this.getLastOvmTimestampSeconds(),
-      this.getLastOvmBlockNumber()
+      this.getLastOvmBlockNumber(),
     ])
 
     const nowSeconds = Math.round(new Date().getTime() / 1000)
@@ -300,10 +300,7 @@ export class CanonicalChainBatchSubmitter extends ScheduledTask {
       )
     }
 
-    if (
-      !!safetyQueueBlockNumber &&
-      batchBlockNumber > safetyQueueBlockNumber
-    ) {
+    if (!!safetyQueueBlockNumber && batchBlockNumber > safetyQueueBlockNumber) {
       throw new RollupBatchSafetyQueueBlockNumberError(
         `Safety Queue tx must come first. Safety queue blockNumber is ${safetyQueueBlockNumber}, batch blockNumber is ${batchBlockNumber}`
       )
@@ -318,10 +315,7 @@ export class CanonicalChainBatchSubmitter extends ScheduledTask {
       )
     }
 
-    if (
-      !!l1ToL2QueueBlockNumber &&
-      batchBlockNumber > l1ToL2QueueBlockNumber
-    ) {
+    if (!!l1ToL2QueueBlockNumber && batchBlockNumber > l1ToL2QueueBlockNumber) {
       throw new RollupBatchL1ToL2QueueBlockNumberError(
         `L1 to L2 Queue tx must come first. L1 to L2 Queue blockNumber is ${l1ToL2QueueBlockNumber}, batch blockNumber is ${batchBlockNumber}`
       )
@@ -361,26 +355,36 @@ export class CanonicalChainBatchSubmitter extends ScheduledTask {
   }
 
   private async getMaxSafetyQueueTimestampSeconds(): Promise<number> {
-    return this.catchQueueIsEmptyAndReturnUndefined(this.safetyQueueContract.peekTimestamp)
+    return this.catchQueueIsEmptyAndReturnUndefined(
+      this.safetyQueueContract.peekTimestamp
+    )
   }
 
   private async getMaxSafetyQueueBlockNumber(): Promise<number> {
-    return this.catchQueueIsEmptyAndReturnUndefined(this.safetyQueueContract.peekBlockNumber)
+    return this.catchQueueIsEmptyAndReturnUndefined(
+      this.safetyQueueContract.peekBlockNumber
+    )
   }
 
   private async getMaxL1ToL2QueueTimestampSeconds(): Promise<number> {
-    return this.catchQueueIsEmptyAndReturnUndefined(this.l1ToL2QueueContract.peekTimestamp)
+    return this.catchQueueIsEmptyAndReturnUndefined(
+      this.l1ToL2QueueContract.peekTimestamp
+    )
   }
 
   private async getMaxL1ToL2QueueBlockNumber(): Promise<number> {
-    return this.catchQueueIsEmptyAndReturnUndefined(this.l1ToL2QueueContract.peekBlockNumber)
+    return this.catchQueueIsEmptyAndReturnUndefined(
+      this.l1ToL2QueueContract.peekBlockNumber
+    )
   }
 
-  private async catchQueueIsEmptyAndReturnUndefined(func: () => Promise<number>): Promise<number> {
+  private async catchQueueIsEmptyAndReturnUndefined(
+    func: () => Promise<number>
+  ): Promise<number> {
     try {
       return await func()
     } catch (e) {
-      if (e.message.indexOf("Queue is empty") > -1) {
+      if (e.message.indexOf('Queue is empty') > -1) {
         return undefined
       }
       throw e

--- a/packages/rollup-core/src/app/data/consumers/canonical-chain-batch-submitter.ts
+++ b/packages/rollup-core/src/app/data/consumers/canonical-chain-batch-submitter.ts
@@ -121,7 +121,8 @@ export class CanonicalChainBatchSubmitter extends ScheduledTask {
       const txRes: TransactionResponse = await this.canonicalTransactionChain.appendSequencerBatch(
         txsCalldata,
         timestamp,
-        batchBlockNumber
+        batchBlockNumber,
+        l2Batch.startIndex
       )
       log.debug(
         `Tx batch ${l2Batch.batchNumber} appended with at least one confirmation! Tx Hash: ${txRes.hash}`

--- a/packages/rollup-core/src/app/data/consumers/state-commitment-chain-batch-submitter.ts
+++ b/packages/rollup-core/src/app/data/consumers/state-commitment-chain-batch-submitter.ts
@@ -85,7 +85,8 @@ export class StateCommitmentChainBatchSubmitter extends ScheduledTask {
       )
 
       const txRes: TransactionResponse = await this.stateCommitmentChain.appendStateBatch(
-        stateRoots
+        stateRoots,
+        stateRootBatch.startIndex
       )
       log.debug(
         `State Root batch ${stateRootBatch.batchNumber} appended with at least one confirmation! Tx Hash: ${txRes.hash}`

--- a/packages/rollup-core/src/app/data/data-service.ts
+++ b/packages/rollup-core/src/app/data/data-service.ts
@@ -612,7 +612,7 @@ export class DefaultDataService implements DataService {
   public async getNextCanonicalChainTransactionBatchToSubmit(): Promise<
     TransactionBatchSubmission
   > {
-    const res = await this.rdb.select(
+    const batchRes = await this.rdb.select(
       `SELECT cc.batch_number, cc.status, cc.submission_tx_hash, tx.block_number, tx.block_timestamp, tx.tx_index, tx.tx_hash, tx.sender, tx.l1_message_sender, tx.target, tx.calldata, tx.nonce, tx.signature, tx.state_root
       FROM l2_tx_output tx
         INNER JOIN canonical_chain_batch cc ON tx.canonical_chain_batch_number = cc.batch_number 
@@ -624,18 +624,34 @@ export class DefaultDataService implements DataService {
       ORDER BY block_number ASC, tx_index ASC`
     )
 
-    if (!res || !res.length || !res[0]) {
+    if (!batchRes || !batchRes.length || !batchRes[0]) {
       log.debug(`No canonical chain tx batch to submit.`)
       return undefined
     }
 
+    const batchNumber: number = batchRes[0]['batch_number']
+
+    const txIndexRes = await this.rdb.select(
+      `SELECT COUNT(*) as start_index
+      FROM l2_tx_output
+      WHERE canonical_chain_batch_number < ${batchNumber}`
+    )
+
+    if (!txIndexRes || !txIndexRes.length || !txIndexRes[0]) {
+      log.error(
+        `Could not fetch start index for next canonical tx chain batch to submit!`
+      )
+      return undefined
+    }
+
     const batch: TransactionBatchSubmission = {
-      submissionTxHash: res[0]['submission_tx_hash'],
-      status: res[0]['status'],
-      batchNumber: res[0]['batch_number'],
+      batchNumber,
+      startIndex: txIndexRes[0]['start_index'],
+      status: batchRes[0]['status'],
+      submissionTxHash: batchRes[0]['submission_tx_hash'],
       transactions: [],
     }
-    for (const row of res) {
+    for (const row of batchRes) {
       batch.transactions.push({
         timestamp: row['block_timestamp'],
         blockNumber: row['block_number'],
@@ -716,10 +732,11 @@ export class DefaultDataService implements DataService {
   public async getNextStateCommitmentBatchToSubmit(): Promise<
     StateCommitmentBatchSubmission
   > {
-    const res = await this.rdb.select(
+    const batchRes = await this.rdb.select(
       `SELECT scc.batch_number, scc.status, scc.submission_tx_hash, tx.state_root
-      FROM l2_tx_output tx
-        INNER JOIN state_commitment_chain_batch scc ON tx.state_commitment_chain_batch_number = scc.batch_number 
+      FROM 
+            l2_tx_output tx
+            INNER JOIN state_commitment_chain_batch scc ON tx.state_commitment_chain_batch_number = scc.batch_number
       WHERE batch_number = (
             SELECT MIN(batch_number)
             FROM state_commitment_chain_batch
@@ -728,15 +745,31 @@ export class DefaultDataService implements DataService {
       ORDER BY block_number ASC, tx_index ASC`
     )
 
-    if (!res || !res.length || !res[0]) {
+    if (!batchRes || !batchRes.length || !batchRes[0]) {
+      return undefined
+    }
+
+    const batchNumber: number = batchRes[0]['batch_number']
+
+    const rootIndexRes = await this.rdb.select(
+      `SELECT COUNT(*) as start_index
+      FROM l2_tx_output
+      WHERE state_commitment_chain_batch_number < ${batchNumber}`
+    )
+
+    if (!rootIndexRes || !rootIndexRes.length || !rootIndexRes[0]) {
+      log.error(
+        `Could not fetch start index for next state commitment batch to submit!`
+      )
       return undefined
     }
 
     return {
-      submissionTxHash: res[0]['submission_tx_hash'],
-      status: res[0]['status'],
-      batchNumber: res[0]['batch_number'],
-      stateRoots: res.map((x: Row) => x['state_root']),
+      batchNumber,
+      startIndex: rootIndexRes[0]['start_index'],
+      status: batchRes[0]['status'],
+      submissionTxHash: batchRes[0]['submission_tx_hash'],
+      stateRoots: batchRes.map((x: Row) => x['state_root']),
     }
   }
 

--- a/packages/rollup-core/src/app/data/data-service.ts
+++ b/packages/rollup-core/src/app/data/data-service.ts
@@ -668,7 +668,7 @@ export class DefaultDataService implements DataService {
 
     const batch: TransactionBatchSubmission = {
       batchNumber,
-      startIndex: txIndexRes[0]['start_index'],
+      startIndex: parseInt(txIndexRes[0]['start_index'], 10),
       status: batchRes[0]['status'],
       submissionTxHash: batchRes[0]['submission_tx_hash'],
       transactions: [],
@@ -788,7 +788,7 @@ export class DefaultDataService implements DataService {
 
     return {
       batchNumber,
-      startIndex: rootIndexRes[0]['start_index'],
+      startIndex: parseInt(rootIndexRes[0]['start_index'], 10),
       status: batchRes[0]['status'],
       submissionTxHash: batchRes[0]['submission_tx_hash'],
       stateRoots: batchRes.map((x: Row) => x['state_root']),

--- a/packages/rollup-core/src/app/data/data-service.ts
+++ b/packages/rollup-core/src/app/data/data-service.ts
@@ -346,10 +346,32 @@ export class DefaultDataService implements DataService {
    * @inheritDoc
    */
   public async updateBlockToProcessed(blockHash: string): Promise<void> {
-    return this.rdb.execute(`
-    UPDATE l1_block 
-    SET processed = TRUE 
-    WHERE block_hash = '${add0x(blockHash)}'`)
+    return this.rdb.execute(
+      `UPDATE l1_block 
+        SET processed = TRUE 
+        WHERE block_hash = '${add0x(blockHash)}'`
+    )
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public async getL1RollupStateRootCount(): Promise<number> {
+    const res: Row[] = await this.rdb.select(
+      `SELECT COUNT(id) as l1_state_root_count
+      FROM l1_rollup_state_root
+      WHERE removed = false`
+    )
+
+    if (!res || !res.length || !res[0]) {
+      const msg: string = `Got result ${JSON.stringify(
+        res
+      )} from L1 Rollup State Root Count query!`
+      log.error(msg)
+      throw Error(msg)
+    }
+
+    return res[0]['l1_state_root_count']
   }
 
   /*******************

--- a/packages/rollup-core/src/app/data/data-service.ts
+++ b/packages/rollup-core/src/app/data/data-service.ts
@@ -371,7 +371,7 @@ export class DefaultDataService implements DataService {
       throw Error(msg)
     }
 
-    return res[0]['l1_state_root_count']
+    return parseInt(res[0]['l1_state_root_count'], 10)
   }
 
   /*******************

--- a/packages/rollup-core/src/app/data/producers/log-handlers.ts
+++ b/packages/rollup-core/src/app/data/producers/log-handlers.ts
@@ -22,6 +22,7 @@ import {
   LogHandler,
   QueueOrigin,
   RollupTransaction,
+  StateRootsMissingError,
 } from '../../../types'
 import { CHAIN_ID } from '../../constants'
 import { Environment } from '../../util'
@@ -388,7 +389,7 @@ export const StateBatchAppendedLogHandler = async (
   if (sliceIndex < 0) {
     const msg: string = `Received rollup state root batch that starts at ${startsAtRootIndex} but we only have ${rollupStateRootCount} rollup state roots in the DB!`
     log.error(msg)
-    throw Error(msg)
+    throw new StateRootsMissingError(msg)
   }
 
   if (sliceIndex >= stateRoots.length) {

--- a/packages/rollup-core/src/types/data/l1-data-service.ts
+++ b/packages/rollup-core/src/types/data/l1-data-service.ts
@@ -112,4 +112,11 @@ export interface L1DataService {
    * @throws An error if there is a DB error.
    */
   markQueuedGethSubmissionSubmittedToGeth(queueIndex: number): Promise<void>
+
+  /**
+   * Gets the total count of L1 RollupStateRoots.
+   *
+   * @returns The number of L1 RollupStateRoots in the DB.
+   */
+  getL1RollupStateRootCount(): Promise<number>
 }

--- a/packages/rollup-core/src/types/data/types.ts
+++ b/packages/rollup-core/src/types/data/types.ts
@@ -31,9 +31,10 @@ export interface GethSubmissionRecord {
 }
 
 export interface BatchSubmission {
-  submissionTxHash: string
-  status: BatchSubmissionStatus
   batchNumber: number
+  startIndex?: number
+  status: BatchSubmissionStatus
+  submissionTxHash: string
 }
 
 export interface TransactionBatchSubmission extends BatchSubmission {

--- a/packages/rollup-core/src/types/errors.ts
+++ b/packages/rollup-core/src/types/errors.ts
@@ -59,6 +59,12 @@ export class NotSyncedError extends Error {
   }
 }
 
+export class StateRootsMissingError extends Error {
+  constructor(msg: string) {
+    super(msg)
+  }
+}
+
 /***************************
  * Batch Submission Errors *
  ***************************/

--- a/packages/rollup-core/test/app/canonical-chain-batch-submitter.spec.ts
+++ b/packages/rollup-core/test/app/canonical-chain-batch-submitter.spec.ts
@@ -124,7 +124,8 @@ class MockCanonicalTransactionChain {
   public async appendSequencerBatch(
     calldata: string,
     timestamp: number,
-    blockNumber: number
+    blockNumber: number,
+    startIndex: number
   ): Promise<TransactionResponse> {
     const response: TransactionResponse = this.responses.shift()
     if (!response) {

--- a/packages/rollup-core/test/app/canonical-chain-batch-submitter.spec.ts
+++ b/packages/rollup-core/test/app/canonical-chain-batch-submitter.spec.ts
@@ -152,14 +152,20 @@ class MockCanonicalTransactionChain {
 }
 
 class MockQueue {
-  public timestamp: number = 0
-  public blockNumber: number = 0
+  public timestamp: number
+  public blockNumber: number
 
   public async peekBlockNumber(): Promise<number> {
+    if (this.blockNumber === undefined) {
+      throw Error(`Queue is empty`)
+    }
     return this.blockNumber
   }
 
   public async peekTimestamp(): Promise<number> {
+    if (this.timestamp === undefined) {
+      throw Error(`Queue is empty`)
+    }
     return this.timestamp
   }
 }
@@ -194,7 +200,7 @@ describe('Canonical Chain Batch Submitter', () => {
   })
 
   it('should not do anything if there are no batches', async () => {
-    const res = await batchSubmitter.runTask()
+    const res = await batchSubmitter.runTask(true)
 
     res.should.equal(false, 'Incorrect result when there are no batches')
 
@@ -230,7 +236,7 @@ describe('Canonical Chain Batch Submitter', () => {
     })
 
     await TestUtils.assertThrowsAsync(async () => {
-      await batchSubmitter.runTask()
+      await batchSubmitter.runTask(true)
     }, UnexpectedBatchStatus)
 
     dataService.txBatchesSubmitted.length.should.equal(
@@ -269,7 +275,7 @@ describe('Canonical Chain Batch Submitter', () => {
     canonicalTransactionChain.responses.push({ hash } as any)
     canonicalProvider.txReceipts.set(hash, { status: 1 } as any)
 
-    const res: boolean = await batchSubmitter.runTask()
+    const res: boolean = await batchSubmitter.runTask(true)
     res.should.equal(true, `Batch should have been submitted successfully.`)
 
     dataService.txBatchesSubmitted.length.should.equal(
@@ -317,7 +323,7 @@ describe('Canonical Chain Batch Submitter', () => {
     canonicalTransactionChain.responses.push({ hash } as any)
     canonicalProvider.txReceipts.set(hash, { status: 0 } as any)
 
-    const res: boolean = await batchSubmitter.runTask()
+    const res: boolean = await batchSubmitter.runTask(true)
     res.should.equal(false, `Batch tx should have errored out.`)
 
     dataService.txBatchesSubmitted.length.should.equal(
@@ -366,7 +372,7 @@ describe('Canonical Chain Batch Submitter', () => {
       setUpTask()
 
       await TestUtils.assertThrowsAsync(async () => {
-        await batchSubmitter.runTask()
+        await batchSubmitter.runTask(true)
       }, FutureRollupBatchNumberError)
     })
 
@@ -376,7 +382,7 @@ describe('Canonical Chain Batch Submitter', () => {
       setUpTask(nowSeconds + 20)
 
       await TestUtils.assertThrowsAsync(async () => {
-        await batchSubmitter.runTask()
+        await batchSubmitter.runTask(true)
       }, FutureRollupBatchTimestampError)
     })
 
@@ -388,7 +394,7 @@ describe('Canonical Chain Batch Submitter', () => {
       setUpTask(nowSeconds - 5)
 
       await TestUtils.assertThrowsAsync(async () => {
-        await batchSubmitter.runTask()
+        await batchSubmitter.runTask(true)
       }, RollupBatchTimestampTooOldError)
     })
 
@@ -400,7 +406,7 @@ describe('Canonical Chain Batch Submitter', () => {
       setUpTask()
 
       await TestUtils.assertThrowsAsync(async () => {
-        await batchSubmitter.runTask()
+        await batchSubmitter.runTask(true)
       }, RollupBatchBlockNumberTooOldError)
     })
 
@@ -412,7 +418,7 @@ describe('Canonical Chain Batch Submitter', () => {
       setUpTask(nowSeconds - 1)
 
       await TestUtils.assertThrowsAsync(async () => {
-        await batchSubmitter.runTask()
+        await batchSubmitter.runTask(true)
       }, RollupBatchSafetyQueueBlockTimestampError)
     })
 
@@ -424,7 +430,7 @@ describe('Canonical Chain Batch Submitter', () => {
       setUpTask(nowSeconds - 1)
 
       await TestUtils.assertThrowsAsync(async () => {
-        await batchSubmitter.runTask()
+        await batchSubmitter.runTask(true)
       }, RollupBatchL1ToL2QueueBlockTimestampError)
     })
 
@@ -436,7 +442,7 @@ describe('Canonical Chain Batch Submitter', () => {
       setUpTask()
 
       await TestUtils.assertThrowsAsync(async () => {
-        await batchSubmitter.runTask()
+        await batchSubmitter.runTask(true)
       }, RollupBatchSafetyQueueBlockNumberError)
     })
 
@@ -448,7 +454,7 @@ describe('Canonical Chain Batch Submitter', () => {
       setUpTask()
 
       await TestUtils.assertThrowsAsync(async () => {
-        await batchSubmitter.runTask()
+        await batchSubmitter.runTask(true)
       }, RollupBatchL1ToL2QueueBlockNumberError)
     })
 
@@ -460,7 +466,7 @@ describe('Canonical Chain Batch Submitter', () => {
       setUpTask(nowSeconds - 5)
 
       await TestUtils.assertThrowsAsync(async () => {
-        await batchSubmitter.runTask()
+        await batchSubmitter.runTask(true)
       }, RollupBatchOvmTimestampError)
     })
 
@@ -472,7 +478,7 @@ describe('Canonical Chain Batch Submitter', () => {
       setUpTask()
 
       await TestUtils.assertThrowsAsync(async () => {
-        await batchSubmitter.runTask()
+        await batchSubmitter.runTask(true)
       }, RollupBatchOvmBlockNumberError)
     })
   })

--- a/packages/rollup-core/test/db/l1-data-service.dbspec.ts
+++ b/packages/rollup-core/test/db/l1-data-service.dbspec.ts
@@ -346,10 +346,7 @@ describe('L1 Data Service (will fail if postgres is not running with expected sc
         keccak256FromUtf8('root2'),
         keccak256FromUtf8('root3'),
       ]
-      await dataService.insertL1RollupStateRoots(
-        tx.hash,
-        stateRoots
-      )
+      await dataService.insertL1RollupStateRoots(tx.hash, stateRoots)
 
       const count = await dataService.getL1RollupStateRootCount()
       count.should.equal(3, `Incorrect state root count!`)
@@ -363,15 +360,13 @@ describe('L1 Data Service (will fail if postgres is not running with expected sc
         keccak256FromUtf8('root2'),
         keccak256FromUtf8('root3'),
       ]
-      await dataService.insertL1RollupStateRoots(
-        tx.hash,
-        stateRoots
-      )
+      await dataService.insertL1RollupStateRoots(tx.hash, stateRoots)
 
       await postgres.execute(
         `UPDATE l1_rollup_state_root 
         SET removed = true 
-        WHERE state_root = '${stateRoots[0]}'`)
+        WHERE state_root = '${stateRoots[0]}'`
+      )
 
       const count = await dataService.getL1RollupStateRootCount()
       count.should.equal(2, `Incorrect State Root Count!`)


### PR DESCRIPTION
## Description
Adds a `startsAtIndex` field for sequencer batch appends to prevent race conditions from causing errors.

## Metadata
### Fixes
- Fixes # [YAS-635](https://optimists.atlassian.net/browse/YAS-635)

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
