### PR TITLE
ovm-toolchain: default arg for ganache construction

### DIFF
--- a/packages/ovm-toolchain/src/ganache.ts
+++ b/packages/ovm-toolchain/src/ganache.ts
@@ -5,7 +5,7 @@ const VM = require('ethereumjs-ovm').default
 const BN = require('bn.js')
 
 // tslint:disable-next-line:no-shadowed-variable
-const wrap = (provider: any, opts: any) => {
+const wrap = (provider: any, opts: any = {}) => {
   const gasLimit = opts.gasLimit || 100_000_000
   const blockchain = provider.engine.manager.state.blockchain
 


### PR DESCRIPTION
## Description

This adds a default argument to the `wrap` function so that it doesn't throw an error when no argument is provided. Both of the unwrapped `ganache.server` and `ganache.provider` handle the case of no argument being passed in, right now an empty object must be passed in to prevent an error from being thrown for the wrapper versions. This will allow both wrapped versions to be called without an argument.

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
