### PR TITLE
Allow batch submitter to intentionally commit fraud

### DIFF
--- a/packages/batch-submitter/src/batch-submitter/state-batch-submitter.ts
+++ b/packages/batch-submitter/src/batch-submitter/state-batch-submitter.ts
@@ -152,7 +152,9 @@ export class StateBatchSubmitter extends BatchSubmitter {
         i
       )) as L2Block
       if (block.transactions[0].from === this.fraudSubmissionAddress) {
-        batch.push(ethers.utils.keccak256(Date.now().toString(16)))
+        batch.push(
+          '0xbad1bad1bad1bad1bad1bad1bad1bad1bad1bad1bad1bad1bad1bad1bad1bad1'
+        )
       } else {
         batch.push(block.stateRoot)
       }

--- a/packages/batch-submitter/src/exec/run-batch-submitter.ts
+++ b/packages/batch-submitter/src/exec/run-batch-submitter.ts
@@ -32,7 +32,6 @@ interface RequiredEnvVars {
   FINALITY_CONFIRMATIONS: 'FINALITY_CONFIRMATIONS'
   RUN_TX_BATCH_SUBMITTER: 'true' | 'false' | 'RUN_TX_BATCH_SUBMITTER'
   RUN_STATE_BATCH_SUBMITTER: 'true' | 'false' | 'RUN_STATE_BATCH_SUBMITTER'
-  FRAUD_SUBMISSION_ADDRESS: 'FRAUD_SUBMISSION_ADDRESS'
 }
 const requiredEnvVars: RequiredEnvVars = {
   SEQUENCER_PRIVATE_KEY: 'SEQUENCER_PRIVATE_KEY',
@@ -46,8 +45,10 @@ const requiredEnvVars: RequiredEnvVars = {
   FINALITY_CONFIRMATIONS: 'FINALITY_CONFIRMATIONS',
   RUN_TX_BATCH_SUBMITTER: 'RUN_TX_BATCH_SUBMITTER',
   RUN_STATE_BATCH_SUBMITTER: 'RUN_STATE_BATCH_SUBMITTER',
-  FRAUD_SUBMISSION_ADDRESS: 'FRAUD_SUBMISSION_ADDRESS',
 }
+/** Optional Env Vars
+ * FRAUD_SUBMISSION_ADDRESS
+ */
 
 export const run = async () => {
   log.info('Starting batch submitter...')
@@ -93,7 +94,7 @@ export const run = async () => {
     parseInt(requiredEnvVars.FINALITY_CONFIRMATIONS, 10),
     true,
     getLogger(STATE_BATCH_SUBMITTER_LOG_TAG),
-    requiredEnvVars.FRAUD_SUBMISSION_ADDRESS
+    process.env.FRAUD_SUBMISSION_ADDRESS || 'no fraud'
   )
 
   // Loops infinitely!

--- a/packages/batch-submitter/src/exec/run-batch-submitter.ts
+++ b/packages/batch-submitter/src/exec/run-batch-submitter.ts
@@ -32,6 +32,7 @@ interface RequiredEnvVars {
   FINALITY_CONFIRMATIONS: 'FINALITY_CONFIRMATIONS'
   RUN_TX_BATCH_SUBMITTER: 'true' | 'false' | 'RUN_TX_BATCH_SUBMITTER'
   RUN_STATE_BATCH_SUBMITTER: 'true' | 'false' | 'RUN_STATE_BATCH_SUBMITTER'
+  FRAUD_SUBMISSION_ADDRESS: 'FRAUD_SUBMISSION_ADDRESS'
 }
 const requiredEnvVars: RequiredEnvVars = {
   SEQUENCER_PRIVATE_KEY: 'SEQUENCER_PRIVATE_KEY',
@@ -45,6 +46,7 @@ const requiredEnvVars: RequiredEnvVars = {
   FINALITY_CONFIRMATIONS: 'FINALITY_CONFIRMATIONS',
   RUN_TX_BATCH_SUBMITTER: 'RUN_TX_BATCH_SUBMITTER',
   RUN_STATE_BATCH_SUBMITTER: 'RUN_STATE_BATCH_SUBMITTER',
+  FRAUD_SUBMISSION_ADDRESS: 'FRAUD_SUBMISSION_ADDRESS',
 }
 
 export const run = async () => {
@@ -90,7 +92,8 @@ export const run = async () => {
     parseInt(requiredEnvVars.NUM_CONFIRMATIONS, 10),
     parseInt(requiredEnvVars.FINALITY_CONFIRMATIONS, 10),
     true,
-    getLogger(STATE_BATCH_SUBMITTER_LOG_TAG)
+    getLogger(STATE_BATCH_SUBMITTER_LOG_TAG),
+    requiredEnvVars.FRAUD_SUBMISSION_ADDRESS
   )
 
   // Loops infinitely!

--- a/packages/batch-submitter/src/exec/run-batch-submitter.ts
+++ b/packages/batch-submitter/src/exec/run-batch-submitter.ts
@@ -46,7 +46,7 @@ const requiredEnvVars: RequiredEnvVars = {
   RUN_TX_BATCH_SUBMITTER: 'RUN_TX_BATCH_SUBMITTER',
   RUN_STATE_BATCH_SUBMITTER: 'RUN_STATE_BATCH_SUBMITTER',
 }
-/** Optional Env Vars
+/* Optional Env Vars
  * FRAUD_SUBMISSION_ADDRESS
  */
 


### PR DESCRIPTION
## Description
A quick change to the state root batch submission to intentionally commit fraud if we so desire. (useful for the fraud proof security drill! The point is we'd get caught if we ever did this!!)


## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
