### PR TITLE
Setup whitelist as OVM precompile

### DIFF
--- a/packages/contracts/contracts/optimistic-ethereum/ovm/ExecutionManager.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/ovm/ExecutionManager.sol
@@ -38,6 +38,7 @@ contract ExecutionManager is ContractResolver {
     // Precompile addresses
     address constant private L2_TO_L1_OVM_MESSAGE_PASSER = 0x4200000000000000000000000000000000000000;
     address constant private L1_MESSAGE_SENDER = 0x4200000000000000000000000000000000000001;
+    address constant private DEPLOYER_WHITELIST = 0x4200000000000000000000000000000000000002;
 
     /*
      * Contract Variables
@@ -76,6 +77,7 @@ contract ExecutionManager is ContractResolver {
         stateManager.associateCodeContract(L2_TO_L1_OVM_MESSAGE_PASSER, address(l2ToL1MessagePasser));
         L1MessageSender l1MessageSender = new L1MessageSender(address(this));
         stateManager.associateCodeContract(L1_MESSAGE_SENDER, address(l1MessageSender));
+        stateManager.associateCodeContract(DEPLOYER_WHITELIST, address(resolveDeployerWhitelist()));
 
         executionContext.chainId = 420;
 
@@ -1228,6 +1230,10 @@ contract ExecutionManager is ContractResolver {
     function getStateManagerAddress() public view returns (address) {
         StateManager stateManager = resolveStateManager();
         return address(stateManager);
+    }
+
+    function associateDeployerPrecompile() public {
+        resolveStateManager().associateCodeContract(DEPLOYER_WHITELIST, address(resolveDeployerWhitelist()));
     }
 
     /*

--- a/packages/contracts/contracts/optimistic-ethereum/ovm/ExecutionManager.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/ovm/ExecutionManager.sol
@@ -198,7 +198,10 @@ contract ExecutionManager is ContractResolver {
         if (isCreate) {
             // Require that the deployer whitelist contract approves of the deployment.
             // TODO: Put this check inside of our default EOA contracts
+
+            restoreContractContext(ZERO_ADDRESS, DEPLOYER_WHITELIST);
             require(resolveDeployerWhitelist().isDeployerAllowed(_fromAddress), "Sender not allowed to deploy new contracts!");
+            restoreContractContext(ZERO_ADDRESS, _fromAddress);
             methodId = METHOD_ID_OVM_CREATE;
             callSize = _callBytes.length + 4;
 
@@ -1230,10 +1233,6 @@ contract ExecutionManager is ContractResolver {
     function getStateManagerAddress() public view returns (address) {
         StateManager stateManager = resolveStateManager();
         return address(stateManager);
-    }
-
-    function associateDeployerPrecompile() public {
-        resolveStateManager().associateCodeContract(DEPLOYER_WHITELIST, address(resolveDeployerWhitelist()));
     }
 
     /*

--- a/packages/contracts/contracts/optimistic-ethereum/ovm/precompiles/DeployerWhitelist.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/ovm/precompiles/DeployerWhitelist.sol
@@ -1,6 +1,5 @@
 pragma solidity ^0.5.0;
 pragma experimental ABIEncoderV2;
-import { console } from "@nomiclabs/buidler/console.sol";
 
 /**
  * @title DeployerWhitelist
@@ -16,30 +15,15 @@ contract DeployerWhitelist {
     function initialize(address _owner, bool _allowArbitraryDeployment)
         public
     {
-        console.log("..........initializing............."); // WITH OVM ADDRESS:");
-        // console.logBytes32(getOvmADDRESS());
         bytes32 alreadyInitialized = get(INITIALIZED_KEY);
         if (alreadyInitialized != bytes32(0)) {
-            console.log("................already initialized, aborting............");
             return;
         }
 
-        console.log("setting initialized");
         set(INITIALIZED_KEY, bytes32(uint(1)));
-        console.log("setting owner key");
         set(OWNER_KEY, bytes32(bytes20(_owner)));
-        console.log("setting allow arbitrary");
         uint allowArbitraryDeployment = _allowArbitraryDeployment ? 1 : 0;
         set(ALLOW_ARBITRARY_DEPLOYMENT, bytes32(allowArbitraryDeployment));
-
-        console.log("I will now immediately get all the vals to check persistence intra-transaction.");
-        console.log("getting  initialized");
-        get(INITIALIZED_KEY);
-        console.log("getting owner key");
-        get(OWNER_KEY);
-        console.log("getting allow arbitrary");
-        get(ALLOW_ARBITRARY_DEPLOYMENT);
-        console.log("...........Initialized successfully..........");
     }
 
     /*
@@ -47,16 +31,12 @@ contract DeployerWhitelist {
      */
     // Source: https://solidity.readthedocs.io/en/v0.5.3/contracts.html
     modifier onlyOwner {
-        console.log("in onlyOwner modifier, here is a get for owner key...");
         bytes32 owner = get(OWNER_KEY);
-        console.log("and here is the ovmCALLER address...");
         bytes32 ovmCALLER = getOvmCALLER();
-        console.logBytes32(ovmCALLER);
         require(
             ovmCALLER == owner,
             "Only owner can call this function."
         );
-        console.log("successfully authenticated that this is the owner.");
         _;
     }
 
@@ -125,11 +105,8 @@ contract DeployerWhitelist {
         external
         returns(bool)
     {
-        console.log("getting allowarbitrary");
         bool allowArbitraryDeployment = uint(get(ALLOW_ARBITRARY_DEPLOYMENT)) == 1;
-        console.log("getting isWhitelistedDeployer");
         bool isWhitelistedDeployer = uint(get(bytes32(bytes20(_deployerAddress)))) == 1;
-        console.log("getting isInitialized");
         bool isInitialized = uint(get(INITIALIZED_KEY)) != 0;
         
         return allowArbitraryDeployment || isWhitelistedDeployer || !isInitialized;
@@ -146,10 +123,6 @@ contract DeployerWhitelist {
     {
         bytes4 methodId = bytes4(keccak256("ovmSSTORE()"));
         msg.sender.call(abi.encodeWithSelector(methodId, _key, _value));
-        console.log("SET key");
-        console.logBytes32(_key);
-        console.log("SET value");
-        console.logBytes32(_value);
     }
 
     /**
@@ -167,18 +140,12 @@ contract DeployerWhitelist {
         assembly {
             value := mload(add(result, 0x20))
         }
-        console.log("GET key");
-        console.logBytes32(_key);
-        console.log("GET returned value");
-        console.logBytes32(value);
         return value;
     }
 
     function getOvmCALLER() internal returns(bytes32) {
         bytes4 methodId = bytes4(keccak256("ovmCALLER()"));
         (, bytes memory result) = msg.sender.call(abi.encodeWithSelector(methodId)); 
-        // console.log("result of ovmCALLER call data:");
-        // console.logBytes(result);
         
         bytes32 value;
         assembly {

--- a/packages/contracts/contracts/optimistic-ethereum/ovm/precompiles/DeployerWhitelist.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/ovm/precompiles/DeployerWhitelist.sol
@@ -119,7 +119,7 @@ contract DeployerWhitelist {
         bytes32 _key,
         bytes32 _value
     )
-        public
+        internal
     {
         bytes4 methodId = bytes4(keccak256("ovmSSTORE()"));
         msg.sender.call(abi.encodeWithSelector(methodId, _key, _value));

--- a/packages/contracts/test/contracts/ovm/StateTransitioner.spec.ts
+++ b/packages/contracts/test/contracts/ovm/StateTransitioner.spec.ts
@@ -489,23 +489,6 @@ describe('StateTransitioner', () => {
     StateTransitioner = await ethers.getContractFactory('StateTransitioner')
     StateManager = await ethers.getContractFactory('PartialStateManager')
 
-    console.log(
-      `path is ${path.resolve(
-        __dirname,
-        '../../../contracts/test-helpers/FraudTester.sol'
-      )}`
-    )
-    console.log(
-      `compile esult is ${JSON.stringify(
-        compile(
-          solc,
-          path.resolve(
-            __dirname,
-            '../../../contracts/test-helpers/FraudTester.sol'
-          )
-        ).errors
-      )}`
-    )
     const AllFraudTestJson = compile(
       solc,
       path.resolve(__dirname, '../../../contracts/test-helpers/FraudTester.sol')

--- a/packages/contracts/test/contracts/ovm/StateTransitioner.spec.ts
+++ b/packages/contracts/test/contracts/ovm/StateTransitioner.spec.ts
@@ -130,6 +130,14 @@ const CUMULATIVE_SEQUENCED_GAS_AT_EPOCH_START_STORAGE_KEY =
 const CUMULATIVE_QUEUED_GAS_AT_EPOCH_START_STORAGE_KEY =
   '0x0000000000000000000000000000000000000000000000000000000000000005'
 
+const DEPLOYER_WHITELIST_ADDRESS = '0x4200000000000000000000000000000000000002'
+const INITIALIZED_KEY =
+  '0x0000000000000000000000000000000000000000000000000000000000000010'
+const OWNER_KEY =
+  '0x0000000000000000000000000000000000000000000000000000000000000011'
+const ALLOW_ARBITRARY_DEPLOYMENT =
+  '0x0000000000000000000000000000000000000000000000000000000000000012'
+
 const initialCumulativeSequencedGas = 0
 const initialCumulativeQueuedGas = 0
 const initialGasRateLimitEpochStart = 0
@@ -206,6 +214,10 @@ const DUMMY_INITIAL_STATE_TRIE = {
   [METADATA_STORAGE_ADDRESS]: {
     state: EMPTY_ACCOUNT_STATE(),
     storage: INITIAL_OVM_GAS_STORAGE(),
+  },
+  [DEPLOYER_WHITELIST_ADDRESS]: {
+    state: EMPTY_ACCOUNT_STATE(),
+    storage: DUMMY_ACCOUNT_STORAGE(),
   },
 }
 
@@ -477,6 +489,23 @@ describe('StateTransitioner', () => {
     StateTransitioner = await ethers.getContractFactory('StateTransitioner')
     StateManager = await ethers.getContractFactory('PartialStateManager')
 
+    console.log(
+      `path is ${path.resolve(
+        __dirname,
+        '../../../contracts/test-helpers/FraudTester.sol'
+      )}`
+    )
+    console.log(
+      `compile esult is ${JSON.stringify(
+        compile(
+          solc,
+          path.resolve(
+            __dirname,
+            '../../../contracts/test-helpers/FraudTester.sol'
+          )
+        ).errors
+      )}`
+    )
     const AllFraudTestJson = compile(
       solc,
       path.resolve(__dirname, '../../../contracts/test-helpers/FraudTester.sol')

--- a/packages/contracts/test/contracts/ovm/execution-manager/ExecutionManager.executeCall.spec.ts
+++ b/packages/contracts/test/contracts/ovm/execution-manager/ExecutionManager.executeCall.spec.ts
@@ -27,7 +27,6 @@ import {
   AddressResolverMapping,
   getDefaultGasMeterParams,
 } from '../../../test-helpers'
-import {} from 'ethers/providers'
 
 /* Logging */
 const log = getLogger('execution-manager-calls', true)

--- a/packages/contracts/test/contracts/ovm/execution-manager/ExecutionManager.executeCall.spec.ts
+++ b/packages/contracts/test/contracts/ovm/execution-manager/ExecutionManager.executeCall.spec.ts
@@ -383,7 +383,7 @@ describe('Execution Manager -- TX/Call Execution Functions', () => {
           chainId: CHAIN_ID,
         })
       } catch (e) {
-        log.debug(JSON.stringify(e) + '  ' + e.stack)
+        log.debug(e.stack)
         failed = true
       }
 
@@ -423,7 +423,7 @@ describe('Execution Manager -- TX/Call Execution Functions', () => {
           chainId: CHAIN_ID,
         })
       } catch (e) {
-        log.debug(JSON.stringify(e) + '  ' + e.stack)
+        log.debug(e.stack)
         failed = true
       }
 

--- a/packages/contracts/test/contracts/ovm/execution-manager/ExecutionManager.executeCall.spec.ts
+++ b/packages/contracts/test/contracts/ovm/execution-manager/ExecutionManager.executeCall.spec.ts
@@ -27,13 +27,14 @@ import {
   AddressResolverMapping,
   getDefaultGasMeterParams,
 } from '../../../test-helpers'
-import {  } from 'ethers/providers'
+import {} from 'ethers/providers'
 
 /* Logging */
 const log = getLogger('execution-manager-calls', true)
 
 export const abi = new ethers.utils.AbiCoder()
-const DEPLOYER_WHITELIST_OVM_ADDRESS = '0x4200000000000000000000000000000000000002'
+const DEPLOYER_WHITELIST_OVM_ADDRESS =
+  '0x4200000000000000000000000000000000000002'
 
 /* Tests */
 describe('Execution Manager -- TX/Call Execution Functions', () => {
@@ -101,8 +102,6 @@ describe('Execution Manager -- TX/Call Execution Functions', () => {
         [intParam, bytesParam]
       )
 
-
-
       const nonce = await stateManager.getOvmContractNonceView(wallet.address)
       const transaction = {
         nonce,
@@ -137,13 +136,10 @@ describe('Execution Manager -- TX/Call Execution Functions', () => {
       await callDeployerWhitelist(
         wallet,
         executionManager,
-        DeployerWhitelist.interface.encodeFunctionData(
-          'initialize',
-          [
-            wallet.address,
-            false
-          ]
-        )
+        DeployerWhitelist.interface.encodeFunctionData('initialize', [
+          wallet.address,
+          false,
+        ])
       )
 
       // Generate our tx calldata
@@ -183,10 +179,7 @@ describe('Execution Manager -- TX/Call Execution Functions', () => {
         executionManager,
         DeployerWhitelist.interface.encodeFunctionData(
           'setWhitelistedDeployer',
-          [
-            wallet.address,
-            true
-          ]
+          [wallet.address, true]
         )
       )
 
@@ -206,10 +199,7 @@ describe('Execution Manager -- TX/Call Execution Functions', () => {
         executionManager,
         DeployerWhitelist.interface.encodeFunctionData(
           'setWhitelistedDeployer',
-          [
-            wallet.address,
-            false
-          ]
+          [wallet.address, false]
         )
       )
 

--- a/packages/contracts/test/contracts/ovm/execution-manager/ExecutionManager.executeCall.spec.ts
+++ b/packages/contracts/test/contracts/ovm/execution-manager/ExecutionManager.executeCall.spec.ts
@@ -91,7 +91,7 @@ describe('Execution Manager -- TX/Call Execution Functions', () => {
     log.debug(`Contract address: [${dummyContractAddress}]`)
   })
 
-  describe.only('executeNonEOACall', async () => {
+  describe('executeNonEOACall', async () => {
     it('properly executes a raw call -- 0 param', async () => {
       // Create the variables we will use for setStorage
       const intParam = 0

--- a/packages/contracts/test/contracts/ovm/execution-manager/ExecutionManager.executeCall.spec.ts
+++ b/packages/contracts/test/contracts/ovm/execution-manager/ExecutionManager.executeCall.spec.ts
@@ -87,12 +87,10 @@ describe('Execution Manager -- TX/Call Execution Functions', () => {
       []
     )
 
-    console.log('successfully manually deployed DummyContract')
-
     log.debug(`Contract address: [${dummyContractAddress}]`)
   })
 
-  describe('executeNonEOACall', async () => {
+  describe.only('executeNonEOACall', async () => {
     it('properly executes a raw call -- 0 param', async () => {
       // Create the variables we will use for setStorage
       const intParam = 0
@@ -129,21 +127,11 @@ describe('Execution Manager -- TX/Call Execution Functions', () => {
       await provider.waitForTransaction(tx.hash)
     })
 
-    it.only('utilizes the DeployerWhitelist contract to disallow arbitrary contract deployment', async () => {
+    it('utilizes the DeployerWhitelist contract to disallow arbitrary contract deployment', async () => {
       wallet = wallet.connect(executionManager.provider)
       const DeployerWhitelist = await ethers.getContractFactory(
         'DeployerWhitelist'
       )
-      // const deployerWhitelist = await DeployerWhitelist.deploy(
-      //   wallet.address,
-      //   false
-      // )
-      // await resolver.addressResolver.setAddress(
-      //   'DeployerWhitelist',
-      //   deployerWhitelist.address
-      // )
-
-      // await executionManager.associateDeployerPrecompile()
 
       // Initialize our deployment whitelist
       await callDeployerWhitelist(
@@ -173,7 +161,7 @@ describe('Execution Manager -- TX/Call Execution Functions', () => {
         data: calldata,
         chainId: CHAIN_ID,
       }
-      console.log("attempting creation");
+
       // Call using Ethers and expect it to fail
       await TestUtils.assertRevertsAsync(
         async () =>
@@ -189,8 +177,6 @@ describe('Execution Manager -- TX/Call Execution Functions', () => {
         'Sender not allowed to deploy new contracts!'
       )
 
-      console.log('setting whitelisted deployer to true')
-
       // Now add the wallet.address to the whitelist and it should work this time!
       await callDeployerWhitelist(
         wallet,
@@ -203,7 +189,6 @@ describe('Execution Manager -- TX/Call Execution Functions', () => {
           ]
         )
       )
-      console.log('calling deploy')
 
       await executionManager.executeTransaction(
         getCurrentTime(),
@@ -216,7 +201,6 @@ describe('Execution Manager -- TX/Call Execution Functions', () => {
       )
 
       // And then... set it to false, try to call, and it'll fail again!
-
       await callDeployerWhitelist(
         wallet,
         executionManager,
@@ -257,7 +241,7 @@ describe('Execution Manager -- TX/Call Execution Functions', () => {
         0,
         transaction.to,
         transaction.data,
-        wallet.address,
+        '0x' + '1234'.repeat(10),
         ZERO_ADDRESS,
         true
       )


### PR DESCRIPTION
## Description
This PR sets up the previously created `DeployerWhitelist` to be an OVM precompile, and fixes the context before it is called, so that it may use OVM storage.

## Usage
- The whitelist is associated with OVM address `0x4200000000000000000000000000000000000002`.
- The whitelist now uses `function initialize(address _owner, bool _allowArbitraryDeployment)` in place of a constructor.

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
