### PR TITLE
Fixing block hang on syncing empty blocks

### DIFF
--- a/packages/contracts/src/deployment/contract-deploy.ts
+++ b/packages/contracts/src/deployment/contract-deploy.ts
@@ -32,7 +32,7 @@ const deployContract = async (
 
   const deployResult = await config.signer.sendTransaction({
     data: rawTx.data,
-    gasLimit: 9_500_000,
+    gasLimit: 7_500_000,
     gasPrice: 2_000_000_000,
     value: 0,
     nonce: await config.signer.getTransactionCount('pending'),


### PR DESCRIPTION
## Description
Fixes infinite error loop on syncing an empty block by waiting for the block X blocks after it to exist.

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
