### PR TITLE
Fixing Block Subscription Re-orgs

### DIFF
--- a/packages/core-db/src/app/ethereum/ethereum-block-processor.ts
+++ b/packages/core-db/src/app/ethereum/ethereum-block-processor.ts
@@ -111,7 +111,6 @@ export class EthereumBlockProcessor {
       log.debug(
         `Waiting for ${this.confirmsUntilFinal} confirms before disseminating block ${blockNumber}`
       )
-      // TODO: What happens on re-org? I think we're stuck waiting on this confirmation that will never come forever.
       try {
         const receipt: TransactionReceipt = await provider.waitForTransaction(
           (block.transactions[0] as any).hash,

--- a/packages/core-db/src/app/ethereum/ethereum-block-processor.ts
+++ b/packages/core-db/src/app/ethereum/ethereum-block-processor.ts
@@ -1,6 +1,6 @@
 /* External Imports */
 import { getLogger, logError } from '@eth-optimism/core-utils'
-import { Block, Provider } from 'ethers/providers'
+import { Block, Provider, TransactionReceipt } from 'ethers/providers'
 
 /* Internal Imports */
 import { EthereumListener } from '../../types/ethereum'
@@ -90,7 +90,7 @@ export class EthereumBlockProcessor {
   }
 
   /**
-   * Fetches and broadcasts the Block for the provided block number.
+   * Fetches the Block, waits for finalization, and broadcasts the Block for the provided block number.
    *
    * @param provider The provider with the connection to the blockchain
    * @param blockNumber The block number
@@ -113,10 +113,16 @@ export class EthereumBlockProcessor {
       )
       // TODO: What happens on re-org? I think we're stuck waiting on this confirmation that will never come forever.
       try {
-        await provider.waitForTransaction(
+        const receipt: TransactionReceipt = await provider.waitForTransaction(
           (block.transactions[0] as any).hash,
           this.confirmsUntilFinal
         )
+        if (receipt.blockHash !== block.hash) {
+          log.info(
+            `Re-org processing block number ${blockNumber}. Re-fetching block.`
+          )
+          return this.fetchAndDisseminateBlock(provider, blockNumber)
+        }
       } catch (e) {
         logError(
           log,


### PR DESCRIPTION
## Description
Making it so that after the first tx in a block is final, we check to make sure it is in the same block and if not re-fetch the block by number to handle re-orgs.


## Metadata
### Fixes
- Fixes # [Link to Issue]

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
