### PR TITLE
Change MIN_TX_SIZE to be in bytes

### DIFF
--- a/packages/batch-submitter/src/batch-submitter/state-batch-submitter.ts
+++ b/packages/batch-submitter/src/batch-submitter/state-batch-submitter.ts
@@ -98,7 +98,7 @@ export class StateBatchSubmitter extends BatchSubmitter {
       'appendStateBatch',
       [batch, startBlock]
     )
-    if (tx.length < this.minTxSize) {
+    if (tx.length < this.minTxSize * 2) {
       this.log.info('State batch too small. Skipping batch submission...')
       return
     }


### PR DESCRIPTION
## Description
Quick bug fix where the state batch submitter was not using bytes for the MIN_TX_SIZE .

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
