### PR TITLE
Accounting for 66-byte signatures

### DIFF
--- a/db/scripts/3_create_l2_tables.sql
+++ b/db/scripts/3_create_l2_tables.sql
@@ -37,7 +37,7 @@ CREATE TABLE l2_tx_output (
   gas_limit NUMERIC(78) NOT NULL,
   gas_price NUMERIC(78) NOT NULL,
   calldata TEXT NOT NULL,
-  signature CHARACTER(132) NOT NULL,
+  signature CHARACTER(134) NOT NULL,
   state_root CHARACTER(66) NOT NULL,
   l1_rollup_tx_id BIGINT DEFAULT NULL,
   canonical_chain_batch_number BIGINT DEFAULT NULL,

--- a/packages/rollup-core/src/app/constants.ts
+++ b/packages/rollup-core/src/app/constants.ts
@@ -43,4 +43,4 @@ export const L2_TO_L1_MESSAGE_PASSER_OVM_ADDRESS =
   '0x4200000000000000000000000000000000000000'
 
 // See the getTransactionBatchCalldata(...) function of canonical-chain-batch-submitter.ts for more info
-export const ROLLUP_TX_SIZE_IN_BYTES_MINUS_CALLDATA = 149
+export const ROLLUP_TX_SIZE_IN_BYTES_MINUS_CALLDATA = 150

--- a/packages/rollup-core/src/app/constants.ts
+++ b/packages/rollup-core/src/app/constants.ts
@@ -7,7 +7,7 @@ export const L1ToL2TransactionBatchEventName = 'NewTransactionBatchAdded'
 export const CREATOR_CONTRACT_ADDRESS = ZERO_ADDRESS
 export const GAS_LIMIT = 1_000_000_000
 
-export const CHAIN_ID = 108
+export const CHAIN_ID = 420
 
 export const DEFAULT_UNSAFE_OPCODES: EVMOpcode[] = [
   Opcode.ADDRESS,

--- a/packages/rollup-core/src/app/data/consumers/canonical-chain-batch-submitter.ts
+++ b/packages/rollup-core/src/app/data/consumers/canonical-chain-batch-submitter.ts
@@ -231,8 +231,8 @@ export class CanonicalChainBatchSubmitter extends ScheduledTask {
    *    target: 20-byte address    0-20
    *    nonce: 32-byte uint        20-52
    *    gasLimit: 32-byte uint     52-84
-   *    signature: 65-byte bytes   84-149
-   *    calldata: bytes            149-end
+   *    signature: 66-byte bytes   84-150
+   *    calldata: bytes            150-end
    *
    * @param batch The batch to turn into ABI-encoded calldata bytes.
    * @returns The ABI-encoded bytes[] of the Rollup Transactions in the format listed above.

--- a/packages/rollup-core/src/app/data/producers/log-handlers.ts
+++ b/packages/rollup-core/src/app/data/producers/log-handlers.ts
@@ -102,8 +102,8 @@ export const L1ToL2TxEnqueuedLogHandler = async (
  *   - target: 20-byte address	  0-20
  *   - nonce: 32-byte uint 	      20-52
  *   - gasLimit: 32-byte uint	    52-84
- *   - signature: 65-byte bytes   84-149
- *   - calldata: bytes    		    149-end
+ *   - signature: 66-byte bytes   84-150
+ *   - calldata: bytes    		    150-end
  *
  * @param ds The L1DataService to use for persistence.
  * @param l The log event that was emitted.
@@ -127,8 +127,8 @@ export const CalldataTxEnqueuedLogHandler = async (
     const target = add0x(l1TxCalldata.substr(0, 40))
     const nonce = new BigNumber(l1TxCalldata.substr(40, 64), 'hex')
     const gasLimit = new BigNumber(l1TxCalldata.substr(104, 64), 'hex')
-    const signature = add0x(l1TxCalldata.substr(168, 130))
-    const calldata = add0x(l1TxCalldata.substr(298))
+    const signature = add0x(l1TxCalldata.substr(168, 132))
+    const calldata = add0x(l1TxCalldata.substr(300))
 
     const unsigned: TransactionRequest = {
       to: target,
@@ -142,7 +142,7 @@ export const CalldataTxEnqueuedLogHandler = async (
 
     const r = add0x(signature.substr(2, 64))
     const s = add0x(signature.substr(66, 64))
-    const v = parseInt(signature.substr(130, 2), 16)
+    const v = parseInt(signature.substr(130, 4), 16)
     const sender: string = await getTxSigner(unsigned, r, s, v)
 
     rollupTransaction.l1BlockNumber = tx.blockNumber
@@ -261,8 +261,8 @@ export const SafetyQueueBatchAppendedLogHandler = async (
  *   - target: 20-byte address	  0-20
  *   - nonce: 32-byte uint 	      20-52
  *   - gasLimit: 32-byte uint	    52-84
- *   - signature: 65-byte bytes   84-149
- *   - calldata: bytes    		    149-end
+ *   - signature: 65-byte bytes   84-150
+ *   - calldata: bytes    		    150-end
  *
  * @param ds The L1DataService to use for persistence.
  * @param l The log event that was emitted.
@@ -295,8 +295,8 @@ export const SequencerBatchAppendedLogHandler = async (
       const target = add0x(txBytes.substr(0, 40))
       const nonce = new BigNumber(txBytes.substr(40, 64), 'hex')
       const gasLimit = new BigNumber(txBytes.substr(104, 64), 'hex')
-      const signature = add0x(txBytes.substr(168, 130))
-      const calldata = add0x(txBytes.substr(298))
+      const signature = add0x(txBytes.substr(168, 132))
+      const calldata = add0x(txBytes.substr(300))
 
       const unsigned: TransactionRequest = {
         to: target,
@@ -310,7 +310,7 @@ export const SequencerBatchAppendedLogHandler = async (
 
       const r = add0x(signature.substr(2, 64))
       const s = add0x(signature.substr(66, 64))
-      const v = parseInt(signature.substr(130, 2), 16)
+      const v = parseInt(signature.substr(130, 4), 16)
       const sender: string = await getTxSigner(unsigned, r, s, v)
 
       rollupTransactions.push({

--- a/packages/rollup-core/test/app/log-handlers.spec.ts
+++ b/packages/rollup-core/test/app/log-handlers.spec.ts
@@ -2,6 +2,7 @@
 import {
   add0x,
   keccak256FromUtf8,
+  padToLength,
   remove0x,
   TestUtils,
   ZERO_ADDRESS,
@@ -163,7 +164,7 @@ const getTxSignature = async (
   const sig = await w.sign(trans)
   const t: Transaction = parseTransaction(sig)
 
-  return add0x(`${t.r}${remove0x(t.s)}${t.v.toString(16)}`)
+  return add0x(`${t.r}${remove0x(t.s)}${padToLength(t.v.toString(16), 4)}`)
 }
 
 describe('Log Handlers', () => {


### PR DESCRIPTION
## Description
Accounting for 66-byte signatures.

Updating:
* Rollup tx format documentation in canonical chain batch submitter
* log-handlers to parse rolled up txs as having 66-byte signatures
* Queries that account for total tx size to be 150 bytes without calldata instead of 149

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
