### PR TITLE
Add native flag to ovm toolchain tests

### DIFF
--- a/packages/ovm-toolchain/buidler.config.ts
+++ b/packages/ovm-toolchain/buidler.config.ts
@@ -9,6 +9,7 @@ import './src/buidler-plugins/buidler-ovm-node'
 
 task('test')
   .addFlag('ovm', 'Run tests on the OVM using a custom OVM provider')
+  .addFlag('native', 'Use custom native solc compiler')
   .setAction(async (taskArguments, bre: any, runSuper) => {
     if (taskArguments.ovm) {
       console.log('Compiling and running tests in the OVM...')
@@ -17,6 +18,11 @@ task('test')
       }
       await bre.config.startOvmNode()
     }
+
+    if (taskArguments.native) {
+      bre.config.solc.native = true
+    }
+
     await runSuper(taskArguments)
   })
 

--- a/packages/ovm-toolchain/package.json
+++ b/packages/ovm-toolchain/package.json
@@ -28,7 +28,8 @@
     "test": "yarn run test:truffle && yarn run test:waffle-v2 && yarn run test:buidler",
     "test:truffle": "truffle test \"test/test-truffle/erc20.spec.js\" --config \"test/config/truffle-config.js\"",
     "test:waffle-v2": "waffle \"test/config/waffle-config.json\" && mocha --require source-map-support/register --require ts-node/register \"test/test-waffle-v2/**/*.spec.ts\" --timeout 10000",
-    "test:buidler": "buidler test --ovm"
+    "test:buidler": "buidler test --ovm",
+    "test:buidler:native": "buidler test --ovm --native"
   },
   "keywords": [
     "optimistic",


### PR DESCRIPTION
## Description
This PR is to aid in the testing of `YAS-637`, allowing us to test the v0.6 solc fork w/ `native` against the `ovm-toolchain`.

## Metadata
### Fixes
- Fixes #

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [X] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
