### PR TITLE
Adding a hardhat plugin for ovm compilation

### DIFF
--- a/packages/ovm-toolchain/hardhat.config.ts
+++ b/packages/ovm-toolchain/hardhat.config.ts
@@ -19,7 +19,7 @@ const config: any = {
   solidity: {
     version: '0.5.16',
     settings: {},
-  }
+  },
 }
 
 export default config

--- a/packages/ovm-toolchain/hardhat.config.ts
+++ b/packages/ovm-toolchain/hardhat.config.ts
@@ -1,0 +1,25 @@
+import path from 'path'
+import { task } from 'hardhat/config'
+
+import '@nomiclabs/hardhat-ethers'
+import '@nomiclabs/hardhat-waffle'
+
+import './src/plugins/hardhat/ovm-compiler'
+
+const config: any = {
+  paths: {
+    sources: './test/common/contracts',
+    tests: './test/test-buidler',
+    cache: './test/temp/build/hardhat/cache',
+    artifacts: './test/temp/build/hardhat/artifacts',
+  },
+  mocha: {
+    timeout: 50000,
+  },
+  solidity: {
+    version: '0.5.16',
+    settings: {},
+  }
+}
+
+export default config

--- a/packages/ovm-toolchain/package.json
+++ b/packages/ovm-toolchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/ovm-toolchain",
-  "version": "0.0.2",
+  "version": "0.0.2-alpha.0",
   "description": "Wrappers for Ethereum dev tools",
   "main": "build/index.js",
   "private": true,

--- a/packages/ovm-toolchain/package.json
+++ b/packages/ovm-toolchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/ovm-toolchain",
-  "version": "0.0.1-alpha.12",
+  "version": "0.0.2",
   "description": "Wrappers for Ethereum dev tools",
   "main": "build/index.js",
   "private": true,
@@ -24,6 +24,7 @@
     "lint": "tslint --format stylish --project .",
     "fix": "prettier --config ../../prettier-config.json --write \"index.ts\" \"{deploy,test,src,bin}/**/*.ts\"",
     "build": "yarn run build:waffle && yarn run build:typescript",
+    "build:hardhat": "hardhat compile --show-stack-traces",
     "build:waffle": "waffle \"test/config/waffle-config.json\"",
     "build:typescript": "tsc -p .",
     "clean": "rimraf build/ && rimraf test/temp/",
@@ -77,6 +78,8 @@
     "@eth-optimism/core-utils": "^0.0.1-alpha.30",
     "@eth-optimism/ethereumjs-vm": "4.2.0-alpha.1",
     "@nomiclabs/buidler": "^1.4.4",
+    "@nomiclabs/hardhat-ethers": "^2.0.0",
+    "@nomiclabs/hardhat-waffle": "^2.0.0",
     "bn.js": "^5.1.3",
     "child_process": "^1.0.2",
     "ethereum-waffle": "3",
@@ -85,6 +88,7 @@
     "ethers-v4": "npm:ethers@4",
     "ethers-v5": "npm:ethers@5.0.7",
     "ethjs-common-v1": "npm:ethereumjs-common@1.5.0",
-    "ethjs-util-v6": "npm:ethereumjs-util@6.2.1"
+    "ethjs-util-v6": "npm:ethereumjs-util@6.2.1",
+    "hardhat": "^2.0.3"
   }
 }

--- a/packages/ovm-toolchain/src/plugins/hardhat/ovm-compiler.ts
+++ b/packages/ovm-toolchain/src/plugins/hardhat/ovm-compiler.ts
@@ -59,7 +59,7 @@ subtask(
       input: ovmInput,
       solcJsPath: ovmSolcPath,
     })
-    const evmOutput = await runSuper({ input: evmInput, solcPath: solcPath })
+    const evmOutput = await runSuper({ input: evmInput, solcPath })
 
     // Filter out any "No input sources specified" errors, but only if one of the two compilations
     // threw the error.
@@ -77,7 +77,7 @@ subtask(
         ...ovmOutput.contracts,
         ...evmOutput.contracts,
       },
-      errors: errors,
+      errors,
       sources: {
         ...ovmOutput.sources,
         ...evmOutput.sources,

--- a/packages/ovm-toolchain/src/plugins/hardhat/ovm-compiler.ts
+++ b/packages/ovm-toolchain/src/plugins/hardhat/ovm-compiler.ts
@@ -1,0 +1,89 @@
+import { subtask } from 'hardhat/config'
+import {
+  TASK_COMPILE_SOLIDITY_RUN_SOLCJS,
+  TASK_COMPILE_SOLIDITY_RUN_SOLC,
+} from 'hardhat/builtin-tasks/task-names'
+
+subtask(
+  TASK_COMPILE_SOLIDITY_RUN_SOLC,
+  async (
+    { input, solcPath }: { input: any; solcPath: string },
+    { config, run },
+    runSuper
+  ) => {
+    // Try to find a path to @eth-optimism/solc, throw if we can't.
+    let ovmSolcPath: string
+    try {
+      ovmSolcPath = require.resolve('@eth-optimism/solc/soljson.js')
+    } catch (err) {
+      if (err.toString().contains('Cannot find module')) {
+        throw new Error(
+          `ovm-toolchain: Could not find "@eth-optimism/solc" in your node_modules.`
+        )
+      } else {
+        throw err
+      }
+    }
+
+    const ovmInput = {
+      language: 'Solidity',
+      sources: {},
+      settings: input.settings,
+    }
+    const evmInput = {
+      language: 'Solidity',
+      sources: {},
+      settings: input.settings,
+    }
+
+    // Separate the EVM and OVM inputs.
+    const re = new RegExp('// +build (.*?)$', 'gm')
+    for (const file of Object.keys(input.sources)) {
+      const content = input.sources[file].content
+      const matches = content.match(re)
+
+      if (
+        matches &&
+        matches.some((match: string) => {
+          return match.includes('ovm')
+        })
+      ) {
+        ovmInput.sources[file] = input.sources[file]
+      } else {
+        evmInput.sources[file] = input.sources[file]
+      }
+    }
+
+    // Build both inputs separately.
+    const ovmOutput = await run(TASK_COMPILE_SOLIDITY_RUN_SOLCJS, {
+      input: ovmInput,
+      solcJsPath: ovmSolcPath,
+    })
+    const evmOutput = await runSuper({ input: evmInput, solcPath: solcPath })
+
+    // Filter out any "No input sources specified" errors, but only if one of the two compilations
+    // threw the error.
+    let errors = (ovmOutput.errors || []).concat(evmOutput.errors || [])
+    const filtered = errors.filter((error: any) => {
+      return error.message !== 'No input sources specified.'
+    })
+    if (errors.length === filtered.length + 1) {
+      errors = filtered
+    }
+
+    // Combine the outputs.
+    const output = {
+      contracts: {
+        ...ovmOutput.contracts,
+        ...evmOutput.contracts,
+      },
+      errors: errors,
+      sources: {
+        ...ovmOutput.sources,
+        ...evmOutput.sources,
+      },
+    }
+
+    return output
+  }
+)

--- a/packages/ovm-toolchain/test/common/contracts/ovm-contracts/OvmSimpleStorage.sol
+++ b/packages/ovm-toolchain/test/common/contracts/ovm-contracts/OvmSimpleStorage.sol
@@ -1,0 +1,13 @@
+// +build ovm
+pragma solidity ^0.5.0;
+
+contract SimpleStorage {
+    mapping(bytes32 => bytes32) public builtInStorage;
+    function setStorage(bytes32 key, bytes32 value) public {
+        builtInStorage[key] = value;
+    }
+
+    function getStorage(bytes32 key) public view returns (bytes32) {
+        return builtInStorage[key];
+    }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2132,6 +2132,19 @@
     safe-buffer "^5.1.1"
     util.promisify "^1.0.0"
 
+"@nomiclabs/hardhat-ethers@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@nomiclabs/hardhat-ethers/-/hardhat-ethers-2.0.0.tgz#ebab032b3aed03945ea560f56bb67aec56a30cbc"
+  integrity sha512-fIi6XP9PgKqwSNVcLDr6S5hvGlc21PendaLD5eGdXEXc9aYQ0OJX8Mk3evs+p78x7W9n9U3ZcKtTiGc1+YScDw==
+
+"@nomiclabs/hardhat-waffle@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@nomiclabs/hardhat-waffle/-/hardhat-waffle-2.0.0.tgz#b06533c802da1a9d614e432f719d2816384df9b3"
+  integrity sha512-CnG9JC0rgqa68LTgyETxBUEWYAovvNGVs5abqaXjG80eF7iMLjDjM8IjOM87siAaxaxFCf6VBMJmtueqVq7jZw==
+  dependencies:
+    "@types/sinon-chai" "^3.2.3"
+    "@types/web3" "1.0.19"
+
 "@octokit/auth-token@^2.4.0":
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/@octokit/auth-token/-/auth-token-2.4.2.tgz#10d0ae979b100fa6b72fa0e8e63e27e6d0dbff8a"
@@ -2360,6 +2373,11 @@
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/@solidity-parser/parser/-/parser-0.5.2.tgz#4d74670ead39e4f4fdab605a393ba8ea2390a2c4"
   integrity sha512-uRyvnvVYmgNmTBpWDbBsH/0kPESQhQpEc4KsvMRLVzFJ1o1s0uIv0Y6Y9IB5vI1Dwz2CbS4X/y4Wyw/75cTFnQ==
+
+"@solidity-parser/parser@^0.7.1":
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/@solidity-parser/parser/-/parser-0.7.1.tgz#660210130e4237476cb55e2882064809f80f861e"
+  integrity sha512-5ma2uuwPAEX1TPl2rAPAAuGlBkKnn2oUKQvnhTFlDIB8U/KDWX77FpHtL6Rcz+OwqSCWx9IClxACgyIEJ/GhIw==
 
 "@szmarczak/http-timer@^1.1.2":
   version "1.1.2"
@@ -2672,6 +2690,11 @@ accepts@~1.3.7:
   dependencies:
     mime-types "~2.1.24"
     negotiator "0.6.2"
+
+adm-zip@^0.4.16:
+  version "0.4.16"
+  resolved "https://registry.yarnpkg.com/adm-zip/-/adm-zip-0.4.16.tgz#cf4c508fdffab02c269cbc7f471a875f05570365"
+  integrity sha512-TFi4HBKSGfIKsK5YCkKaaFG2m4PEDyViZmEwof3MTIgzimHLto6muaHVpbrljdIvIrFZzEq/p4nafOeLcYegrg==
 
 aes-js@3.0.0:
   version "3.0.0"
@@ -7628,6 +7651,56 @@ hard-rejection@^2.1.0:
   resolved "https://registry.yarnpkg.com/hard-rejection/-/hard-rejection-2.1.0.tgz#1c6eda5c1685c63942766d79bb40ae773cecd883"
   integrity sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==
 
+hardhat@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/hardhat/-/hardhat-2.0.3.tgz#35e07060d9854d4182f201aeaa1c05316bd7e4d3"
+  integrity sha512-mDygAl+1qd5KBdXQBfc3R5XmC/rVdYYbEuOTSQY3rlncVu9gfockZVDsHtAMPw/FiBIRMApLcOceK7D1XQmHRw==
+  dependencies:
+    "@nomiclabs/ethereumjs-vm" "^4.1.1"
+    "@sentry/node" "^5.18.1"
+    "@solidity-parser/parser" "^0.7.1"
+    "@types/bn.js" "^4.11.5"
+    "@types/lru-cache" "^5.1.0"
+    abort-controller "^3.0.0"
+    adm-zip "^0.4.16"
+    ansi-escapes "^4.3.0"
+    chalk "^2.4.2"
+    chokidar "^3.4.0"
+    ci-info "^2.0.0"
+    debug "^4.1.1"
+    enquirer "^2.3.0"
+    env-paths "^2.2.0"
+    eth-sig-util "^2.5.2"
+    ethereum-cryptography "^0.1.2"
+    ethereumjs-abi "^0.6.8"
+    ethereumjs-account "^3.0.0"
+    ethereumjs-block "^2.2.0"
+    ethereumjs-common "^1.5.0"
+    ethereumjs-tx "^2.1.1"
+    ethereumjs-util "^6.1.0"
+    find-up "^2.1.0"
+    fp-ts "1.19.3"
+    fs-extra "^7.0.1"
+    glob "^7.1.3"
+    immutable "^4.0.0-rc.12"
+    io-ts "1.10.4"
+    lodash "^4.17.11"
+    merkle-patricia-tree "^3.0.0"
+    mocha "^7.1.2"
+    node-fetch "^2.6.0"
+    qs "^6.7.0"
+    raw-body "^2.4.1"
+    resolve "1.17.0"
+    semver "^6.3.0"
+    slash "^3.0.0"
+    solc "0.7.3"
+    source-map-support "^0.5.13"
+    stacktrace-parser "^0.1.10"
+    "true-case-path" "^2.2.1"
+    tsort "0.0.1"
+    uuid "^3.3.2"
+    ws "^7.2.1"
+
 has-ansi@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/has-ansi/-/has-ansi-2.0.0.tgz#34f5049ce1ecdf2b0649af3ef24e45ed35416d91"
@@ -7907,6 +7980,11 @@ immediate@~3.2.3:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.2.3.tgz#d140fa8f614659bd6541233097ddaac25cdd991c"
   integrity sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw=
+
+immutable@^4.0.0-rc.12:
+  version "4.0.0-rc.12"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.0.0-rc.12.tgz#ca59a7e4c19ae8d9bf74a97bdf0f6e2f2a5d0217"
+  integrity sha512-0M2XxkZLx/mi3t8NVwIm1g8nHoEmM9p9UBl/G9k4+hm0kBgOVdMV/B3CY5dQ8qG8qc80NN4gDV4HQv6FTJ5q7A==
 
 import-fresh@^2.0.0:
   version "2.0.0"
@@ -11661,11 +11739,19 @@ resolve-url@^0.2.1:
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
-resolve@^1.1.6, resolve@^1.1.7, resolve@^1.10.0, resolve@^1.3.2, resolve@^1.4.0, resolve@~1.17.0:
+resolve@1.17.0, resolve@~1.17.0:
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
   integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==
   dependencies:
+    path-parse "^1.0.6"
+
+resolve@^1.1.6, resolve@^1.1.7, resolve@^1.10.0, resolve@^1.17.0, resolve@^1.3.2, resolve@^1.4.0:
+  version "1.19.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.19.0.tgz#1af5bf630409734a067cae29318aac7fa29a267c"
+  integrity sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==
+  dependencies:
+    is-core-module "^2.1.0"
     path-parse "^1.0.6"
 
 responselike@1.0.2, responselike@^1.0.2:
@@ -12132,6 +12218,21 @@ solc@0.6.8:
     semver "^5.5.0"
     tmp "0.0.33"
 
+solc@0.7.3:
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/solc/-/solc-0.7.3.tgz#04646961bd867a744f63d2b4e3c0701ffdc7d78a"
+  integrity sha512-GAsWNAjGzIDg7VxzP6mPjdurby3IkGCjQcM8GFYZT6RyaoUZKmMU6Y7YwG+tFGhv7dwZ8rmR4iwFDrrD99JwqA==
+  dependencies:
+    command-exists "^1.2.8"
+    commander "3.0.2"
+    follow-redirects "^1.12.1"
+    fs-extra "^0.30.0"
+    js-sha3 "0.8.0"
+    memorystream "^0.3.1"
+    require-from-string "^2.0.0"
+    semver "^5.5.0"
+    tmp "0.0.33"
+
 solc@^0.4.20:
   version "0.4.26"
   resolved "https://registry.yarnpkg.com/solc/-/solc-0.4.26.tgz#5390a62a99f40806b86258c737c1cf653cc35cb5"
@@ -12339,6 +12440,13 @@ stack-trace@0.0.10:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.10.tgz#547c70b347e8d32b4e108ea1a2a159e5fdde19c0"
   integrity sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=
+
+stacktrace-parser@^0.1.10:
+  version "0.1.10"
+  resolved "https://registry.yarnpkg.com/stacktrace-parser/-/stacktrace-parser-0.1.10.tgz#29fb0cae4e0d0b85155879402857a1639eb6051a"
+  integrity sha512-KJP1OCML99+8fhOHxwwzyWrlUuVX5GQ0ZpJTd1DFXhdkrvg1szxfHhawXUZ3g9TkXORQd4/WG68jMlQZ2p8wlg==
+  dependencies:
+    type-fest "^0.7.1"
 
 static-extend@^0.1.1:
   version "0.1.2"
@@ -12947,6 +13055,11 @@ trim-right@^1.0.1:
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
   integrity sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=
 
+"true-case-path@^2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/true-case-path/-/true-case-path-2.2.1.tgz#c5bf04a5bbec3fd118be4084461b3a27c4d796bf"
+  integrity sha512-0z3j8R7MCjy10kc/g+qg7Ln3alJTodw9aDuVWZa3uiWqfuBMKeAeP2ocWcxoyM3D73yz3Jt/Pu4qPr4wHSdB/Q==
+
 truffle@^5.1.41:
   version "5.1.43"
   resolved "https://registry.yarnpkg.com/truffle/-/truffle-5.1.43.tgz#544e7b0955b6728a00761a86555c1eb259313266"
@@ -13089,6 +13202,11 @@ type-fest@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.6.0.tgz#8d2a2370d3df886eb5c90ada1c5bf6188acf838b"
   integrity sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==
+
+type-fest@^0.7.1:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.7.1.tgz#8dda65feaf03ed78f0a3f9678f1869147f7c5c48"
+  integrity sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==
 
 type-fest@^0.8.1:
   version "0.8.1"


### PR DESCRIPTION
## Description
Adds a new plugin for hardhat ovm compilation. No more need to provide a path to the ovm compiler, just uses `require.resolve` to figure out the right path and complains if `@eth-optimism/solc` doesn't exist in your node modules. Currently **does not** support compiling the same file with both the evm and ovm compilers.

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
