### PR TITLE
Fix batch submitter

### DIFF
--- a/packages/batch-submitter/src/batch-submitter/index.ts
+++ b/packages/batch-submitter/src/batch-submitter/index.ts
@@ -4,3 +4,7 @@ export * from './state-batch-submitter'
 
 export const TX_BATCH_SUBMITTER_LOG_TAG = 'oe:batch-submitter:tx-chain'
 export const STATE_BATCH_SUBMITTER_LOG_TAG = 'oe:batch-submitter:state-chain'
+
+// BLOCK_OFFSET is the number of L2 blocks we need to skip for the
+// batch submitter.
+export const BLOCK_OFFSET = 1 // TODO: Update testnet / mainnet to make this zero.

--- a/packages/batch-submitter/src/batch-submitter/state-batch-submitter.ts
+++ b/packages/batch-submitter/src/batch-submitter/state-batch-submitter.ts
@@ -5,7 +5,7 @@ import { Contract } from 'ethers'
 
 /* Internal Imports */
 import { L2Block, Bytes32 } from '..'
-import { RollupInfo, Range, BatchSubmitter } from '.'
+import { RollupInfo, Range, BatchSubmitter, BLOCK_OFFSET } from '.'
 
 export class StateBatchSubmitter extends BatchSubmitter {
   // TODO: Change this so that we calculate start = scc.totalElements() and end = ctc.totalElements()!
@@ -61,7 +61,7 @@ export class StateBatchSubmitter extends BatchSubmitter {
 
   public async _getBatchStartAndEnd(): Promise<Range> {
     const startBlock: number =
-      (await this.chainContract.getTotalElements()).toNumber() + 1 // TODO: Remove `+1` by removing Geth's genesis block
+      (await this.chainContract.getTotalElements()).toNumber() + BLOCK_OFFSET // TODO: Remove BLOCK_OFFSET by removing Geth's genesis block
     // We will submit state roots for txs which have been in the tx chain for a while.
     const callBlockNumber: number =
       (await this.signer.provider.getBlockNumber()) - this.finalityConfirmations
@@ -102,7 +102,7 @@ export class StateBatchSubmitter extends BatchSubmitter {
       this.log.info('State batch too small. Skipping batch submission...')
       return
     }
-    const offsetStartsAtIndex = startBlock - 1 // TODO: Remove `-1` by removing Geth's genesis block
+    const offsetStartsAtIndex = startBlock - BLOCK_OFFSET // TODO: Remove BLOCK_OFFSET by removing Geth's genesis block
     return this._submitAndLogTx(
       this.chainContract.appendStateBatch(batch, offsetStartsAtIndex),
       'Submitted state root batch!'

--- a/packages/batch-submitter/src/batch-submitter/state-batch-submitter.ts
+++ b/packages/batch-submitter/src/batch-submitter/state-batch-submitter.ts
@@ -61,7 +61,7 @@ export class StateBatchSubmitter extends BatchSubmitter {
 
   public async _getBatchStartAndEnd(): Promise<Range> {
     const startBlock: number =
-      (await this.chainContract.getTotalElements()).toNumber() + BLOCK_OFFSET // TODO: Remove BLOCK_OFFSET by removing Geth's genesis block
+      (await this.chainContract.getTotalElements()).toNumber() + BLOCK_OFFSET // TODO: Remove BLOCK_OFFSET by adding a tx to Geth's genesis
     // We will submit state roots for txs which have been in the tx chain for a while.
     const callBlockNumber: number =
       (await this.signer.provider.getBlockNumber()) - this.finalityConfirmations
@@ -102,7 +102,7 @@ export class StateBatchSubmitter extends BatchSubmitter {
       this.log.info('State batch too small. Skipping batch submission...')
       return
     }
-    const offsetStartsAtIndex = startBlock - BLOCK_OFFSET // TODO: Remove BLOCK_OFFSET by removing Geth's genesis block
+    const offsetStartsAtIndex = startBlock - BLOCK_OFFSET // TODO: Remove BLOCK_OFFSET by adding a tx to Geth's genesis
     return this._submitAndLogTx(
       this.chainContract.appendStateBatch(batch, offsetStartsAtIndex),
       'Submitted state root batch!'

--- a/packages/batch-submitter/src/batch-submitter/state-batch-submitter.ts
+++ b/packages/batch-submitter/src/batch-submitter/state-batch-submitter.ts
@@ -60,11 +60,14 @@ export class StateBatchSubmitter extends BatchSubmitter {
   }
 
   public async _getBatchStartAndEnd(): Promise<Range> {
-    const startBlock: number = (await this.chainContract.getTotalElements()).toNumber() + 1  // TODO: Remove `+1` by removing Geth's genesis block
+    const startBlock: number =
+      (await this.chainContract.getTotalElements()).toNumber() + 1 // TODO: Remove `+1` by removing Geth's genesis block
     // We will submit state roots for txs which have been in the tx chain for a while.
     const callBlockNumber: number =
       (await this.signer.provider.getBlockNumber()) - this.finalityConfirmations
-    const totalElements: number = (await this.ctcContract.getTotalElements()).toNumber()
+    const totalElements: number = (
+      await this.ctcContract.getTotalElements()
+    ).toNumber()
     const endBlock: number = Math.min(
       startBlock + this.maxBatchSize,
       totalElements
@@ -99,7 +102,7 @@ export class StateBatchSubmitter extends BatchSubmitter {
       this.log.info('State batch too small. Skipping batch submission...')
       return
     }
-    const offsetStartsAtIndex = startBlock - 1  // TODO: Remove `-1` by removing Geth's genesis block
+    const offsetStartsAtIndex = startBlock - 1 // TODO: Remove `-1` by removing Geth's genesis block
     return this._submitAndLogTx(
       this.chainContract.appendStateBatch(batch, offsetStartsAtIndex),
       'Submitted state root batch!'

--- a/packages/batch-submitter/src/batch-submitter/state-batch-submitter.ts
+++ b/packages/batch-submitter/src/batch-submitter/state-batch-submitter.ts
@@ -60,27 +60,11 @@ export class StateBatchSubmitter extends BatchSubmitter {
   }
 
   public async _getBatchStartAndEnd(): Promise<Range> {
-    const startBlock: number = parseInt(
-      await this.chainContract.getTotalElements(),
-      16
-    )
+    const startBlock: number = (await this.chainContract.getTotalElements()).toNumber() + 1  // TODO: Remove `+1` by removing Geth's genesis block
     // We will submit state roots for txs which have been in the tx chain for a while.
     const callBlockNumber: number =
       (await this.signer.provider.getBlockNumber()) - this.finalityConfirmations
-    const getTotalElementsTx: string = this.ctcContract.interface.encodeFunctionData(
-      'getTotalElements',
-      []
-    )
-    const totalElements: number = parseInt(
-      await this.signer.provider.call(
-        {
-          to: this.ctcContract.address,
-          data: getTotalElementsTx,
-        },
-        callBlockNumber
-      ),
-      16
-    )
+    const totalElements: number = (await this.ctcContract.getTotalElements()).toNumber()
     const endBlock: number = Math.min(
       startBlock + this.maxBatchSize,
       totalElements
@@ -115,8 +99,9 @@ export class StateBatchSubmitter extends BatchSubmitter {
       this.log.info('State batch too small. Skipping batch submission...')
       return
     }
+    const offsetStartsAtIndex = startBlock - 1  // TODO: Remove `-1` by removing Geth's genesis block
     return this._submitAndLogTx(
-      this.chainContract.appendStateBatch(batch, startBlock),
+      this.chainContract.appendStateBatch(batch, offsetStartsAtIndex),
       'Submitted state root batch!'
     )
   }

--- a/packages/batch-submitter/src/batch-submitter/tx-batch-submitter.ts
+++ b/packages/batch-submitter/src/batch-submitter/tx-batch-submitter.ts
@@ -31,7 +31,7 @@ import {
   QueueOrigin,
   queueOriginPlainText,
 } from '..'
-import { RollupInfo, Range, BatchSubmitter } from '.'
+import { RollupInfo, Range, BatchSubmitter, BLOCK_OFFSET } from '.'
 
 export class TransactionBatchSubmitter extends BatchSubmitter {
   protected chainContract: CanonicalTransactionChainContract
@@ -120,7 +120,7 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
 
   public async _getBatchStartAndEnd(): Promise<Range> {
     const startBlock =
-      (await this.chainContract.getTotalElements()).toNumber() + 1 // TODO: Remove `+1` by removing Geth's genesis block
+      (await this.chainContract.getTotalElements()).toNumber() + BLOCK_OFFSET // TODO: Remove BLOCK_OFFSET by removing Geth's genesis block
     const endBlock =
       Math.min(
         startBlock + this.maxBatchSize,
@@ -252,7 +252,7 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
     }
 
     return {
-      shouldStartAtBatch: shouldStartAtIndex - 1, // TODO: Remove `-1` by removing Geth's genesis block
+      shouldStartAtBatch: shouldStartAtIndex - BLOCK_OFFSET, // TODO: Remove BLOCK_OFFSET by removing Geth's genesis block
       totalElementsToAppend,
       contexts,
       transactions,

--- a/packages/batch-submitter/src/batch-submitter/tx-batch-submitter.ts
+++ b/packages/batch-submitter/src/batch-submitter/tx-batch-submitter.ts
@@ -120,7 +120,7 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
 
   public async _getBatchStartAndEnd(): Promise<Range> {
     const startBlock =
-      (await this.chainContract.getTotalElements()).toNumber() + BLOCK_OFFSET // TODO: Remove BLOCK_OFFSET by removing Geth's genesis block
+      (await this.chainContract.getTotalElements()).toNumber() + BLOCK_OFFSET // TODO: Remove BLOCK_OFFSET by adding a tx to Geth's genesis
     const endBlock =
       Math.min(
         startBlock + this.maxBatchSize,
@@ -252,7 +252,7 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
     }
 
     return {
-      shouldStartAtBatch: shouldStartAtIndex - BLOCK_OFFSET, // TODO: Remove BLOCK_OFFSET by removing Geth's genesis block
+      shouldStartAtBatch: shouldStartAtIndex - BLOCK_OFFSET, // TODO: Remove BLOCK_OFFSET by adding a tx to Geth's genesis
       totalElementsToAppend,
       contexts,
       transactions,

--- a/packages/batch-submitter/src/batch-submitter/tx-batch-submitter.ts
+++ b/packages/batch-submitter/src/batch-submitter/tx-batch-submitter.ts
@@ -102,7 +102,7 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
       const queueElement = await this.chainContract.getQueueElement(
         nextQueueIndex
       )
-      this.lastL1BlockNumber = queueElement[2]  // The block number is the 3rd element returned in the array....
+      this.lastL1BlockNumber = queueElement[2] // The block number is the 3rd element returned in the array....
     } else {
       const curBlockNum = await this.chainContract.provider.getBlockNumber()
       if (!this.lastL1BlockNumber) {
@@ -120,7 +120,7 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
 
   public async _getBatchStartAndEnd(): Promise<Range> {
     const startBlock =
-      (await this.chainContract.getTotalElements()).toNumber() + 1  // TODO: Remove `+1` by removing Geth's genesis block
+      (await this.chainContract.getTotalElements()).toNumber() + 1 // TODO: Remove `+1` by removing Geth's genesis block
     const endBlock =
       Math.min(
         startBlock + this.maxBatchSize,
@@ -252,7 +252,7 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
     }
 
     return {
-      shouldStartAtBatch: shouldStartAtIndex - 1,  // TODO: Remove `-1` by removing Geth's genesis block
+      shouldStartAtBatch: shouldStartAtIndex - 1, // TODO: Remove `-1` by removing Geth's genesis block
       totalElementsToAppend,
       contexts,
       transactions,

--- a/packages/batch-submitter/src/batch-submitter/tx-batch-submitter.ts
+++ b/packages/batch-submitter/src/batch-submitter/tx-batch-submitter.ts
@@ -99,9 +99,10 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
 
     if (pendingQueueElements !== 0) {
       const nextQueueIndex = await this.chainContract.getNextQueueIndex()
-      this.lastL1BlockNumber = await this.chainContract.getQueueElement(
+      const queueElement = await this.chainContract.getQueueElement(
         nextQueueIndex
-      ).blockNumber
+      )
+      this.lastL1BlockNumber = queueElement[2]  // The block number is the 3rd element returned in the array....
     } else {
       const curBlockNum = await this.chainContract.provider.getBlockNumber()
       if (!this.lastL1BlockNumber) {
@@ -119,7 +120,7 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
 
   public async _getBatchStartAndEnd(): Promise<Range> {
     const startBlock =
-      parseInt(await this.chainContract.getTotalElements(), 16) + 1 // +1 to skip L2 genesis block
+      (await this.chainContract.getTotalElements()).toNumber() + 1  // TODO: Remove `+1` by removing Geth's genesis block
     const endBlock =
       Math.min(
         startBlock + this.maxBatchSize,
@@ -251,7 +252,7 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
     }
 
     return {
-      shouldStartAtBatch: shouldStartAtIndex - 1,
+      shouldStartAtBatch: shouldStartAtIndex - 1,  // TODO: Remove `-1` by removing Geth's genesis block
       totalElementsToAppend,
       contexts,
       transactions,


### PR DESCRIPTION
## Description
Tested the batch submitter against L1 and made a few fixes which solved the remaining issues. This should allow the batch submitter to be run against testnet without an issue.

### Note
The `lastL1BlockNumber` logic is very dumb and should be replaced ASAP with the correct logic added to L2Geth.

## Metadata
### Fixes
- Fixes https://github.com/ethereum-optimism/roadmap/issues/176

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
