### PR TITLE
provider: include txmeta in transaction response

### DIFF
--- a/packages/provider/src/app/provider.ts
+++ b/packages/provider/src/app/provider.ts
@@ -43,24 +43,22 @@ export class OptimismProvider extends JsonRpcProvider {
     this._ethersType = 'Provider'
 
     // Handle properly deriving "from" on the transaction
-    const format = this.formatter.transaction
+    const format = this.formatter.transaction.bind(this.formatter)
     this.formatter.transaction = (transaction) => {
       const tx = format(transaction)
       const sig = joinSignature(tx as SignatureLike)
       const hash = utils.sighashEthSign(tx)
-      // need to concat and hash with
       tx.from = verifyMessage(hash, sig)
       return tx
     }
 
-    // TODO(mark): debugging help
-    const formatTxResponse = this.formatter.transactionResponse
+    // Handle additional data sent from RPC
+    const formatTxResponse = this.formatter.transactionResponse.bind(this.formatter)
     this.formatter.transactionResponse = (transaction) => {
-      const tx = formatTxResponse(transaction)
+      const tx = formatTxResponse(transaction) as any
       tx.type = transaction.type
       tx.queueOrigin = transaction.queueOrigin
       tx.l1MessageSender = transaction.l1MessageSender
-      console.log(tx)
       return tx
     }
   }

--- a/packages/provider/src/app/provider.ts
+++ b/packages/provider/src/app/provider.ts
@@ -53,7 +53,9 @@ export class OptimismProvider extends JsonRpcProvider {
     }
 
     // Handle additional data sent from RPC
-    const formatTxResponse = this.formatter.transactionResponse.bind(this.formatter)
+    const formatTxResponse = this.formatter.transactionResponse.bind(
+      this.formatter
+    )
     this.formatter.transactionResponse = (transaction) => {
       const tx = formatTxResponse(transaction) as any
       tx.type = transaction.type

--- a/packages/provider/src/app/provider.ts
+++ b/packages/provider/src/app/provider.ts
@@ -83,10 +83,6 @@ export class OptimismProvider extends JsonRpcProvider {
     )
   }
 
-  public async getTransaction(transactionHash: string | Promise<string>) {
-    return super.getTransaction(transactionHash)
-  }
-
   // `send` takes the literal RPC method name. The signer cannot use this
   // codepath, it is for querying an optimism node.
   public async send(method: string, params: any[]): Promise<any> {

--- a/packages/provider/src/app/provider.ts
+++ b/packages/provider/src/app/provider.ts
@@ -52,6 +52,17 @@ export class OptimismProvider extends JsonRpcProvider {
       tx.from = verifyMessage(hash, sig)
       return tx
     }
+
+    // TODO(mark): debugging help
+    const formatTxResponse = this.formatter.transactionResponse
+    this.formatter.transactionResponse = (transaction) => {
+      const tx = formatTxResponse(transaction)
+      tx.type = transaction.type
+      tx.queueOrigin = transaction.queueOrigin
+      tx.l1MessageSender = transaction.l1MessageSender
+      console.log(tx)
+      return tx
+    }
   }
 
   public get ethereum() {
@@ -70,6 +81,10 @@ export class OptimismProvider extends JsonRpcProvider {
         operation: 'getSigner',
       }
     )
+  }
+
+  public async getTransaction(transactionHash: string | Promise<string>) {
+    return super.getTransaction(transactionHash)
   }
 
   // `send` takes the literal RPC method name. The signer cannot use this


### PR DESCRIPTION
## Description

Adds additional txmeta fields from l2geth
https://github.com/ethereum-optimism/go-ethereum/pull/35

## Metadata
### Fixes
- Fixes # [Link to Issue]

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
