### PR TITLE
ovm-toolchain: check waffle provider defined

### DIFF
--- a/packages/ovm-toolchain/src/waffle/waffle-v2.ts
+++ b/packages/ovm-toolchain/src/waffle/waffle-v2.ts
@@ -38,20 +38,24 @@ export class MockProvider extends providers.Web3Provider {
    */
   public async rpc(method: string, params: any[] = []): Promise<any> {
     return new Promise<any>((resolve, reject) => {
-      this._web3Provider.sendAsync(
-        {
-          jsonrpc: '2.0',
-          method,
-          params,
-        },
-        (err: any, res: any) => {
-          if (err) {
-            reject(err)
-          } else {
-            resolve(res.result)
+      if (!!this._web3Provider) {
+        this._web3Provider.sendAsync(
+          {
+            jsonrpc: '2.0',
+            method,
+            params,
+          },
+          (err: any, res: any) => {
+            if (err) {
+              reject(err)
+            } else {
+              resolve(res.result)
+            }
           }
-        }
-      )
+        )
+      } else {
+        reject('web3Provider not defined')
+      }
     })
   }
 }


### PR DESCRIPTION
## Description
This small PR adds a check in our `waffleV2` export that `_web3Provider` is defined, as some dev environments with strict `tsconfig`s previously rejected builds because the dependency `invokes an object which is potentially undefined`.

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
