### PR TITLE
Fixing geth submission index to not be 0 for all records

### DIFF
--- a/packages/rollup-core/src/app/data/data-service.ts
+++ b/packages/rollup-core/src/app/data/data-service.ts
@@ -224,7 +224,9 @@ export class DefaultDataService implements DataService {
 
       await this.rdb.execute(
         `UPDATE l1_rollup_tx
-        SET geth_submission_queue_index = ${submissionQueueIndex}, index_within_submission = 0
+        SET 
+            geth_submission_queue_index = ${submissionQueueIndex}, 
+            index_within_submission = COALESCE(index_within_submission, 0)
         WHERE l1_tx_hash = '${txHash}' AND l1_tx_log_index = ${txLogIndex}`,
         txContext
       )

--- a/packages/rollup-core/test/db/helpers.ts
+++ b/packages/rollup-core/test/db/helpers.ts
@@ -141,13 +141,14 @@ export const createRollupTx = (
   queueOrigin: QueueOrigin,
   txIndex: number = 0,
   submissionIndex: number = 0,
+  calldata?: string,
   l1MessageSender?: string,
   logIndex: number = 0
 ): RollupTransaction => {
   return {
     indexWithinSubmission: submissionIndex,
     target: tx.to,
-    calldata: tx.data,
+    calldata: calldata || tx.data,
     sender: tx.from,
     l1MessageSender,
     gasLimit: gasLimit.toNumber(),


### PR DESCRIPTION
## Description
Makes it so all `l1_rollup_tx.index_within_submission` will not be 0, and for rollup batches with multiple transactions, the correct number will be assigned.

## Metadata
### Fixes
- Fixes #310

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
