### PR TITLE
Fixing Tx / State Batch Creation Inconsistencies

### DIFF
--- a/db/scripts/4_create_views.sql
+++ b/db/scripts/4_create_views.sql
@@ -56,7 +56,7 @@ ORDER BY l1.batch_index ASC
 CREATE OR REPLACE VIEW batchable_l2_only_tx_states
 AS
 
-SELECT tx.*, row_number() over (ORDER BY tx.block_number ASC) -1 AS row_number
+SELECT tx.*, row_number() over (ORDER BY tx.block_number ASC, tx.tx_index ASC) -1 AS row_number
 FROM l2_tx_output tx
   INNER JOIN canonical_chain_batch cc
     ON tx.canonical_chain_batch_number = cc.batch_number

--- a/db/scripts/4_create_views.sql
+++ b/db/scripts/4_create_views.sql
@@ -56,7 +56,7 @@ ORDER BY l1.batch_index ASC
 CREATE OR REPLACE VIEW batchable_l2_only_tx_states
 AS
 
-SELECT tx.*, row_number() over (ORDER BY tx.id ASC) -1 AS row_number
+SELECT tx.*, row_number() over (ORDER BY tx.block_number ASC) -1 AS row_number
 FROM l2_tx_output tx
   INNER JOIN canonical_chain_batch cc
     ON tx.canonical_chain_batch_number = cc.batch_number

--- a/packages/rollup-core/src/app/data/data-service.ts
+++ b/packages/rollup-core/src/app/data/data-service.ts
@@ -437,7 +437,7 @@ export class DefaultDataService implements DataService {
             canonical_chain_batch_index = t.batch_index
         FROM 
           (
-            SELECT id, row_number() over (ORDER BY block_number) -1 as batch_index
+            SELECT id, row_number() over (ORDER BY block_number ASC, tx_index ASC) -1 as batch_index
             FROM l2_tx_output
             WHERE
               canonical_chain_batch_number IS NULL
@@ -604,7 +604,7 @@ export class DefaultDataService implements DataService {
             state_commitment_chain_batch_number = ${batchNumber},
             state_commitment_chain_batch_index = t.row_number
         FROM (
-          SELECT id, row_number() over (ORDER BY id) -1 as row_number
+          SELECT id, row_number() over (ORDER BY block_number ASC, tx_index ASC) -1 as row_number
           FROM l2_tx_output
           WHERE state_commitment_chain_batch_number IS NULL
           ORDER BY block_number ASC, tx_index ASC

--- a/packages/rollup-core/src/types/data/l2-data-service.ts
+++ b/packages/rollup-core/src/types/data/l2-data-service.ts
@@ -31,15 +31,15 @@ export interface L2DataService {
   ): Promise<number>
 
   /**
-   * Gets the largest L2 Tx Output ID that should be included in the batch built with batchTimestamp.
+   * Gets the largest L2 Tx Output block number that should be included in the batch built with batchTimestamp.
    * This is mainly useful as a filter when there is an available batch that has enough rollup transactions'
    * bytes to exceed the maxBatchCalldataBytes value.
    *
    * @param batchTimestamp The block timestamp of the L2 Tx Outputs to be used for the Rollup Batch.
    * @param maxBatchCalldataBytes The max amount of rolled up tx bytes to include in the batch.
-   * @returns The ID of the last (biggest ID) L2 Tx Output to be included in the batch.
+   * @returns The L2 block number of the last (latest) L2 Tx Output to be included in the batch.
    */
-  getMaxL2TxOutputIdForCanonicalChainBatch(
+  getMaxL2TxOutputBlockNumberForCanonicalChainBatch(
     batchTimestamp: number,
     maxBatchCalldataBytes: number
   ): Promise<number>

--- a/packages/rollup-core/test/db/helpers.ts
+++ b/packages/rollup-core/test/db/helpers.ts
@@ -8,7 +8,7 @@ import {
   ZERO,
   ZERO_ADDRESS,
 } from '@eth-optimism/core-utils'
-import { PostgresDB, Row } from '@eth-optimism/core-db'
+import { PostgresDB, RDB, Row } from '@eth-optimism/core-db'
 import { BigNumber as BigNum } from 'ethers/utils'
 import { Block, TransactionResponse } from 'ethers/providers'
 
@@ -369,4 +369,16 @@ export const insertTxOutput = async (
       )
     }
   }
+}
+
+export const selectStateRootBatchRes = async (
+  rdb: RDB,
+  batchNum: number
+): Promise<Row[]> => {
+  return rdb.select(
+    `SELECT * 
+            FROM l2_tx_output 
+            WHERE state_commitment_chain_batch_number = ${batchNum}
+            ORDER BY state_commitment_chain_batch_index ASC`
+  )
 }

--- a/packages/rollup-core/test/db/verifier-data-service.dbspec.ts
+++ b/packages/rollup-core/test/db/verifier-data-service.dbspec.ts
@@ -1,31 +1,21 @@
 import '../setup'
 
 /* External Imports */
-import { PostgresDB, Row } from '@eth-optimism/core-db'
+import { PostgresDB } from '@eth-optimism/core-db'
 import { keccak256FromUtf8 } from '@eth-optimism/core-utils'
 
 /* Internal Imports */
 import { DefaultDataService } from '../../src/app/data'
 import {
   blockNumber,
-  createRollupTx,
   createTx,
   createTxOutput,
   defaultStateRoot,
   deleteAllData,
   insertTxOutput,
   l1Block,
-  verifyL1BlockRes,
-  verifyL2TxOutput,
 } from './helpers'
-import {
-  BatchSubmissionStatus,
-  QueueOrigin,
-  StateCommitmentBatchSubmission,
-  TransactionBatchSubmission,
-  VerificationStatus,
-} from '../../src/types/data'
-import { VerificationCandidate } from '../../src/types'
+import { BatchSubmissionStatus, VerificationStatus } from '../../src/types/data'
 
 describe('Verifier Data Data Service (will fail if postgres is not running with expected schema)', () => {
   let dataService: DefaultDataService
@@ -111,7 +101,7 @@ describe('Verifier Data Data Service (will fail if postgres is not running with 
       const tx2 = createTxOutput(
         keccak256FromUtf8('tx 2'),
         keccak256FromUtf8(defaultStateRoot),
-        blockNumber
+        blockNumber + 1
       )
       await insertTxOutput(dataService, tx2, BatchSubmissionStatus.FINALIZED)
 
@@ -156,7 +146,7 @@ describe('Verifier Data Data Service (will fail if postgres is not running with 
       const tx2 = createTxOutput(
         keccak256FromUtf8('tx 2'),
         keccak256FromUtf8(defaultStateRoot),
-        blockNumber
+        blockNumber + 1
       )
       await insertTxOutput(dataService, tx2, BatchSubmissionStatus.FINALIZED)
 
@@ -198,7 +188,7 @@ describe('Verifier Data Data Service (will fail if postgres is not running with 
       const tx2 = createTxOutput(
         keccak256FromUtf8('tx 2'),
         keccak256FromUtf8(defaultStateRoot),
-        blockNumber
+        blockNumber + 1
       )
       await insertTxOutput(dataService, tx2, BatchSubmissionStatus.FINALIZED)
 
@@ -240,7 +230,7 @@ describe('Verifier Data Data Service (will fail if postgres is not running with 
       const tx2 = createTxOutput(
         keccak256FromUtf8('tx 2'),
         keccak256FromUtf8(defaultStateRoot),
-        blockNumber
+        blockNumber + 1
       )
       await insertTxOutput(dataService, tx2, BatchSubmissionStatus.FINALIZED)
 
@@ -285,13 +275,13 @@ describe('Verifier Data Data Service (will fail if postgres is not running with 
       const tx2 = createTxOutput(
         keccak256FromUtf8('tx 2'),
         keccak256FromUtf8(defaultStateRoot),
-        blockNumber
+        blockNumber + 1
       )
       await insertTxOutput(dataService, tx2, BatchSubmissionStatus.FINALIZED)
       const tx3 = createTxOutput(
         keccak256FromUtf8('tx 3'),
         keccak256FromUtf8(defaultStateRoot),
-        blockNumber
+        blockNumber + 2
       )
       await insertTxOutput(dataService, tx3, BatchSubmissionStatus.FINALIZED)
 
@@ -307,14 +297,14 @@ describe('Verifier Data Data Service (will fail if postgres is not running with 
       const tx4 = createTxOutput(
         keccak256FromUtf8('tx 4'),
         stateRoot4,
-        blockNumber
+        blockNumber + 3
       )
       await insertTxOutput(dataService, tx4, BatchSubmissionStatus.FINALIZED)
 
       const tx5 = createTxOutput(
         keccak256FromUtf8('tx 5'),
         stateRoot5,
-        blockNumber
+        blockNumber + 4
       )
       await insertTxOutput(dataService, tx5, BatchSubmissionStatus.FINALIZED)
 


### PR DESCRIPTION
## Description
Fixes an issue where state batches and tx batches may be built in differing orders, leading to fraudulent batches being posted on-chain.

## Metadata
### Fixes
- Fixes #295

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
