### PR TITLE
Use `rollup_getInfo` endpoint for ctc address & more

### DIFF
--- a/packages/batch-submitter/src/batch-submitter.ts
+++ b/packages/batch-submitter/src/batch-submitter.ts
@@ -89,12 +89,18 @@ export class BatchSubmitter {
       startBlock,
       endBlock
     )
-    return this._submitAndLogTx(this.txChain.appendSequencerBatch(batchParams), 'Submitted batch!')
+    return this._submitAndLogTx(
+      this.txChain.appendSequencerBatch(batchParams),
+      'Submitted batch!'
+    )
   }
 
   private async _clearQueue(): Promise<TransactionReceipt> {
     // Empty the queue with a huge `appendQueueBatch(..)` call
-    return await this._submitAndLogTx(this.txChain.appendQueueBatch(99999999), 'Cleared queue!')
+    return this._submitAndLogTx(
+      this.txChain.appendQueueBatch(99999999),
+      'Cleared queue!'
+    )
   }
 
   private async _updateL2ChainInfo(): Promise<void> {
@@ -302,7 +308,10 @@ export class BatchSubmitter {
     return this.l2Provider.send('eth_chainId', [])
   }
 
-  private async _submitAndLogTx(txPromise: Promise<TransactionResponse>, successMessage: string): Promise<TransactionReceipt> {
+  private async _submitAndLogTx(
+    txPromise: Promise<TransactionResponse>,
+    successMessage: string
+  ): Promise<TransactionReceipt> {
     const response = await txPromise
     const receipt = await response.wait(this.numConfirmations)
     log.info(successMessage)

--- a/packages/batch-submitter/src/batch-submitter.ts
+++ b/packages/batch-submitter/src/batch-submitter.ts
@@ -315,7 +315,7 @@ export class BatchSubmitter {
     const response = await txPromise
     const receipt = await response.wait(this.numConfirmations)
     log.info(successMessage)
-    log.debug('Transaction Response:', response)
+    log.debug('Transaction response:', response)
     log.debug('Transaction receipt:', receipt)
     return receipt
   }

--- a/packages/batch-submitter/src/exec/run-batch-submitter.ts
+++ b/packages/batch-submitter/src/exec/run-batch-submitter.ts
@@ -1,10 +1,6 @@
 /* External Imports */
 import { getLogger } from '@eth-optimism/core-utils'
 import { exit } from 'process'
-import {
-  getContractInterface,
-  getContractFactory,
-} from '@eth-optimism/contracts'
 import { Signer, Wallet } from 'ethers'
 import { Provider, JsonRpcProvider } from '@ethersproject/providers'
 import { OptimismProvider } from '@eth-optimism/provider'
@@ -16,39 +12,24 @@ import { BatchSubmitter, CanonicalTransactionChainContract } from '..'
 const log = getLogger('oe:batch-submitter:init')
 
 interface RequiredEnvVars {
-  ADDRESS_MANAGER_ADDRESS: 'ADDRESS_MANAGER_ADDRESS'
   SEQUENCER_PRIVATE_KEY: 'SEQUENCER_PRIVATE_KEY'
   INFURA_NETWORK: 'INFURA_NETWORK'
   INFURA_PROJECT_ID: 'INFURA_PROJECT_ID'
   L2_WEB3_URL: 'L2_WEB3_URL'
-  L2_CHAIN_ID: 'L2_CHAIN_ID'
   MAX_TX_SIZE: 'MAX_TX_SIZE'
   POLL_INTERVAL: 'POLL_INTERVAL'
   DEFAULT_BATCH_SIZE: 'DEFAULT_BATCH_SIZE'
   NUM_CONFIRMATIONS: 'NUM_CONFIRMATIONS'
 }
 const requiredEnvVars: RequiredEnvVars = {
-  ADDRESS_MANAGER_ADDRESS: 'ADDRESS_MANAGER_ADDRESS',
   SEQUENCER_PRIVATE_KEY: 'SEQUENCER_PRIVATE_KEY',
   INFURA_NETWORK: 'INFURA_NETWORK',
   INFURA_PROJECT_ID: 'INFURA_PROJECT_ID',
   L2_WEB3_URL: 'L2_WEB3_URL',
-  L2_CHAIN_ID: 'L2_CHAIN_ID',
   MAX_TX_SIZE: 'MAX_TX_SIZE',
   POLL_INTERVAL: 'POLL_INTERVAL',
   DEFAULT_BATCH_SIZE: 'DEFAULT_BATCH_SIZE',
   NUM_CONFIRMATIONS: 'NUM_CONFIRMATIONS',
-}
-
-const getAddressFromResolver = async (
-  addressResolverAddress: string,
-  contractToResolve: string,
-  signer: Signer
-): Promise<string> => {
-  const Lib_AddressResolver = (
-    await getContractFactory('Lib_AddressResolver', signer)
-  ).attach(addressResolverAddress)
-  return Lib_AddressResolver.resolve('OVM_CanonicalTransactionChain')
 }
 
 export const run = async () => {
@@ -73,26 +54,9 @@ export const run = async () => {
     l1Provider
   )
 
-  const ctcAddress = await getAddressFromResolver(
-    requiredEnvVars.ADDRESS_MANAGER_ADDRESS,
-    'OVM_CanonicalTransactionChain',
-    sequencerSigner
-  )
-  const unwrapped_OVM_CanonicalTransactionChain = (
-    await getContractFactory('OVM_CanonicalTransactionChain', sequencerSigner)
-  ).attach(ctcAddress)
-
-  const OVM_CanonicalTransactionChain = new CanonicalTransactionChainContract(
-    unwrapped_OVM_CanonicalTransactionChain.address,
-    getContractInterface('OVM_CanonicalTransactionChain'),
-    sequencerSigner
-  )
-
   const batchSubmitter = new BatchSubmitter(
-    OVM_CanonicalTransactionChain,
     sequencerSigner,
     l2Provider,
-    parseInt(requiredEnvVars.L2_CHAIN_ID, 10),
     parseInt(requiredEnvVars.MAX_TX_SIZE, 10),
     parseInt(requiredEnvVars.DEFAULT_BATCH_SIZE, 10),
     parseInt(requiredEnvVars.NUM_CONFIRMATIONS, 10)

--- a/packages/batch-submitter/src/exec/run-batch-submitter.ts
+++ b/packages/batch-submitter/src/exec/run-batch-submitter.ts
@@ -13,9 +13,8 @@ const log = getLogger('oe:batch-submitter:init')
 
 interface RequiredEnvVars {
   SEQUENCER_PRIVATE_KEY: 'SEQUENCER_PRIVATE_KEY'
-  INFURA_NETWORK: 'INFURA_NETWORK'
-  INFURA_PROJECT_ID: 'INFURA_PROJECT_ID'
-  L2_WEB3_URL: 'L2_WEB3_URL'
+  L1_NODE_WEB3_URL: 'L1_NODE_WEB3_URL'
+  L2_NODE_WEB3_URL: 'L2_NODE_WEB3_URL'
   MAX_TX_SIZE: 'MAX_TX_SIZE'
   POLL_INTERVAL: 'POLL_INTERVAL'
   DEFAULT_BATCH_SIZE: 'DEFAULT_BATCH_SIZE'
@@ -23,9 +22,8 @@ interface RequiredEnvVars {
 }
 const requiredEnvVars: RequiredEnvVars = {
   SEQUENCER_PRIVATE_KEY: 'SEQUENCER_PRIVATE_KEY',
-  INFURA_NETWORK: 'INFURA_NETWORK',
-  INFURA_PROJECT_ID: 'INFURA_PROJECT_ID',
-  L2_WEB3_URL: 'L2_WEB3_URL',
+  L1_NODE_WEB3_URL: 'L1_NODE_WEB3_URL',
+  L2_NODE_WEB3_URL: 'L2_NODE_WEB3_URL',
   MAX_TX_SIZE: 'MAX_TX_SIZE',
   POLL_INTERVAL: 'POLL_INTERVAL',
   DEFAULT_BATCH_SIZE: 'DEFAULT_BATCH_SIZE',
@@ -44,10 +42,10 @@ export const run = async () => {
   }
 
   const l1Provider: Provider = new JsonRpcProvider(
-    `https://${requiredEnvVars.INFURA_NETWORK}.infura.io/v3/${requiredEnvVars.INFURA_PROJECT_ID}`
+    requiredEnvVars.L1_NODE_WEB3_URL
   )
   const l2Provider: OptimismProvider = new OptimismProvider(
-    requiredEnvVars.L2_WEB3_URL
+    requiredEnvVars.L2_NODE_WEB3_URL
   )
   const sequencerSigner: Signer = new Wallet(
     requiredEnvVars.SEQUENCER_PRIVATE_KEY,

--- a/packages/batch-submitter/test/batch-submitter/batch-submitter.spec.ts
+++ b/packages/batch-submitter/test/batch-submitter/batch-submitter.spec.ts
@@ -116,7 +116,7 @@ describe('BatchSubmitter', () => {
       getContractInterface('OVM_CanonicalTransactionChain'),
       sequencer
     )
-    l2Provider = new MockchainProvider()
+    l2Provider = new MockchainProvider(OVM_CanonicalTransactionChain.address)
   })
 
   describe('Submit', () => {
@@ -125,6 +125,7 @@ describe('BatchSubmitter', () => {
       timestamp: number
     }> = []
 
+    let batchSubmitter
     beforeEach(async () => {
       for (let i = 1; i < 15; i++) {
         await OVM_CanonicalTransactionChain.enqueue(
@@ -136,18 +137,16 @@ describe('BatchSubmitter', () => {
           }
         )
       }
-    })
-
-    it('should submit a sequencer batch correctly', async () => {
-      const batchSubmitter = new BatchSubmitter(
-        OVM_CanonicalTransactionChain,
+      batchSubmitter = new BatchSubmitter(
         sequencer,
         l2Provider as any,
-        l2Provider.chainId(),
         MAX_TX_SIZE,
         10,
         1
       )
+    })
+
+    it('should submit a sequencer batch correctly', async () => {
       l2Provider.setNumBlocksToReturn(5)
       const nextQueueElement = await getQueueElement(
         OVM_CanonicalTransactionChain
@@ -181,15 +180,6 @@ describe('BatchSubmitter', () => {
     })
 
     it('should submit a queue batch correctly', async () => {
-      const batchSubmitter = new BatchSubmitter(
-        OVM_CanonicalTransactionChain,
-        sequencer,
-        l2Provider as any,
-        l2Provider.chainId(),
-        MAX_TX_SIZE,
-        10,
-        1
-      )
       l2Provider.setNumBlocksToReturn(5)
       l2Provider.setL2BlockData({
         meta: {
@@ -209,15 +199,6 @@ describe('BatchSubmitter', () => {
     })
 
     it('should submit a batch with both queue and sequencer chain elements', async () => {
-      const batchSubmitter = new BatchSubmitter(
-        OVM_CanonicalTransactionChain,
-        sequencer,
-        l2Provider as any,
-        l2Provider.chainId(),
-        MAX_TX_SIZE,
-        10,
-        1
-      )
       l2Provider.setNumBlocksToReturn(10) // For this batch we'll return 10 elements!
       l2Provider.setL2BlockData({
         meta: {


### PR DESCRIPTION
## Description
Takes the CTC address out of the BS config & instead pulls it from the L2Geth node.

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
