### PR TITLE
Fix L1ToL2 tx postgres ingestion

### DIFF
--- a/packages/core-utils/src/app/crypto.ts
+++ b/packages/core-utils/src/app/crypto.ts
@@ -108,12 +108,13 @@ export const getTxSigner = async (
  * @throws Error If r, s, or v are not the correct length.
  */
 export const rsvToSignature = (r: string, s: string, v: number): string => {
-  const vString = remove0x(numberToHexString(v, 1))
+  const vString = remove0x(numberToHexString(v, 2))
   const sig = `${add0x(r)}${remove0x(s)}${vString}`
-  // '0x' + 64 chars for r + 64 chars for s + 2 chars for v = 132
-  if (sig.length !== 132) {
+
+  // '0x' + 64 chars for r + 64 chars for s + 4 chars for v = 134
+  if (sig.length !== 134) {
     throw Error(
-      `Invalid v [${vString}], r [${r}], s[${s}]. v [${vString.length}] should be 2 chars, r [${r.length}] should be 64 chars, and s [${s.length}] should be 64 chars.`
+      `Invalid v [${vString}], r [${r}], s[${s}]. v [${vString.length}] should be 4 chars, r [${r.length}] should be 64 chars, and s [${s.length}] should be 64 chars.`
     )
   }
 

--- a/packages/rollup-core/src/app/data/data-service.ts
+++ b/packages/rollup-core/src/app/data/data-service.ts
@@ -95,7 +95,7 @@ export class DefaultDataService implements DataService {
     txContext?: any
   ): Promise<void> {
     return this.rdb.execute(
-      `${l1BlockInsertStatement} 
+      `${l1BlockInsertStatement}
       VALUES (${getL1BlockInsertValue(block, processed)})`,
       txContext
     )
@@ -114,8 +114,9 @@ export class DefaultDataService implements DataService {
     const values: string[] = transactions.map(
       (tx, index) => `(${getL1TransactionInsertValue(tx, index)})`
     )
+
     return this.rdb.execute(
-      `${l1TxInsertStatement} 
+      `${l1TxInsertStatement}
       VALUES ${values.join(',')}`,
       txContext
     )

--- a/packages/rollup-core/src/app/data/producers/l1-chain-data-persister.ts
+++ b/packages/rollup-core/src/app/data/producers/l1-chain-data-persister.ts
@@ -107,7 +107,7 @@ export class L1ChainDataPersister extends ChainDataProcessor {
         return this.markProcessed(index)
       }
 
-      const logs: Log[] = await this.getLogsForBlock(block)
+      const logs: Log[] = await this.getLogsForBlock(block.hash)
 
       log.debug(
         `Got ${logs.length} logs from block ${block.number}: ${JSON.stringify(
@@ -195,19 +195,15 @@ export class L1ChainDataPersister extends ChainDataProcessor {
    * @param blockHash The block hash for the block in which we're searching for logs.
    * @returns The combined array of Logs that we care about based on our topics.
    */
-  private async getLogsForBlock(block: Block): Promise<Log[]> {
+  private async getLogsForBlock(blockHash: string): Promise<Log[]> {
     if (!this.topics.length) {
       return []
     }
 
-    // TODO: Protect against reorgs which change the block number from under us
-    //       Once Ganache supports EIP-234 then we should move this back to using blockHash
-    //       https://github.com/trufflesuite/ganache-core/issues/136
     const logsArrays: Log[][] = await Promise.all(
       this.topics.map((topic) =>
         this.l1Provider.getLogs({
-          toBlock: block.number,
-          fromBlock: block.number,
+          blockHash,
           topics: [topic],
         })
       )

--- a/packages/rollup-core/src/app/data/producers/log-handlers.ts
+++ b/packages/rollup-core/src/app/data/producers/log-handlers.ts
@@ -84,10 +84,11 @@ export const L1ToL2TxEnqueuedLogHandler = async (
       'hex'
     ).toNumber()
     rollupTransaction.calldata = add0x(parsedLogData[3])
+    rollupTransaction.l1TxLogIndex = l.logIndex
   } catch (e) {
     // This is, by definition, just an ill-formatted, and therefore invalid, tx.
     log.debug(
-      `Error parsing calldata tx from CalldataTxEnqueued event. Calldata: ${tx.data}. Error: ${e.message}. Stack: ${e.stack}.`
+      `Error parsing calldata tx from L1ToL2TxEnqueued event. Calldata: ${tx.data}. Error: ${e.message}. Stack: ${e.stack}.`
     )
   }
 
@@ -334,7 +335,7 @@ export const SequencerBatchAppendedLogHandler = async (
   } catch (e) {
     // This is, by definition, just an ill-formatted, and therefore invalid, tx.
     log.debug(
-      `Error parsing calldata tx from CalldataTxEnqueued event. Calldata: ${tx.data}. Error: ${e.message}. Stack: ${e.stack}.`
+      `Error parsing calldata tx from SequencerBatchAppended event. Calldata: ${tx.data}. Error: ${e.message}. Stack: ${e.stack}.`
     )
     return
   }
@@ -375,7 +376,7 @@ export const StateBatchAppendedLogHandler = async (
   } catch (e) {
     // This is, by definition, just an ill-formatted, and therefore invalid, tx.
     log.debug(
-      `Error parsing calldata tx from CalldataTxEnqueued event. Calldata: ${tx.data}. Error: ${e.message}. Stack: ${e.stack}.`
+      `Error parsing calldata tx from StateBatchAppended event. Calldata: ${tx.data}. Error: ${e.message}. Stack: ${e.stack}.`
     )
     return
   }

--- a/packages/rollup-services/src/exec/services.ts
+++ b/packages/rollup-services/src/exec/services.ts
@@ -165,14 +165,15 @@ const createL1ChainDataPersister = async (): Promise<L1ChainDataPersister> => {
   log.info(
     `Creating L1 Chain Data Persister with earliest block ${Environment.l1EarliestBlock()}`
   )
-  console.log('Just checking that this worked')
   return L1ChainDataPersister.create(
     getProcessingDataService(),
     getDataService(),
     getL1Provider(),
     [
       {
-        topic: ethers.utils.id('L1ToL2TxEnqueued(address,address,uint32,bytes)'), // 7f897cd072f041e68ba57be8f0eec7b8933b0b113622ed8ef85685764f6e7986
+        topic: ethers.utils.id(
+          'L1ToL2TxEnqueued(address,address,uint32,bytes)'
+        ), // 7f897cd072f041e68ba57be8f0eec7b8933b0b113622ed8ef85685764f6e7986
         contractAddress: Environment.getOrThrow(
           Environment.l1ToL2TransactionQueueContractAddress
         ),

--- a/packages/rollup-services/src/exec/services.ts
+++ b/packages/rollup-services/src/exec/services.ts
@@ -165,13 +165,14 @@ const createL1ChainDataPersister = async (): Promise<L1ChainDataPersister> => {
   log.info(
     `Creating L1 Chain Data Persister with earliest block ${Environment.l1EarliestBlock()}`
   )
+  console.log('Just checking that this worked')
   return L1ChainDataPersister.create(
     getProcessingDataService(),
     getDataService(),
     getL1Provider(),
     [
       {
-        topic: ethers.utils.id('L1ToL2TxEnqueued(bytes)'), // 0x2a9dd32a4056f7419a3a05b09f30cf775204afed73c0981470da34d97ca5e5cd
+        topic: ethers.utils.id('L1ToL2TxEnqueued(address,address,uint32,bytes)'), // 7f897cd072f041e68ba57be8f0eec7b8933b0b113622ed8ef85685764f6e7986
         contractAddress: Environment.getOrThrow(
           Environment.l1ToL2TransactionQueueContractAddress
         ),


### PR DESCRIPTION
## Description
Fix our L1ToL2Transaction ingestion logic so that it passes some integration tests which I will add to the integration tests repository shortly.

## Questions
- @willmeister does the change `rollupTransaction.l1TxLogIndex = l.logIndex` look right to you?

## Metadata
### Fixes
- Partially addresses https://github.com/ethereum-optimism/optimistic-rollup-integration-tests/issues/9

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
