### PR TITLE
Add watcher tool

### DIFF
--- a/packages/ovm-toolchain/README.md
+++ b/packages/ovm-toolchain/README.md
@@ -87,29 +87,3 @@ const config = {
 
 export default config
 ```
-
-#### Watcher
-Our `Watcher` allows you to retrieve all transaction hashes related to cross domain messages such as deposits and withdrawals. In order to use, first send a transaction which sends a cross domain message, for example a deposit from L1 into L2. After sending the deposit transaction and storing the transaction hash, use `getMessageHashesFromL1Tx(l1TxHash)` to get an array of the message hashes of all of the L1->L2 messages that were sent inside of that L1 tx (This will usually just be a single element array, but it can return multiple if one L1 transaction triggers multiple deposits). `getMessageHashesFromL2Tx(l2TxHash)` does the same for L2->L1 messages. `onceL2Relay(messageHash, callback)` takes in an L1->L2 message hash and a callback that will be triggered after 2-5 minutes with the hash of the L2 tx that the message ends up getting relayed in. `onceL1Relay(messageHash, callback)` does the same for L2->L1 messages, except the delay is 7 days.
-
-```typescript
-import { Watcher } from '@eth-optimism/ovm-toolchain/'
-import { JsonRpcProvider } from 'ethers/providers'
-
-const watcher = new Watcher({
-  l1: {
-    provider: new JsonRpcProvider('INFURA_L1_URL'),
-    messengerAddress: '0x...'
-  },
-  l2: {
-    provider: new JsonRpcProvider('OPTIMISM_L2_URL'),
-    messengerAddress: '0x...'
-  }
-})
-const l1TxHash = (await depositContract.deposit(100)).hash
-const [messageHash] = await watcher.getMessageHashesFromL1Tx(l1TxHash)
-console.log('L1->L2 message hash:', messageHash)
-watcher.onceL2Relay(messageHash, (l2txhash) => {
-  // Takes 2-5 minutes
-  console.log('Got L2 Tx Hash:', l2txhash)
-})
-```

--- a/packages/ovm-toolchain/src/index.ts
+++ b/packages/ovm-toolchain/src/index.ts
@@ -1,4 +1,3 @@
 export * from './ganache'
 export * from './waffle'
 export * from './x-domain-utils'
-export * from './watcher'

--- a/packages/watcher/.gitignore
+++ b/packages/watcher/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+build/
+test/temp/

--- a/packages/watcher/README.md
+++ b/packages/watcher/README.md
@@ -1,0 +1,24 @@
+# @eth-optimism/watcher
+
+#### Watcher
+Our `Watcher` allows you to retrieve all transaction hashes related to cross domain messages such as deposits and withdrawals. In order to use, first send a transaction which sends a cross domain message, for example a deposit from L1 into L2. After sending the deposit transaction and storing the transaction hash, use `getMessageHashesFromL1Tx(l1TxHash)` to get an array of the message hashes of all of the L1->L2 messages that were sent inside of that L1 tx (This will usually just be a single element array, but it can return multiple if one L1 transaction triggers multiple deposits). `getMessageHashesFromL2Tx(l2TxHash)` does the same for L2->L1 messages. `getL2TransactionReceipt(messageHash)` takes in an L1->L2 message hash and then after 2-5 minutes, returns the receipt of the L2 tx that the message ends up getting relayed in. `getL1TransactionReceipt(messageHash)` does the same for L2->L1 messages, except the delay is 7 days.
+
+```typescript
+import { Watcher } from '@eth-optimism/ovm-toolchain/'
+import { JsonRpcProvider } from 'ethers/providers'
+
+const watcher = new Watcher({
+  l1: {
+    provider: new JsonRpcProvider('INFURA_L1_URL'),
+    messengerAddress: '0x...'
+  },
+  l2: {
+    provider: new JsonRpcProvider('OPTIMISM_L2_URL'),
+    messengerAddress: '0x...'
+  }
+})
+const l1TxHash = (await depositContract.deposit(100)).hash
+const [messageHash] = await watcher.getMessageHashesFromL1Tx(l1TxHash)
+console.log('L1->L2 message hash:', messageHash)
+const l2TxReceipt = await watcher.getL2TransactionReceipt(messageHash)
+```

--- a/packages/watcher/exec/run-watcher.js
+++ b/packages/watcher/exec/run-watcher.js
@@ -6,10 +6,8 @@ const {
 } = require('ethers');
 
 const env = process.env
-// const L1_WEB3_URL = env.L1_WEB3_URL || 'http://localhost:9545'
-// const L2_WEB3_URL = env.L2_WEB3_URL || 'http://localhost:8545'
-const L1_WEB3_URL = env.L1_WEB3_URL || 'http://192.168.1.112:8545'
-const L2_WEB3_URL = env.L2_WEB3_URL || 'http://mainnet.optimism.io:8545'
+const L1_WEB3_URL = env.L1_WEB3_URL || 'http://localhost:9545'
+const L2_WEB3_URL = env.L2_WEB3_URL || 'http://localhost:8545'
 
 // Note: be sure to use the proxy for the L1xdomain
 // messenger, not the implementation

--- a/packages/watcher/exec/run-watcher.js
+++ b/packages/watcher/exec/run-watcher.js
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+
+const { Watcher } = require("../build/src")
+const {
+	providers: { JsonRpcProvider },
+} = require('ethers');
+
+const l2Provider = new JsonRpcProvider('')
+const l1Provider = new JsonRpcProvider('')
+let watcher
+const initWatcher = () => {
+	watcher = new Watcher({
+		l1: {
+			provider: l1Provider,
+			messengerAddress: '0x'
+		},
+		l2: {
+			provider: l2Provider,
+			messengerAddress: '0x'
+		}
+	})
+}
+
+;(async ()=> {
+	initWatcher()
+	const msgHashes = await watcher.getMessageHashesFromL2Tx('')
+	console.log('got messages', msgHashes)
+	const receipt = await watcher.getL1TransactionReceipt(msgHashes[0])
+	console.log('got receipt:', receipt)
+})()

--- a/packages/watcher/index.ts
+++ b/packages/watcher/index.ts
@@ -1,0 +1,1 @@
+export * from './src'

--- a/packages/watcher/package.json
+++ b/packages/watcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/watcher",
-  "version": "0.0.1-alpha.4",
+  "version": "0.0.1-alpha.6",
   "description": "Watcher for cross domain messages",
   "main": "build/index.js",
   "files": [

--- a/packages/watcher/package.json
+++ b/packages/watcher/package.json
@@ -1,0 +1,58 @@
+{
+  "name": "@eth-optimism/watcher",
+  "version": "0.0.1-alpha.4",
+  "description": "Watcher for cross domain messages",
+  "main": "build/index.js",
+  "files": [
+    "build/**/*.js"
+  ],
+  "workspaces": {
+    "nohoist": [
+      "**/@nomiclabs",
+      "**/@nomiclabs/**",
+      "**/typescript",
+      "**/typescript/**",
+      "**/ts-node",
+      "**/ts-node/**"
+    ]
+  },
+  "scripts": {
+    "all": "yarn clean && yarn build && yarn test && yarn fix && yarn lint",
+    "lint": "tslint --format stylish --project .",
+    "fix": "prettier --config ../../prettier-config.json --write \"index.ts\" \"{deploy,test,src,bin}/**/*.ts\"",
+    "build": "yarn run build:typescript",
+    "build:typescript": "tsc -p .",
+    "clean": "rimraf build/"
+  },
+  "keywords": [
+    "optimistic",
+    "rollup",
+    "group",
+    "ethereum",
+    "smart",
+    "contract"
+  ],
+  "author": "Optimism",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ethereum-optimism/optimism-monorepo.git"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "devDependencies": {
+    "@types/chai": "^4.1.7",
+    "@types/mocha": "^5.2.6",
+    "@types/node": "^11.11.3",
+    "chai": "^4.2.0",
+    "chai-as-promised": "^7.1.1",
+    "mocha": "^6.0.2",
+    "rimraf": "^2.6.3",
+    "ts-node": "^8.10.2",
+    "typescript": "^3.3.3333"
+  },
+  "dependencies": {
+    "ethers": "5.0.0"
+  }
+}

--- a/packages/watcher/src/index.ts
+++ b/packages/watcher/src/index.ts
@@ -1,0 +1,1 @@
+export * from './watcher'

--- a/packages/watcher/src/watcher.ts
+++ b/packages/watcher/src/watcher.ts
@@ -48,7 +48,11 @@ export class Watcher {
         log.address === layer.messengerAddress &&
         log.topics[0] === ethers.utils.id('SentMessage(bytes)')
       ) {
-        msgHashes.push(ethers.utils.solidityKeccak256(['bytes'], [log.data]))
+        const [message] = ethers.utils.defaultAbiCoder.decode(
+          ['bytes'],
+          log.data
+        )
+        msgHashes.push(ethers.utils.solidityKeccak256(['bytes'], [message]))
       }
     }
     return msgHashes

--- a/packages/watcher/src/watcher.ts
+++ b/packages/watcher/src/watcher.ts
@@ -42,6 +42,10 @@ export class Watcher {
   ): Promise<string[]> {
     const layer = isL1 ? this.l1 : this.l2
     const receipt = await layer.provider.getTransactionReceipt(txHash)
+    if (!receipt) {
+      return []
+    }
+
     const msgHashes = []
     for (const log of receipt.logs) {
       if (

--- a/packages/watcher/src/watcher.ts
+++ b/packages/watcher/src/watcher.ts
@@ -1,0 +1,98 @@
+/* External Imports */
+import { ethers } from 'ethers'
+
+interface Layer {
+  provider: any
+  messengerAddress: string
+}
+
+interface WatcherOptions {
+  l1: Layer
+  l2: Layer
+}
+
+export class Watcher {
+  public l1: Layer
+  public l2: Layer
+  public NUM_BLOCKS_TO_FETCH: number = 10_000_000
+
+  constructor(opts: WatcherOptions) {
+    this.l1 = opts.l1
+    this.l2 = opts.l2
+  }
+
+  public async getMessageHashesFromL1Tx(l1TxHash: string): Promise<string[]> {
+    return this._getMessageHashesFromTx(true, l1TxHash)
+  }
+  public async getMessageHashesFromL2Tx(l2TxHash: string): Promise<string[]> {
+    return this._getMessageHashesFromTx(false, l2TxHash)
+  }
+
+  public async getL1TransactionReceipt(l2ToL1MsgHash: string): Promise<any> {
+    return this._getLXTransactionReceipt(true, l2ToL1MsgHash)
+  }
+
+  public async getL2TransactionReceipt(l1ToL2MsgHash: string): Promise<any> {
+    return this._getLXTransactionReceipt(false, l1ToL2MsgHash)
+  }
+
+  private async _getMessageHashesFromTx(
+    isL1: boolean,
+    txHash: string
+  ): Promise<string[]> {
+    const layer = isL1 ? this.l1 : this.l2
+    const receipt = await layer.provider.getTransactionReceipt(txHash)
+    const msgHashes = []
+    for (const log of receipt.logs) {
+      if (
+        log.address === layer.messengerAddress &&
+        log.topics[0] === ethers.utils.id('SentMessage(bytes)')
+      ) {
+        msgHashes.push(ethers.utils.solidityKeccak256(['bytes'], [log.data]))
+      }
+    }
+    return msgHashes
+  }
+
+  public async _getLXTransactionReceipt(
+    isL1: boolean,
+    msgHash: string
+  ): Promise<any> {
+    const layer = isL1 ? this.l1 : this.l2
+    const blockNumber = await layer.provider.getBlockNumber()
+    const startingBlock = Math.max(blockNumber - this.NUM_BLOCKS_TO_FETCH, 0)
+    const filter = {
+      address: layer.messengerAddress,
+      topics: [ethers.utils.id(`RelayedMessage(bytes32)`)],
+      fromBlock: startingBlock,
+    }
+    const logs = await layer.provider.getLogs(filter)
+    const matches = logs.filter((log: any) => log.data === msgHash)
+
+    // Message was relayed in the past
+    if (matches.length > 0) {
+      if (matches.length > 1) {
+        throw Error(
+          'Found multiple transactions relaying the same message hash.'
+        )
+      }
+      return layer.provider.getTransactionReceipt(matches[0].transactionHash)
+    }
+
+    // Message has yet to be relayed
+    return new Promise(async (resolve, reject) => {
+      layer.provider.on(filter, async (log: any) => {
+        if (log.data === msgHash) {
+          try {
+            const txReceipt = await layer.provider.getTransactionReceipt(
+              log.transactionHash
+            )
+            resolve(txReceipt)
+          } catch (e) {
+            reject(e)
+          }
+        }
+      })
+    })
+  }
+}

--- a/packages/watcher/src/watcher.ts
+++ b/packages/watcher/src/watcher.ts
@@ -28,11 +28,17 @@ export class Watcher {
     return this._getMessageHashesFromTx(false, l2TxHash)
   }
 
-  public async getL1TransactionReceipt(l2ToL1MsgHash: string, pollForPending: boolean = true): Promise<any> {
+  public async getL1TransactionReceipt(
+    l2ToL1MsgHash: string,
+    pollForPending: boolean = true
+  ): Promise<any> {
     return this._getLXTransactionReceipt(true, l2ToL1MsgHash, pollForPending)
   }
 
-  public async getL2TransactionReceipt(l1ToL2MsgHash: string, pollForPending: boolean = true): Promise<any> {
+  public async getL2TransactionReceipt(
+    l1ToL2MsgHash: string,
+    pollForPending: boolean = true
+  ): Promise<any> {
     return this._getLXTransactionReceipt(false, l1ToL2MsgHash, pollForPending)
   }
 

--- a/packages/watcher/tsconfig.json
+++ b/packages/watcher/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./build",
+    "baseUrl": "./",
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "allowJs": true
+  },
+  "include": ["*.ts", "**/*.ts", "artifacts/*.json"],
+  "exclude": ["./build", "node_modules"]
+}

--- a/packages/watcher/tslint.json
+++ b/packages/watcher/tslint.json
@@ -1,0 +1,7 @@
+{
+  "extends": ["./../../tslint.json"],
+  "rules": {
+    "prettier": [true, "../../prettier-config.json"],
+    "no-console": false
+  }
+}


### PR DESCRIPTION
## Description
Adds the watcher tool, which allows front-ends to watch for cross domain messages and receive the transaction receipt of the cross domain message when it is relayed to its destination.
## Questions
- 
-
-

## Metadata
### Fixes
- Fixes # [Link to Issue]

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
