### PR TITLE
Fix node version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ cd optimism-monorepo
 #### Node.js
 Most of the projects in `optimism-monorepo` are [`Node.js`](https://nodejs.org/en/) projects.
 You'll need to install `Node.js` for your system before continuing.
-All code is only confirmed to work on `Node.js v11.6`, and there are known issues on more recent versions. Please [set your Node.js version to 11.6](https://stackoverflow.com/a/23569481). 
+All code is only confirmed to work on `Node.js v10.16.0`, and there are known issues on more recent versions. Please [set your Node.js version to 10.16.0](https://stackoverflow.com/a/23569481). 
 
 #### Yarn
 We're using a package manager called [Yarn](https://yarnpkg.com/en/).


### PR DESCRIPTION
## Description

The README specified using Node v11.6, but the packages require Node v10. Specifically v10.16.0 is what's used according to @K-Ho. This PR updates the README to specify Node v10.16.0

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
