### PR TITLE
Temp fix lastL1BlockNum & small off by 1

### DIFF
--- a/packages/batch-submitter/src/batch-submitter/tx-batch-submitter.ts
+++ b/packages/batch-submitter/src/batch-submitter/tx-batch-submitter.ts
@@ -107,10 +107,11 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
         // Set the block number to the current l1BlockNumber
         this.lastL1BlockNumber = curBlockNum
       } else {
-        this.lastL1BlockNumber =
-          curBlockNum - this.lastL1BlockNumber > 30
-            ? curBlockNum - 10
-            : this.lastL1BlockNumber
+        if (curBlockNum - this.lastL1BlockNumber > 30) {
+          // If the lastL1BlockNumber is too old, then set it to a recent
+          // block number. (10 blocks ago to prevent reorgs)
+          this.lastL1BlockNumber = curBlockNum - 10
+        }
       }
     }
   }

--- a/packages/batch-submitter/src/batch-submitter/tx-batch-submitter.ts
+++ b/packages/batch-submitter/src/batch-submitter/tx-batch-submitter.ts
@@ -97,7 +97,7 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
     const endBlock = Math.min(
       startBlock + this.maxBatchSize,
       await this.l2Provider.getBlockNumber()
-    )
+    ) + 1 // +1 because the `endBlock` is *exclusive*
     if (startBlock >= endBlock) {
       if (startBlock > endBlock) {
         this.log

--- a/packages/batch-submitter/src/batch-submitter/tx-batch-submitter.ts
+++ b/packages/batch-submitter/src/batch-submitter/tx-batch-submitter.ts
@@ -37,6 +37,7 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
   protected chainContract: CanonicalTransactionChainContract
   protected l2ChainId: number
   protected syncing: boolean
+  protected lastL1BlockNumber: number
 
   /*****************************
    * Batch Submitter Overrides *
@@ -77,6 +78,8 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
 
   public async _onSync(): Promise<TransactionReceipt> {
     const pendingQueueElements = await this.chainContract.getNumPendingQueueElements()
+    this._updateLastL1BlockNumber(pendingQueueElements)
+
     if (pendingQueueElements !== 0) {
       this.log.info(
         `Syncing mode enabled! Skipping batch submission and clearing ${pendingQueueElements} queue elements`
@@ -91,13 +94,35 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
     return
   }
 
+  // TODO: Remove this function and use geth for lastL1BlockNumber!
+  private async _updateLastL1BlockNumber(pendingQueueElements: number) {
+    if (pendingQueueElements !== 0) {
+      const nextQueueIndex = await this.chainContract.getNextQueueIndex()
+      this.lastL1BlockNumber = await this.chainContract.getQueueElement(
+        nextQueueIndex
+      ).blockNumber
+    } else {
+      const curBlockNum = await this.chainContract.provider.getBlockNumber()
+      if (!this.lastL1BlockNumber) {
+        // Set the block number to the current l1BlockNumber
+        this.lastL1BlockNumber = curBlockNum
+      } else {
+        this.lastL1BlockNumber =
+          curBlockNum - this.lastL1BlockNumber > 30
+            ? curBlockNum - 10
+            : this.lastL1BlockNumber
+      }
+    }
+  }
+
   public async _getBatchStartAndEnd(): Promise<Range> {
     const startBlock =
       parseInt(await this.chainContract.getTotalElements(), 16) + 1 // +1 to skip L2 genesis block
-    const endBlock = Math.min(
-      startBlock + this.maxBatchSize,
-      await this.l2Provider.getBlockNumber()
-    ) + 1 // +1 because the `endBlock` is *exclusive*
+    const endBlock =
+      Math.min(
+        startBlock + this.maxBatchSize,
+        await this.l2Provider.getBlockNumber()
+      ) + 1 // +1 because the `endBlock` is *exclusive*
     if (startBlock >= endBlock) {
       if (startBlock > endBlock) {
         this.log
@@ -261,12 +286,8 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
     block.transactions[0].queueOrigin =
       queueOriginPlainText[block.transactions[0].queueOrigin]
     // For now just set the l1BlockNumber based on the current l1 block number
-    const _getMockedL1BlockNumber = async (): Promise<number> => {
-      const curBlockNum = await this.chainContract.signer.provider.getBlockNumber()
-      return curBlockNum - 1
-    }
     if (!block.transactions[0].l1BlockNumber) {
-      block.transactions[0].l1BlockNumber = await _getMockedL1BlockNumber()
+      block.transactions[0].l1BlockNumber = this.lastL1BlockNumber
     }
     return block
   }

--- a/packages/batch-submitter/test/batch-submitter/transaction-batch-submitter.spec.ts
+++ b/packages/batch-submitter/test/batch-submitter/transaction-batch-submitter.spec.ts
@@ -177,12 +177,12 @@ describe('TransactionBatchSubmitter', () => {
       let logData = remove0x(receipt.logs[0].data)
       expect(parseInt(logData.slice(64 * 0, 64 * 1), 16)).to.equal(0) // _startingQueueIndex
       expect(parseInt(logData.slice(64 * 1, 64 * 2), 16)).to.equal(0) // _numQueueElements
-      expect(parseInt(logData.slice(64 * 2, 64 * 3), 16)).to.equal(5) // _totalElements
+      expect(parseInt(logData.slice(64 * 2, 64 * 3), 16)).to.equal(6) // _totalElements
       receipt = await batchSubmitter.submitNextBatch()
       logData = remove0x(receipt.logs[0].data)
       expect(parseInt(logData.slice(64 * 0, 64 * 1), 16)).to.equal(0) // _startingQueueIndex
       expect(parseInt(logData.slice(64 * 1, 64 * 2), 16)).to.equal(0) // _numQueueElements
-      expect(parseInt(logData.slice(64 * 2, 64 * 3), 16)).to.equal(10) // _totalElements
+      expect(parseInt(logData.slice(64 * 2, 64 * 3), 16)).to.equal(11) // _totalElements
     })
 
     it('should submit a queue batch correctly', async () => {
@@ -193,13 +193,13 @@ describe('TransactionBatchSubmitter', () => {
       let receipt = await batchSubmitter.submitNextBatch()
       let logData = remove0x(receipt.logs[0].data)
       expect(parseInt(logData.slice(64 * 0, 64 * 1), 16)).to.equal(0) // _startingQueueIndex
-      expect(parseInt(logData.slice(64 * 1, 64 * 2), 16)).to.equal(5) // _numQueueElements
-      expect(parseInt(logData.slice(64 * 2, 64 * 3), 16)).to.equal(5) // _totalElements
+      expect(parseInt(logData.slice(64 * 1, 64 * 2), 16)).to.equal(6) // _numQueueElements
+      expect(parseInt(logData.slice(64 * 2, 64 * 3), 16)).to.equal(6) // _totalElements
       receipt = await batchSubmitter.submitNextBatch()
       logData = remove0x(receipt.logs[0].data)
-      expect(parseInt(logData.slice(64 * 0, 64 * 1), 16)).to.equal(5) // _startingQueueIndex
+      expect(parseInt(logData.slice(64 * 0, 64 * 1), 16)).to.equal(6) // _startingQueueIndex
       expect(parseInt(logData.slice(64 * 1, 64 * 2), 16)).to.equal(5) // _numQueueElements
-      expect(parseInt(logData.slice(64 * 2, 64 * 3), 16)).to.equal(10) // _totalElements
+      expect(parseInt(logData.slice(64 * 2, 64 * 3), 16)).to.equal(11) // _totalElements
     })
 
     it('should submit a batch with both queue and sequencer chain elements', async () => {
@@ -231,8 +231,8 @@ describe('TransactionBatchSubmitter', () => {
       const receipt = await batchSubmitter.submitNextBatch()
       const logData = remove0x(receipt.logs[0].data)
       expect(parseInt(logData.slice(64 * 0, 64 * 1), 16)).to.equal(0) // _startingQueueIndex
-      expect(parseInt(logData.slice(64 * 1, 64 * 2), 16)).to.equal(7) // _numQueueElements
-      expect(parseInt(logData.slice(64 * 2, 64 * 3), 16)).to.equal(10) // _totalElements
+      expect(parseInt(logData.slice(64 * 1, 64 * 2), 16)).to.equal(8) // _numQueueElements
+      expect(parseInt(logData.slice(64 * 2, 64 * 3), 16)).to.equal(11) // _totalElements
     })
   })
 })


### PR DESCRIPTION
## Description
Submits blocks with `lastL1BlockNum` and fixes  an off by 1 error was simply that we weren't pulling the *last* block
because I forgot to add +1 to the `end` value because it's exclusive. I
was treating it as inclusive.


## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
