### PR TITLE
provider: add in gorli support

### DIFF
--- a/packages/provider/README.md
+++ b/packages/provider/README.md
@@ -19,10 +19,10 @@ const web3 = new Web3Provider()
 const provider = new OptimismProvider('http://localhost:8545', web3)
 ```
 
-## Gorli Testnet
+## Goerli Testnet
 
-To connect to the Gorli testnet:
+To connect to the Goerli testnet:
 
 ```js
-const provider = new OptimismProvider('gorli')
+const provider = new OptimismProvider('goerli')
 ```

--- a/packages/provider/README.md
+++ b/packages/provider/README.md
@@ -18,3 +18,11 @@ const web3 = new Web3Provider()
 // Accepts either a URL or a network name (main, kovan)
 const provider = new OptimismProvider('http://localhost:8545', web3)
 ```
+
+## Rinkeby Testnet
+
+To connect to the Rinkeby testnet:
+
+```js
+const provider = new OptimismProvider('rinkeby')
+```

--- a/packages/provider/README.md
+++ b/packages/provider/README.md
@@ -19,10 +19,10 @@ const web3 = new Web3Provider()
 const provider = new OptimismProvider('http://localhost:8545', web3)
 ```
 
-## Rinkeby Testnet
+## Gorli Testnet
 
-To connect to the Rinkeby testnet:
+To connect to the Gorli testnet:
 
 ```js
-const provider = new OptimismProvider('rinkeby')
+const provider = new OptimismProvider('gorli')
 ```

--- a/packages/provider/src/app/network.ts
+++ b/packages/provider/src/app/network.ts
@@ -143,8 +143,8 @@ export function getUrl(
   // List of publically available urls to use
   // TODO(mark): in this case, turn off calls for `eth_getChainId`
   switch (network ? network.name : 'unknown') {
-    case 'rinkeby':
-      host = 'rinkeby.optimism.io'
+    case 'gorli':
+      host = 'gorli.optimism.io'
       break
     case 'main':
     default:

--- a/packages/provider/src/app/network.ts
+++ b/packages/provider/src/app/network.ts
@@ -143,8 +143,8 @@ export function getUrl(
   // List of publically available urls to use
   // TODO(mark): in this case, turn off calls for `eth_getChainId`
   switch (network ? network.name : 'unknown') {
-    case 'gorli':
-      host = 'gorli.optimism.io'
+    case 'goerli':
+      host = 'goerli.optimism.io'
       break
     case 'main':
     default:

--- a/packages/provider/src/app/network.ts
+++ b/packages/provider/src/app/network.ts
@@ -143,9 +143,10 @@ export function getUrl(
   // List of publically available urls to use
   // TODO(mark): in this case, turn off calls for `eth_getChainId`
   switch (network ? network.name : 'unknown') {
+    case 'ropsten':
+        host = 'ropsten.optimism.io'
+        break;
     case 'main':
-      host = '' // TODO: once the url of mainnet is known
-      break
     default:
       logger.throwError('unsupported network', Logger.errors.INVALID_ARGUMENT, {
         argument: 'network',
@@ -154,7 +155,7 @@ export function getUrl(
   }
 
   const connection: ConnectionInfo = {
-    url: `http://${host}`,
+    url: `https://${host}`,
   }
 
   return connection

--- a/packages/provider/src/app/network.ts
+++ b/packages/provider/src/app/network.ts
@@ -143,8 +143,8 @@ export function getUrl(
   // List of publically available urls to use
   // TODO(mark): in this case, turn off calls for `eth_getChainId`
   switch (network ? network.name : 'unknown') {
-    case 'ropsten':
-        host = 'ropsten.optimism.io'
+    case 'rinkeby':
+        host = 'rinkeby.optimism.io'
         break;
     case 'main':
     default:

--- a/packages/provider/src/app/network.ts
+++ b/packages/provider/src/app/network.ts
@@ -144,8 +144,8 @@ export function getUrl(
   // TODO(mark): in this case, turn off calls for `eth_getChainId`
   switch (network ? network.name : 'unknown') {
     case 'rinkeby':
-        host = 'rinkeby.optimism.io'
-        break;
+      host = 'rinkeby.optimism.io'
+      break
     case 'main':
     default:
       logger.throwError('unsupported network', Logger.errors.INVALID_ARGUMENT, {


### PR DESCRIPTION
## Description

This adds in the url for the public ropsten node so that the provider can be instantiated like:

```js
const provider = new OptimismProvider('gorli')
```

This would set the hostname as `rinkeby.optimism.io`.

Also notes this in the `README.md`

## Questions
- What is the actual url that is going to be used?


## Metadata

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
