### PR TITLE
gitflows: build less in ci now that images are public

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -32,10 +32,6 @@ jobs:
           GIT_COMMIT=$(git rev-parse HEAD | head -c 8)
           echo "optimism-integration $GIT_COMMIT"
           ./docker/build.sh -s batch-submitter -b $GITHUB_HEAD_REF
-          ./docker/build.sh -s hardhat
-          ./docker/build.sh -s deployer
-          ./docker/build.sh -s integration-tests
-          ./docker/build.sh -s go-ethereum
 
       - name: Test
         run: |


### PR DESCRIPTION
## Description

Build less in CI now that all images are public

## Metadata
### Fixes
- Fixes # [Link to Issue]

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
