### PR TITLE
Fix the state batch submitter state & end

### DIFF
--- a/packages/batch-submitter/src/batch-submitter/tx-batch-submitter.ts
+++ b/packages/batch-submitter/src/batch-submitter/tx-batch-submitter.ts
@@ -24,7 +24,7 @@ import {
   EthSignTxData,
 } from '../coders'
 import { L2Block, BatchElement, Batch, QueueOrigin } from '..'
-import { RollupInfo, BatchSubmitter } from '.'
+import { RollupInfo, Range, BatchSubmitter } from '.'
 
 export class TransactionBatchSubmitter extends BatchSubmitter {
   protected chainContract: CanonicalTransactionChainContract
@@ -77,6 +77,28 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
       this.chainContract.appendQueueBatch(99999999),
       'Cleared queue!'
     )
+  }
+
+  public async _getBatchStartAndEnd(): Promise<Range> {
+    const startBlock =
+      parseInt(await this.chainContract.getTotalElements(), 16) + 1 // +1 to skip L2 genesis block
+    const endBlock = Math.min(
+      startBlock + this.maxBatchSize,
+      await this.l2Provider.getBlockNumber()
+    )
+    if (startBlock >= endBlock) {
+      if (startBlock > endBlock) {
+        this.log
+          .error(`More chain elements in L1 (${startBlock}) than in the L2 node (${endBlock}).
+                   This shouldn't happen because we don't submit batches if the sequencer is syncing.`)
+      }
+      this.log.info(`No txs to submit. Skipping batch submission...`)
+      return
+    }
+    return {
+      start: startBlock,
+      end: endBlock,
+    }
   }
 
   public async _submitBatch(

--- a/packages/batch-submitter/src/batch-submitter/tx-batch-submitter.ts
+++ b/packages/batch-submitter/src/batch-submitter/tx-batch-submitter.ts
@@ -69,14 +69,18 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
   }
 
   public async _onSync(): Promise<TransactionReceipt> {
-    this.log.info(
-      'Syncing mode enabled! Skipping batch submission and clearing queue...'
-    )
-    // Empty the queue with a huge `appendQueueBatch(..)` call
-    return this._submitAndLogTx(
-      this.chainContract.appendQueueBatch(99999999),
-      'Cleared queue!'
-    )
+    if (this.chainContract.getNumPendingQueueElements() !== 0) {
+      this.log.info(
+        'Syncing mode enabled! Skipping batch submission and clearing queue...'
+      )
+      // Empty the queue with a huge `appendQueueBatch(..)` call
+      return this._submitAndLogTx(
+        this.chainContract.appendQueueBatch(99999999),
+        'Cleared queue!'
+      )
+    }
+    this.log.info('Syncing mode enabled but queue is empty. Skipping...')
+    return
   }
 
   public async _getBatchStartAndEnd(): Promise<Range> {

--- a/packages/batch-submitter/src/exec/run-batch-submitter.ts
+++ b/packages/batch-submitter/src/exec/run-batch-submitter.ts
@@ -29,6 +29,7 @@ interface RequiredEnvVars {
   MAX_BATCH_SIZE: 'MAX_BATCH_SIZE'
   POLL_INTERVAL: 'POLL_INTERVAL'
   NUM_CONFIRMATIONS: 'NUM_CONFIRMATIONS'
+  FINALITY_CONFIRMATIONS: 'FINALITY_CONFIRMATIONS'
   RUN_TX_BATCH_SUBMITTER: 'true' | 'false' | 'RUN_TX_BATCH_SUBMITTER'
   RUN_STATE_BATCH_SUBMITTER: 'true' | 'false' | 'RUN_STATE_BATCH_SUBMITTER'
 }
@@ -41,6 +42,7 @@ const requiredEnvVars: RequiredEnvVars = {
   MAX_BATCH_SIZE: 'MAX_BATCH_SIZE',
   POLL_INTERVAL: 'POLL_INTERVAL',
   NUM_CONFIRMATIONS: 'NUM_CONFIRMATIONS',
+  FINALITY_CONFIRMATIONS: 'FINALITY_CONFIRMATIONS',
   RUN_TX_BATCH_SUBMITTER: 'RUN_TX_BATCH_SUBMITTER',
   RUN_STATE_BATCH_SUBMITTER: 'RUN_STATE_BATCH_SUBMITTER',
 }
@@ -74,6 +76,7 @@ export const run = async () => {
     parseInt(requiredEnvVars.MAX_TX_SIZE, 10),
     parseInt(requiredEnvVars.MAX_BATCH_SIZE, 10),
     parseInt(requiredEnvVars.NUM_CONFIRMATIONS, 10),
+    parseInt(requiredEnvVars.NUM_CONFIRMATIONS, 10),
     getLogger(TX_BATCH_SUBMITTER_LOG_TAG)
   )
 
@@ -84,6 +87,7 @@ export const run = async () => {
     parseInt(requiredEnvVars.MAX_TX_SIZE, 10),
     parseInt(requiredEnvVars.MAX_BATCH_SIZE, 10),
     parseInt(requiredEnvVars.NUM_CONFIRMATIONS, 10),
+    parseInt(requiredEnvVars.FINALITY_CONFIRMATIONS, 10),
     getLogger(STATE_BATCH_SUBMITTER_LOG_TAG)
   )
 

--- a/packages/batch-submitter/test/batch-submitter/transaction-batch-submitter.spec.ts
+++ b/packages/batch-submitter/test/batch-submitter/transaction-batch-submitter.spec.ts
@@ -149,6 +149,7 @@ describe('TransactionBatchSubmitter', () => {
         MAX_TX_SIZE,
         10,
         1,
+        1,
         getLogger(TX_BATCH_SUBMITTER_LOG_TAG)
       )
     })


### PR DESCRIPTION
## Description
Before there was an issue where the state commitment chain was calculating the state & end based on the L2 chain's start & end. Instead we want to calculate the state and end based on what is finalized in the CTC.

## Questions
None


## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
