### PR TITLE
Simplifying block subscription

### DIFF
--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -32,7 +32,7 @@ services:
       - POSTGRES_CONNECTION_POOL_SIZE                                                   # The connection pool size for postgres (defaults to 20)
       - POSTGRES_USE_SSL                                                                # Set to anything to indicate that SSL should be used in the connection
       # L1 Node
-      - L1_NODE_INFURA_NETWORK=rinkeby                                                  # The Infura network for the connection to the L1 node
+      - L1_NODE_INFURA_NETWORK=goerli                                                  # The Infura network for the connection to the L1 node
       - L1_NODE_INFURA_PROJECT_ID=91981cfffb524ceca0c2e5b18905f9f5                      # The Infura project ID for the connection to the L1 node
       - L1_NODE_WEB3_URL                                                                # The URL of the L1 node
       - FINALITY_DELAY_IN_BLOCKS=1                                                      # The number of block confirmations required to consider a transaction final on L1

--- a/packages/core-db/src/app/ethereum/ethereum-block-processor.ts
+++ b/packages/core-db/src/app/ethereum/ethereum-block-processor.ts
@@ -209,6 +209,9 @@ export class EthereumBlockProcessor {
    * @returns The block number finalized by the provided block number.
    */
   private getBlockFinalizedBy(finalizingBlock: number): number {
+    if (this.confirmsUntilFinal <= 1) {
+      return finalizingBlock
+    }
     return finalizingBlock - (this.confirmsUntilFinal - 1)
   }
 

--- a/packages/core-db/test/app/ethereum/ethereum-block-processor.spec.ts
+++ b/packages/core-db/test/app/ethereum/ethereum-block-processor.spec.ts
@@ -1,7 +1,7 @@
 import '../../setup'
 
 /* External Imports */
-import { getLogger, sleep } from '@eth-optimism/core-utils'
+import { getLogger } from '@eth-optimism/core-utils'
 import { Block } from 'ethers/providers'
 import { createMockProvider, getWallets } from 'ethereum-waffle'
 
@@ -27,100 +27,228 @@ describe('Block Subscription', () => {
   let blockListener: TestListener<Block>
   let tokenContract
 
-  beforeEach(async () => {
-    provider = createMockProvider()
-    wallets = getWallets(provider)
-    ownerWallet = wallets[0]
-    recipientWallet = wallets[1]
+  describe('Instant finalization', () => {
+    beforeEach(async () => {
+      provider = createMockProvider()
+      wallets = getWallets(provider)
+      ownerWallet = wallets[0]
+      recipientWallet = wallets[1]
 
-    log.debug(`Connection info: ${JSON.stringify(provider.connection)}`)
+      log.debug(`Connection info: ${JSON.stringify(provider.connection)}`)
 
-    tokenContract = await deployTokenContract(ownerWallet, initialSupply)
+      tokenContract = await deployTokenContract(ownerWallet, initialSupply)
 
-    db = newInMemoryDB()
-    blockProcessor = new EthereumBlockProcessor(db)
-    blockListener = new TestListener<Block>()
+      db = newInMemoryDB()
+      blockProcessor = new EthereumBlockProcessor(db)
+      blockListener = new TestListener<Block>()
+    })
+
+    it('processes new blocks', async () => {
+      await blockProcessor.subscribe(provider, blockListener, false)
+
+      await tokenContract.transfer(
+        ownerWallet.address,
+        recipientWallet.address,
+        sendAmount
+      )
+
+      const blocks: Block[] = await blockListener.waitForReceive(1)
+
+      blocks.length.should.equal(1)
+      blocks[0].transactions.length.should.equal(1)
+    }).timeout(timeout)
+
+    it('processes old blocks', async () => {
+      await blockProcessor.subscribe(provider, blockListener)
+
+      const blocks: Block[] = await blockListener.waitForSyncToComplete()
+
+      blocks
+        .map((x) => x.number)
+        .sort()
+        .should.deep.equal([0, 1], `Incorrect blocks received!`)
+    }).timeout(timeout)
+
+    it('honors earliest block', async () => {
+      blockProcessor = new EthereumBlockProcessor(db, 1)
+      await blockProcessor.subscribe(provider, blockListener)
+
+      const blocks: Block[] = await blockListener.waitForSyncToComplete()
+
+      blocks.length.should.equal(0)
+    }).timeout(timeout)
+
+    it('processes blocks starting at 1', async () => {
+      blockProcessor = new EthereumBlockProcessor(db, 1)
+      await blockProcessor.subscribe(provider, blockListener)
+
+      let blocks: Block[] = await blockListener.waitForSyncToComplete()
+      blocks.length.should.equal(0)
+
+      await tokenContract.transfer(
+        ownerWallet.address,
+        recipientWallet.address,
+        sendAmount * 2
+      )
+
+      blocks = await blockListener.waitForReceive(2)
+      blocks.length.should.equal(2, `Incorrect number of blocks received!`)
+
+      blocks
+        .map((x) => x.number)
+        .sort()
+        .should.deep.equal([1, 2], `Incorrect blocks received!`)
+      blocks
+        .filter((x) => x.number === 2)[0]
+        .transactions.length.should.equal(1, `Tx Length incorrect!`)
+    }).timeout(timeout)
+
+    it('processes old and new blocks', async () => {
+      await blockProcessor.subscribe(provider, blockListener)
+
+      await tokenContract.transfer(
+        ownerWallet.address,
+        recipientWallet.address,
+        sendAmount * 2
+      )
+
+      const blocks: Block[] = await blockListener.waitForReceive(3)
+
+      blocks.length.should.equal(3, `Incorrect number of blocks received!`)
+
+      blocks
+        .map((x) => x.number)
+        .sort()
+        .should.deep.equal([0, 1, 2], `Incorrect blocks received!`)
+      blocks
+        .filter((x) => x.number === 2)[0]
+        .transactions.length.should.equal(1, `Tx Length incorrect!`)
+    }).timeout(timeout)
   })
 
-  it('processes new blocks', async () => {
-    await blockProcessor.subscribe(provider, blockListener, false)
+  describe('Delayed finalization', () => {
+    const confirmsUntilFinal = 2
+    beforeEach(async () => {
+      provider = createMockProvider()
+      wallets = getWallets(provider)
+      ownerWallet = wallets[0]
+      recipientWallet = wallets[1]
 
-    await tokenContract.transfer(
-      ownerWallet.address,
-      recipientWallet.address,
-      sendAmount
-    )
+      log.debug(`Connection info: ${JSON.stringify(provider.connection)}`)
 
-    const blocks: Block[] = await blockListener.waitForReceive(1)
+      db = newInMemoryDB()
+      blockProcessor = new EthereumBlockProcessor(db, 0, confirmsUntilFinal)
+      blockListener = new TestListener<Block>()
+    })
 
-    blocks.length.should.equal(1)
-    blocks[0].transactions.length.should.equal(1)
-  }).timeout(timeout)
+    it('does not process un-finalized block', async () => {
+      await blockProcessor.subscribe(provider, blockListener, false)
 
-  it('processes old blocks', async () => {
-    await blockProcessor.subscribe(provider, blockListener)
+      const blocks: Block[] = await blockListener.waitForReceive(1, 5_000)
 
-    const blocks: Block[] = await blockListener.waitForSyncToComplete()
+      blocks.length.should.equal(0)
+    }).timeout(timeout)
 
-    blocks
-      .map((x) => x.number)
-      .sort()
-      .should.deep.equal([0, 1], `Incorrect blocks received!`)
-  }).timeout(timeout)
+    it('finalizes blocks after enough confirms', async () => {
+      await blockProcessor.subscribe(provider, blockListener, false)
 
-  it('honors earliest block', async () => {
-    blockProcessor = new EthereumBlockProcessor(db, 1)
-    await blockProcessor.subscribe(provider, blockListener)
+      tokenContract = await deployTokenContract(ownerWallet, initialSupply)
 
-    const blocks: Block[] = await blockListener.waitForSyncToComplete()
+      const blocks: Block[] = await blockListener.waitForReceive(1, 5_000)
 
-    blocks.length.should.equal(0)
-  }).timeout(timeout)
+      blocks.length.should.equal(1, 'Should have received 1 finalized block!')
+      blocks[0].number.should.equal(0, 'Block 0 should have been finalized!')
+      blocks[0].transactions.length.should.equal(
+        0,
+        'There should be 0 transactions in block 0'
+      )
+    }).timeout(timeout)
 
-  it('processes blocks starting at 1', async () => {
-    blockProcessor = new EthereumBlockProcessor(db, 1)
-    await blockProcessor.subscribe(provider, blockListener)
+    it('finalizes multiple blocks after enough confirms', async () => {
+      await blockProcessor.subscribe(provider, blockListener, false)
 
-    let blocks: Block[] = await blockListener.waitForSyncToComplete()
-    blocks.length.should.equal(0)
+      tokenContract = await deployTokenContract(ownerWallet, initialSupply)
+      await tokenContract.transfer(
+        ownerWallet.address,
+        recipientWallet.address,
+        sendAmount * 2
+      )
 
-    await tokenContract.transfer(
-      ownerWallet.address,
-      recipientWallet.address,
-      sendAmount * 2
-    )
+      const blocks: Block[] = await blockListener.waitForReceive(2, 5_000)
 
-    blocks = await blockListener.waitForReceive(2)
-    blocks.length.should.equal(2, `Incorrect number of blocks received!`)
+      blocks.length.should.equal(2, 'Should have received 2 finalized block!')
+      blocks[0].number.should.equal(0, 'Block 0 should have been finalized!')
+      blocks[0].transactions.length.should.equal(
+        0,
+        'There should be 0 transactions in block 0'
+      )
 
-    blocks
-      .map((x) => x.number)
-      .sort()
-      .should.deep.equal([1, 2], `Incorrect blocks received!`)
-    blocks
-      .filter((x) => x.number === 2)[0]
-      .transactions.length.should.equal(1, `Tx Length incorrect!`)
-  }).timeout(timeout)
+      blocks[1].number.should.equal(1, 'Block 1 should have been finalized!')
+      blocks[1].transactions.length.should.equal(
+        1,
+        'There should be 1 transactions in block 1'
+      )
+      const deployToAddressEmpty = !(blocks[1].transactions[0] as any).to
+      deployToAddressEmpty.should.equal(
+        true,
+        'The "to" address for the deploy tx should be null'
+      )
+    }).timeout(timeout)
 
-  it('processes old and new blocks', async () => {
-    await blockProcessor.subscribe(provider, blockListener)
+    describe('Syncing past blocks', () => {
+      it('does not finalize past blocks if not final', async () => {
+        await blockProcessor.subscribe(provider, blockListener, true)
 
-    await tokenContract.transfer(
-      ownerWallet.address,
-      recipientWallet.address,
-      sendAmount * 2
-    )
+        const blocks: Block[] = await blockListener.waitForReceive(1, 5_000)
 
-    const blocks: Block[] = await blockListener.waitForReceive(3)
+        blocks.length.should.equal(0, 'Should not have finalized a block!')
+      }).timeout(timeout)
 
-    blocks.length.should.equal(3, `Incorrect number of blocks received!`)
+      it('finalizes past block', async () => {
+        tokenContract = await deployTokenContract(ownerWallet, initialSupply)
 
-    blocks
-      .map((x) => x.number)
-      .sort()
-      .should.deep.equal([0, 1, 2], `Incorrect blocks received!`)
-    blocks
-      .filter((x) => x.number === 2)[0]
-      .transactions.length.should.equal(1, `Tx Length incorrect!`)
-  }).timeout(timeout)
+        await blockProcessor.subscribe(provider, blockListener, true)
+
+        const blocks: Block[] = await blockListener.waitForReceive(1, 5_000)
+
+        blocks.length.should.equal(1, 'Should have received 1 finalized block!')
+        blocks[0].number.should.equal(0, 'Block 0 should have been finalized!')
+        blocks[0].transactions.length.should.equal(
+          0,
+          'There should be 0 transactions in block 0'
+        )
+      }).timeout(timeout)
+
+      it('finalizes past and future blocks', async () => {
+        tokenContract = await deployTokenContract(ownerWallet, initialSupply)
+
+        await blockProcessor.subscribe(provider, blockListener, true)
+        await tokenContract.transfer(
+          ownerWallet.address,
+          recipientWallet.address,
+          sendAmount * 2
+        )
+
+        const blocks: Block[] = await blockListener.waitForReceive(2, 5_000)
+
+        blocks.length.should.equal(2, 'Should have received 2 finalized block!')
+        blocks[0].number.should.equal(0, 'Block 0 should have been finalized!')
+        blocks[0].transactions.length.should.equal(
+          0,
+          'There should be 0 transactions in block 0'
+        )
+
+        blocks[1].number.should.equal(1, 'Block 1 should have been finalized!')
+        blocks[1].transactions.length.should.equal(
+          1,
+          'There should be 1 transactions in block 1'
+        )
+        const deployToAddressEmpty = !(blocks[1].transactions[0] as any).to
+        deployToAddressEmpty.should.equal(
+          true,
+          'The "to" address for the deploy tx should be null'
+        )
+      }).timeout(timeout)
+    })
+  })
 })

--- a/packages/core-db/test/app/ethereum/utils.ts
+++ b/packages/core-db/test/app/ethereum/utils.ts
@@ -36,12 +36,12 @@ export class TestListener<T> implements EthereumListener<T> {
   }
 
   public async waitForReceive(
-    num: number = 1,
+    numberToReceive: number = 1,
     timeoutMillis: number = -1
   ): Promise<T[]> {
     const startTime = new Date().getTime()
     while (
-      this.received.length < num &&
+      this.received.length < numberToReceive &&
       (timeoutMillis < 0 || new Date().getTime() - startTime < timeoutMillis)
     ) {
       await sleep(this.sleepMillis)


### PR DESCRIPTION
## Description
Simplifies block subscription by finalizing the block X blocks ago when a block is received. Also adds more tests for the transition between syncing past blocks and current/future blocks.


## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
