### PR TITLE
Revert "be sure to commit gitmodules"

### DIFF
--- a/.github/workflows/push-to-integration-repo.yml
+++ b/.github/workflows/push-to-integration-repo.yml
@@ -33,6 +33,6 @@ jobs:
           cd $HOME/optimism-integration
           REPO=$(echo $GITHUB_REPOSITORY | cut -d '/' -f2)
           SHORT=$(echo $GITHUB_SHA | head -c 8)
-          git add $REPO .gitmodules
+          git add $REPO
           git commit -m "submodule bump: $REPO $SHORT"
           git push origin master


### PR DESCRIPTION
Reverts ethereum-optimism/optimism-monorepo#321

We don't actually need this, proper instructions can be found here: https://github.com/ethereum-optimism/optimism-integration/pull/11