### PR TITLE
rollup-core: little fixes

### DIFF
--- a/packages/core-db/src/app/queue/sequential-processing-data-service.ts
+++ b/packages/core-db/src/app/queue/sequential-processing-data-service.ts
@@ -59,9 +59,9 @@ export class DefaultSequentialProcessingDataService
     const res = await this.rdb.select(
       `SELECT MAX(sequence_number) as last_processed
       FROM sequential_processing
-      WHERE 
+      WHERE
         sequence_key = '${sequenceKey}'
-        AND processed = TRUE`
+        AND processed = 'TRUE'`
     )
 
     if (!doesColumnDataExist(res, 0, 'last_processed')) {
@@ -99,7 +99,7 @@ export class DefaultSequentialProcessingDataService
     }
 
     log.debug(
-      `[${sequenceKey}] Persisted item with index ${index}: ${itemData}`
+      `[${sequenceKey}] Persisted item with index ${index}, processed=${processed}: ${itemData}`
     )
   }
 
@@ -112,8 +112,8 @@ export class DefaultSequentialProcessingDataService
   ): Promise<void> {
     await this.rdb.execute(
       `UPDATE sequential_processing
-      SET processed = TRUE
-      WHERE 
+      SET processed = 'TRUE'
+      WHERE
         sequence_key = '${sequenceKey}'
         AND sequence_number = ${index}`
     )

--- a/packages/rollup-core/src/app/data/consumers/canonical-chain-batch-submitter.ts
+++ b/packages/rollup-core/src/app/data/consumers/canonical-chain-batch-submitter.ts
@@ -170,7 +170,7 @@ export class CanonicalChainBatchSubmitter extends ScheduledTask {
   // Returns the most recent block number with a L1 to L2 transaction
   protected async getBatchSubmissionBlockNumber(): Promise<number> {
     const results = await Promise.all([
-      this.dataService.getLatestL1ToL2BlockNumber(),
+      this.dataService.getMaxL1BlockNumber(),
       this.getMaxL1ToL2QueueBlockNumber(),
       this.getMaxSafetyQueueBlockNumber(),
     ])

--- a/packages/rollup-core/src/app/data/consumers/canonical-chain-batch-submitter.ts
+++ b/packages/rollup-core/src/app/data/consumers/canonical-chain-batch-submitter.ts
@@ -96,6 +96,7 @@ export class CanonicalChainBatchSubmitter extends ScheduledTask {
       let validated: boolean = false
       try {
         const batchBlockNumber = await this.getBatchSubmissionBlockNumber()
+        log.debug(`Submitting batch ${batchBlockNumber}: ${JSON.stringify(batchSubmission)}`)
 
         await this.validateBatchSubmission(batchSubmission, batchBlockNumber)
 
@@ -162,10 +163,23 @@ export class CanonicalChainBatchSubmitter extends ScheduledTask {
     )
   }
 
+  // Returns the most recent block number with a L1 to L2 transaction
   protected async getBatchSubmissionBlockNumber(): Promise<number> {
-    // TODO: This will eventually be part of the output metadata from L2 tx outputs
-    //  Need to update geth to have this functionality so this is a mock for now
-    return (await this.getL1BlockNumber()) - 10
+    const results = await Promise.all([
+      this.dataService.getLatestL1ToL2BlockNumber(),
+      this.getMaxL1ToL2QueueBlockNumber(),
+      this.getMaxSafetyQueueBlockNumber()
+    ])
+
+    let min = Number.MAX_SAFE_INTEGER
+    for (const result of results) {
+      // `undefined` values will always return false
+      if (result < min) {
+        min = result
+      }
+    }
+
+    return min
   }
 
   /**

--- a/packages/rollup-core/src/app/data/consumers/canonical-chain-batch-submitter.ts
+++ b/packages/rollup-core/src/app/data/consumers/canonical-chain-batch-submitter.ts
@@ -96,7 +96,11 @@ export class CanonicalChainBatchSubmitter extends ScheduledTask {
       let validated: boolean = false
       try {
         const batchBlockNumber = await this.getBatchSubmissionBlockNumber()
-        log.debug(`Submitting batch ${batchBlockNumber}: ${JSON.stringify(batchSubmission)}`)
+        log.debug(
+          `Submitting batch ${batchBlockNumber}: ${JSON.stringify(
+            batchSubmission
+          )}`
+        )
 
         await this.validateBatchSubmission(batchSubmission, batchBlockNumber)
 
@@ -168,7 +172,7 @@ export class CanonicalChainBatchSubmitter extends ScheduledTask {
     const results = await Promise.all([
       this.dataService.getLatestL1ToL2BlockNumber(),
       this.getMaxL1ToL2QueueBlockNumber(),
-      this.getMaxSafetyQueueBlockNumber()
+      this.getMaxSafetyQueueBlockNumber(),
     ])
 
     let min = Number.MAX_SAFE_INTEGER

--- a/packages/rollup-core/src/app/data/data-service.ts
+++ b/packages/rollup-core/src/app/data/data-service.ts
@@ -377,6 +377,18 @@ export class DefaultDataService implements DataService {
     return parseInt(res[0]['block_number'], 10)
   }
 
+  public async getMaxL1BlockNumber(): Promise<number> {
+    const res: Row[] = await this.rdb.select(
+      `SELECT MAX(block_number) AS block_number from l1_block`
+    )
+
+    if (!res || !res['block_number']) {
+      throw new Error('Last L1 block number not found')
+    }
+
+    return parseInt(res['block_number'], 10)
+  }
+
   /**
    * @inheritDoc
    */

--- a/packages/rollup-core/src/app/data/producers/l1-chain-data-persister.ts
+++ b/packages/rollup-core/src/app/data/producers/l1-chain-data-persister.ts
@@ -81,7 +81,7 @@ export class L1ChainDataPersister extends ChainDataProcessor {
    */
   protected async handleNextItem(index: number, block: Block): Promise<void> {
     log.debug(
-      `handling block ${block.number}. Searching for any relevant logs.`
+      `handling block ${block.number} with index ${index}. Searching for any relevant logs.`
     )
 
     let relevantLogs: Log[]

--- a/packages/rollup-core/src/types/data/l2-data-service.ts
+++ b/packages/rollup-core/src/types/data/l2-data-service.ts
@@ -100,6 +100,13 @@ export interface L2DataService {
   getLatestL1ToL2BlockNumber(): Promise<number>
 
   /**
+   * Get the max L1 block number
+   * @returns Maximum block number
+   */
+
+  getMaxL1BlockNumber(): Promise<number>
+
+  /**
    * Marks the Canonical Chain Tx batch with the provided batch number as in the process of being submitted to the L1 chain.
    *
    * @param batchNumber The batch number to mark as submitting.

--- a/packages/rollup-core/src/types/data/l2-data-service.ts
+++ b/packages/rollup-core/src/types/data/l2-data-service.ts
@@ -96,14 +96,12 @@ export interface L2DataService {
    * Gets the last block number with an L1 to L2 transaction
    * @returns The number
    */
-
   getLatestL1ToL2BlockNumber(): Promise<number>
 
   /**
    * Get the max L1 block number
    * @returns Maximum block number
    */
-
   getMaxL1BlockNumber(): Promise<number>
 
   /**

--- a/packages/rollup-core/src/types/data/l2-data-service.ts
+++ b/packages/rollup-core/src/types/data/l2-data-service.ts
@@ -93,6 +93,13 @@ export interface L2DataService {
   getNextCanonicalChainTransactionBatchToFinalize(): Promise<BatchSubmission>
 
   /**
+   * Gets the last block number with an L1 to L2 transaction
+   * @returns The number
+   */
+
+  getLatestL1ToL2BlockNumber(): Promise<number>
+
+  /**
    * Marks the Canonical Chain Tx batch with the provided batch number as in the process of being submitted to the L1 chain.
    *
    * @param batchNumber The batch number to mark as submitting.

--- a/yarn.lock
+++ b/yarn.lock
@@ -39,6 +39,22 @@
   resolved "https://registry.yarnpkg.com/@ensdomains/resolver/-/resolver-0.2.4.tgz#c10fe28bf5efbf49bff4666d909aed0265efbc89"
   integrity sha512-bvaTH34PMCbv6anRa9I/0zjLJgY4EuznbEMgbV77JBCQ9KNC46rzi0avuxpOfu+xDjPEtSFGqVEOr5GlUSGudA==
 
+"@eth-optimism/ovm-toolchain@0.0.1-alpha.5":
+  version "0.0.1-alpha.5"
+  resolved "https://registry.yarnpkg.com/@eth-optimism/ovm-toolchain/-/ovm-toolchain-0.0.1-alpha.5.tgz#abd961528e1d10eae523ce73547887d811df0aa2"
+  integrity sha512-2geNns/bo1f5Ic/iuT4JeAa+eIzUU8jhrfEOwcQ+W3UoA857rwbff5UqKNvMm3jXlI1YLIYQhXTbBZsezpBPEw==
+  dependencies:
+    "@eth-optimism/core-utils" "^0.0.1-alpha.30"
+    "@eth-optimism/rollup-contracts" "^0.0.1-alpha.32"
+    "@nomiclabs/buidler" "^1.4.4"
+    bn.js "^5.1.3"
+    child_process "^1.0.2"
+    ethereum-waffle-v2 "npm:ethereum-waffle@2"
+    ethereum-waffle-v3 "npm:ethereum-waffle@3"
+    ethereumjs-ovm "git+https://github.com/ethereum-optimism/ethereumjs-vm"
+    ethers-v4 "npm:ethers@4"
+    ethers-v5 "npm:ethers@5.0.7"
+
 "@eth-optimism/solc@^0.5.16-alpha.0":
   version "0.5.16-alpha.1"
   resolved "https://registry.yarnpkg.com/@eth-optimism/solc/-/solc-0.5.16-alpha.1.tgz#04019314df03faac8bc5363e8a1c2c561d404a04"
@@ -5372,6 +5388,32 @@ ethereumjs-common@^1.1.0, ethereumjs-common@^1.3.2, ethereumjs-common@^1.5.0:
 "ethereumjs-ovm@git+https://github.com/ethereum-optimism/ethereumjs-vm":
   version "4.2.0"
   resolved "git+https://github.com/ethereum-optimism/ethereumjs-vm#02ba6e77a88339b04a053b5e653f644acb1555b8"
+  dependencies:
+    "@types/debug" "^4.1.5"
+    "@types/uuid" "^8.3.0"
+    async "^2.1.2"
+    async-eventemitter "^0.2.2"
+    core-js-pure "^3.0.1"
+    debug "^4.1.1"
+    ethereumjs-account "^3.0.0"
+    ethereumjs-block "^2.2.2"
+    ethereumjs-blockchain "^4.0.3"
+    ethereumjs-common "^1.5.0"
+    ethereumjs-tx "^2.1.2"
+    ethereumjs-util "^6.2.0"
+    ethers "^5.0.0"
+    fake-merkle-patricia-tree "^1.0.1"
+    functional-red-black-tree "^1.0.1"
+    merkle-patricia-tree "^2.3.2"
+    rustbn.js "~0.2.0"
+    safe-buffer "^5.1.1"
+    util.promisify "^1.0.0"
+    uuid "^8.3.0"
+
+"ethereumjs-ovm@git+https://github.com/ethereum-optimism/ethereumjs-vm.git":
+  version "4.2.0"
+  uid "02ba6e77a88339b04a053b5e653f644acb1555b8"
+  resolved "git+https://github.com/ethereum-optimism/ethereumjs-vm.git#02ba6e77a88339b04a053b5e653f644acb1555b8"
   dependencies:
     "@types/debug" "^4.1.5"
     "@types/uuid" "^8.3.0"


### PR DESCRIPTION
## Description

Implements `getBatchSubmissionBlockNumber` to enable the batch submission to work with L1 to L2 message passing

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
