### PR TITLE
typed transactions: add support

### DIFF
--- a/db/scripts/3_create_l2_tables.sql
+++ b/db/scripts/3_create_l2_tables.sql
@@ -39,6 +39,7 @@ CREATE TABLE l2_tx_output (
   calldata TEXT NOT NULL,
   signature CHARACTER(132) NOT NULL,
   state_root CHARACTER(66) NOT NULL,
+  tx_type INT NOT NULL,
   l1_rollup_tx_id BIGINT DEFAULT NULL,
   canonical_chain_batch_number BIGINT DEFAULT NULL,
   canonical_chain_batch_index INT DEFAULT NULL,

--- a/packages/core-db/src/app/queue/sequential-processing-data-service.ts
+++ b/packages/core-db/src/app/queue/sequential-processing-data-service.ts
@@ -59,7 +59,7 @@ export class DefaultSequentialProcessingDataService
     const res = await this.rdb.select(
       `SELECT MAX(sequence_number) as last_processed
       FROM sequential_processing
-      WHERE 
+      WHERE
         sequence_key = '${sequenceKey}'
         AND processed = TRUE`
     )
@@ -112,7 +112,7 @@ export class DefaultSequentialProcessingDataService
     await this.rdb.execute(
       `UPDATE sequential_processing
       SET processed = TRUE
-      WHERE 
+      WHERE
         sequence_key = '${sequenceKey}'
         AND sequence_number = ${index}`
     )

--- a/packages/rollup-core/src/app/data/data-service.ts
+++ b/packages/rollup-core/src/app/data/data-service.ts
@@ -94,7 +94,7 @@ export class DefaultDataService implements DataService {
     txContext?: any
   ): Promise<void> {
     return this.rdb.execute(
-      `${l1BlockInsertStatement} 
+      `${l1BlockInsertStatement}
       VALUES (${getL1BlockInsertValue(block, processed)})`,
       txContext
     )
@@ -114,7 +114,7 @@ export class DefaultDataService implements DataService {
       (tx, index) => `(${getL1TransactionInsertValue(tx, index)})`
     )
     return this.rdb.execute(
-      `${l1TxInsertStatement} 
+      `${l1TxInsertStatement}
       VALUES ${values.join(',')}`,
       txContext
     )
@@ -347,8 +347,8 @@ export class DefaultDataService implements DataService {
    */
   public async updateBlockToProcessed(blockHash: string): Promise<void> {
     return this.rdb.execute(
-      `UPDATE l1_block 
-        SET processed = TRUE 
+      `UPDATE l1_block
+        SET processed = TRUE
         WHERE block_hash = '${add0x(blockHash)}'`
     )
   }
@@ -383,7 +383,7 @@ export class DefaultDataService implements DataService {
    */
   public async insertL2TransactionOutput(tx: TransactionOutput): Promise<void> {
     return this.rdb.execute(
-      `${l2TransactionOutputInsertStatement} 
+      `${l2TransactionOutputInsertStatement}
       VALUES (${getL2TransactionOutputInsertValue(tx)})
       ON CONFLICT (tx_hash) DO NOTHING` // makes it so if we're inserting data that already exists, it doesn't fail. If tx_hash is not unique, we have bigger problems =|
     )
@@ -424,10 +424,10 @@ export class DefaultDataService implements DataService {
       const batchNumber = await this.insertNewCanonicalChainBatch(txContext)
       await this.rdb.execute(
         `UPDATE l2_tx_output tx
-        SET 
+        SET
             canonical_chain_batch_number = ${batchNumber},
             canonical_chain_batch_index = t.row_number
-        FROM 
+        FROM
           (
             SELECT id, row_number() over (ORDER BY id) -1 as row_number
             FROM l2_tx_output
@@ -438,7 +438,7 @@ export class DefaultDataService implements DataService {
             ORDER BY block_number ASC, tx_index ASC
             LIMIT ${maxBatchSize}
           ) t
-        WHERE tx.id = t.id 
+        WHERE tx.id = t.id
           `,
         txContext
       )
@@ -463,7 +463,7 @@ export class DefaultDataService implements DataService {
   > {
     const res = await this.rdb.select(
       `SELECT (l1.batch_number - l2.batch_number) as l1_lead
-      FROM 
+      FROM
         (
           SELECT COALESCE(NULLIF(MAX(batch_number), 0), COUNT(*)) as batch_number
           FROM l1_rollup_state_root_batch
@@ -496,18 +496,18 @@ export class DefaultDataService implements DataService {
       (await this.getMaxStateCommitmentChainBatchNumber()) + 1
     const batchSizeRes = await this.rdb.select(
       `SELECT l1.batch_size as l1_batch_size, l2.batch_size as l2_batch_size
-        FROM 
+        FROM
           (
             SELECT COUNT(*) as batch_size
             FROM l1_rollup_state_root
-            WHERE batch_number = ${nextBatchNumber} 
+            WHERE batch_number = ${nextBatchNumber}
           ) l1,
           (
             SELECT COUNT(*) as batch_size
             FROM l2_tx_output
-            WHERE 
+            WHERE
               state_commitment_chain_batch_number IS NULL
-          ) l2  
+          ) l2
       `
     )
 
@@ -544,7 +544,7 @@ export class DefaultDataService implements DataService {
       }
       await this.rdb.execute(
         `UPDATE l2_tx_output as tx
-        SET 
+        SET
             state_commitment_chain_batch_number = ${batchNumber},
             state_commitment_chain_batch_index = t.row_number
         FROM (
@@ -607,7 +607,7 @@ export class DefaultDataService implements DataService {
       )
       await this.rdb.execute(
         `UPDATE l2_tx_output as tx
-        SET 
+        SET
             state_commitment_chain_batch_number = ${batchNumber},
             state_commitment_chain_batch_index = t.row_number
         FROM (
@@ -703,7 +703,7 @@ export class DefaultDataService implements DataService {
   > {
     const res = await this.rdb.select(
       `SELECT batch_number, status, submission_tx_hash
-      FROM canonical_chain_batch 
+      FROM canonical_chain_batch
       WHERE status = '${BatchSubmissionStatus.SENT}'
       ORDER BY batch_number ASC
       LIMIT 1`
@@ -771,7 +771,7 @@ export class DefaultDataService implements DataService {
   > {
     const batchRes = await this.rdb.select(
       `SELECT scc.batch_number, scc.status, scc.submission_tx_hash, tx.state_root
-      FROM 
+      FROM
             l2_tx_output tx
             INNER JOIN state_commitment_chain_batch scc ON tx.state_commitment_chain_batch_number = scc.batch_number
       WHERE batch_number = (
@@ -818,7 +818,7 @@ export class DefaultDataService implements DataService {
   > {
     const res = await this.rdb.select(
       `SELECT batch_number, status, submission_tx_hash
-      FROM state_commitment_chain_batch 
+      FROM state_commitment_chain_batch
       WHERE status = '${BatchSubmissionStatus.SENT}'
       ORDER BY batch_number ASC
       LIMIT 1`
@@ -872,7 +872,7 @@ export class DefaultDataService implements DataService {
     l1TxHash: string
   ): Promise<void> {
     return this.rdb.execute(
-      `UPDATE state_commitment_chain_batch 
+      `UPDATE state_commitment_chain_batch
       SET status = '${BatchSubmissionStatus.FINALIZED}', submission_tx_hash = '${l1TxHash}'
       WHERE batch_number = ${batchNumber}`
     )
@@ -960,7 +960,7 @@ export class DefaultDataService implements DataService {
       try {
         queueIndex = (await this.getMaxGethSubmissionQueueIndex()) + 1
         await this.rdb.execute(
-          `INSERT INTO geth_submission_queue(l1_tx_hash, queue_index) 
+          `INSERT INTO geth_submission_queue(l1_tx_hash, queue_index)
             VALUES ('${l1TxHash}', ${queueIndex})`,
           txContext
         )
@@ -992,7 +992,7 @@ export class DefaultDataService implements DataService {
       try {
         batchNumber = (await this.getMaxL1StateRootBatchNumber()) + 1
         await this.rdb.execute(
-          `INSERT INTO l1_rollup_state_root_batch(l1_tx_hash, batch_number) 
+          `INSERT INTO l1_rollup_state_root_batch(l1_tx_hash, batch_number)
             VALUES ('${l1TxHash}', ${batchNumber})`,
           txContext
         )
@@ -1025,7 +1025,7 @@ export class DefaultDataService implements DataService {
         batchNumber =
           (await this.getMaxCanonicalChainBatchNumber(txContext)) + 1
         await this.rdb.execute(
-          `INSERT INTO canonical_chain_batch(batch_number) 
+          `INSERT INTO canonical_chain_batch(batch_number)
             VALUES (${batchNumber})`,
           txContext
         )
@@ -1086,7 +1086,7 @@ export class DefaultDataService implements DataService {
       try {
         batchNumber = (await this.getMaxStateCommitmentChainBatchNumber()) + 1
         await this.rdb.execute(
-          `INSERT INTO state_commitment_chain_batch(batch_number, status) 
+          `INSERT INTO state_commitment_chain_batch(batch_number, status)
             VALUES (${batchNumber}, '${
             final
               ? BatchSubmissionStatus.FINALIZED
@@ -1111,7 +1111,7 @@ export class DefaultDataService implements DataService {
    */
   protected async getMaxStateCommitmentChainBatchNumber(): Promise<number> {
     const rows = await this.rdb.select(
-      `SELECT MAX(batch_number) as batch_number 
+      `SELECT MAX(batch_number) as batch_number
         FROM state_commitment_chain_batch`
     )
     if (
@@ -1133,7 +1133,7 @@ export class DefaultDataService implements DataService {
    */
   protected async getMaxGethSubmissionQueueIndex(): Promise<number> {
     const rows = await this.rdb.select(
-      `SELECT MAX(queue_index) as queue_index 
+      `SELECT MAX(queue_index) as queue_index
         FROM geth_submission_queue`
     )
     if (
@@ -1155,7 +1155,7 @@ export class DefaultDataService implements DataService {
    */
   protected async getMaxL1StateRootBatchNumber(): Promise<number> {
     const rows = await this.rdb.select(
-      `SELECT MAX(batch_number) as batch_number 
+      `SELECT MAX(batch_number) as batch_number
         FROM l1_rollup_state_root_batch`
     )
     if (

--- a/packages/rollup-core/src/app/data/data-service.ts
+++ b/packages/rollup-core/src/app/data/data-service.ts
@@ -688,6 +688,7 @@ export class DefaultDataService implements DataService {
         gasLimit: row['gas_limit'],
         l1MessageSender: row['l1_message_sender'] || undefined, // should never be present in this case
         signature: row['signature'],
+        type: row['tx_type'],
       })
     }
 

--- a/packages/rollup-core/src/app/data/producers/l2-chain-data-persister.ts
+++ b/packages/rollup-core/src/app/data/producers/l2-chain-data-persister.ts
@@ -10,7 +10,7 @@ import {
 } from 'ethers/providers'
 
 /* Internal Imports */
-import { L2DataService, TransactionOutput } from '../../../types'
+import { L2DataService, TransactionOutput, OptimismTransactionResponse } from '../../../types'
 import { ChainDataProcessor } from './chain-data-processor'
 import { monkeyPatchL2Provider } from '../../utils'
 import { BigNumber, remove0x } from '@eth-optimism/core-utils/build'
@@ -135,6 +135,7 @@ export class L2ChainDataPersister extends ChainDataProcessor {
       stateRoot: block['stateRoot'], // should be added by rollup-core/app/utils.ts: monkeyPatchL2Provider
       gasLimit: L2ChainDataPersister.parseBigNumber(response.gasLimit),
       gasPrice: L2ChainDataPersister.parseBigNumber(response.gasPrice),
+      type: (response as OptimismTransactionResponse).type,
     }
 
     if (!!response['l1MessageSender']) {

--- a/packages/rollup-core/src/app/data/producers/l2-chain-data-persister.ts
+++ b/packages/rollup-core/src/app/data/producers/l2-chain-data-persister.ts
@@ -10,7 +10,11 @@ import {
 } from 'ethers/providers'
 
 /* Internal Imports */
-import { L2DataService, TransactionOutput, OptimismTransactionResponse } from '../../../types'
+import {
+  L2DataService,
+  TransactionOutput,
+  OptimismTransactionResponse,
+} from '../../../types'
 import { ChainDataProcessor } from './chain-data-processor'
 import { monkeyPatchL2Provider } from '../../utils'
 import { BigNumber, remove0x } from '@eth-optimism/core-utils/build'

--- a/packages/rollup-core/src/app/data/query-utils.ts
+++ b/packages/rollup-core/src/app/data/query-utils.ts
@@ -77,7 +77,9 @@ export const getL2TransactionOutputInsertValue = (
     tx.gasLimit
   )}, ${bigNumberOrNull(tx.gasPrice)}, ${stringOrNull(
     tx.signature
-  )}, ${stringOrNull(tx.stateRoot)}, ${numOrNull(tx.l1RollupTransactionId)}, ${numOrNull(tx.type)}`
+  )}, ${stringOrNull(tx.stateRoot)}, ${numOrNull(
+    tx.l1RollupTransactionId
+  )}, ${numOrNull(tx.type)}`
 }
 
 export const bigNumberOrNull = (bigNumber: any): string => {

--- a/packages/rollup-core/src/app/data/query-utils.ts
+++ b/packages/rollup-core/src/app/data/query-utils.ts
@@ -63,7 +63,7 @@ export const getL1RollupStateRootInsertValue = (
   )}`
 }
 
-export const l2TransactionOutputInsertStatement = `INSERT INTO l2_tx_output(block_number, block_timestamp, tx_index, tx_hash, sender, l1_message_sender, target, calldata, nonce, gas_limit, gas_price, signature, state_root, l1_rollup_tx_id) `
+export const l2TransactionOutputInsertStatement = `INSERT INTO l2_tx_output(block_number, block_timestamp, tx_index, tx_hash, sender, l1_message_sender, target, calldata, nonce, gas_limit, gas_price, signature, state_root, l1_rollup_tx_id, tx_type) `
 export const getL2TransactionOutputInsertValue = (
   tx: TransactionOutput
 ): string => {
@@ -77,7 +77,7 @@ export const getL2TransactionOutputInsertValue = (
     tx.gasLimit
   )}, ${bigNumberOrNull(tx.gasPrice)}, ${stringOrNull(
     tx.signature
-  )}, ${stringOrNull(tx.stateRoot)}, ${numOrNull(tx.l1RollupTransactionId)}`
+  )}, ${stringOrNull(tx.stateRoot)}, ${numOrNull(tx.l1RollupTransactionId)}, ${numOrNull(tx.type)}`
 }
 
 export const bigNumberOrNull = (bigNumber: any): string => {

--- a/packages/rollup-core/src/types/types.ts
+++ b/packages/rollup-core/src/types/types.ts
@@ -44,7 +44,7 @@ export interface TransactionOutput {
   nonce: number
   calldata: string
   from: string
-  type: number,
+  type: number
   l1RollupTransactionId?: number
   gasLimit?: BigNumber
   gasPrice?: BigNumber

--- a/packages/rollup-core/src/types/types.ts
+++ b/packages/rollup-core/src/types/types.ts
@@ -44,6 +44,7 @@ export interface TransactionOutput {
   nonce: number
   calldata: string
   from: string
+  type: number,
   l1RollupTransactionId?: number
   gasLimit?: BigNumber
   gasPrice?: BigNumber
@@ -144,4 +145,8 @@ export interface L1BlockPersistenceInfo {
   txPersisted: boolean
   rollupTxsPersisted: boolean
   rollupStateRootsPersisted: boolean
+}
+
+export interface OptimismTransactionResponse extends TransactionResponse {
+  type: number
 }

--- a/packages/rollup-core/test/app/canonical-chain-batch-submitter.spec.ts
+++ b/packages/rollup-core/test/app/canonical-chain-batch-submitter.spec.ts
@@ -275,6 +275,7 @@ describe('Canonical Chain Batch Submitter', () => {
           calldata: keccak256FromUtf8('some calldata'),
           stateRoot: keccak256FromUtf8('l2 state root'),
           signature: 'ab'.repeat(65),
+          type: 0,
         },
       ],
     })
@@ -320,6 +321,7 @@ describe('Canonical Chain Batch Submitter', () => {
           calldata: keccak256FromUtf8('some calldata'),
           stateRoot: keccak256FromUtf8('l2 state root'),
           signature: 'ab'.repeat(65),
+          type: 0,
         },
       ],
     })
@@ -382,6 +384,7 @@ describe('Canonical Chain Batch Submitter', () => {
           calldata: keccak256FromUtf8('some calldata'),
           stateRoot: keccak256FromUtf8('l2 state root'),
           signature: 'ab'.repeat(65),
+          type: 0,
         },
       ],
     })
@@ -441,6 +444,7 @@ describe('Canonical Chain Batch Submitter', () => {
           calldata: keccak256FromUtf8('some calldata'),
           stateRoot: keccak256FromUtf8('l2 state root'),
           signature: 'ab'.repeat(65),
+          type: 0,
         },
       ],
     })
@@ -499,6 +503,7 @@ describe('Canonical Chain Batch Submitter', () => {
           calldata: keccak256FromUtf8('some calldata'),
           stateRoot: keccak256FromUtf8('l2 state root'),
           signature: 'ab'.repeat(65),
+          type: 0,
         },
       ],
     })
@@ -545,6 +550,7 @@ describe('Canonical Chain Batch Submitter', () => {
             calldata: keccak256FromUtf8('some calldata'),
             stateRoot: keccak256FromUtf8('l2 state root'),
             signature: 'ab'.repeat(65),
+            type: 0,
           },
         ],
       })

--- a/packages/rollup-core/test/db/helpers.ts
+++ b/packages/rollup-core/test/db/helpers.ts
@@ -32,6 +32,7 @@ export const defaultNonceString: string = '0x01'
 export const defaultNonceNum: number = 1
 export const defaultSignature: string = `${blockHash}${remove0x(parentHash)}99`
 export const defaultStateRoot: string = keccak256FromUtf8(blockHash)
+export const defaultType: number = 0
 
 export const gasUsed = new BigNum(1)
 export const gasLimit = new BigNum(2)
@@ -104,7 +105,8 @@ export const createTxOutput = (
   signature: string = defaultSignature,
   data: string = defaultData,
   to: string = defaultTo,
-  nonce: number = defaultNonceNum
+  nonce: number = defaultNonceNum,
+  type: number = defaultType,
 ): TransactionOutput => {
   return {
     calldata: data,
@@ -120,6 +122,7 @@ export const createTxOutput = (
     l1MessageSender,
     signature: defaultSignature,
     stateRoot,
+    type,
   }
 }
 


### PR DESCRIPTION
## Description

This PR adds support for typed transactions. The transaction type needs to be indexed by postgres. There are currently two transaction types that are supported, the standard ethereum eip155 tx and also an optimism `eth_sign` transaction that is signed using the `eth_sign` scheme so that it can "just work" with metamask and not need an additional provider to be used.

## Questions
- Are there additional places that need to be updated for full support?


## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
