### PR TITLE
rollup: disable queue batch append flag

### DIFF
--- a/packages/batch-submitter/src/batch-submitter/tx-batch-submitter.ts
+++ b/packages/batch-submitter/src/batch-submitter/tx-batch-submitter.ts
@@ -114,7 +114,7 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
         `Syncing mode enabled! Skipping batch submission and clearing ${pendingQueueElements} queue elements`
       )
 
-      if (this.disableQueueBatchAppend) {
+      if (!this.disableQueueBatchAppend) {
         // Empty the queue with a huge `appendQueueBatch(..)` call
         return this._submitAndLogTx(
           this.chainContract.appendQueueBatch(99999999),

--- a/packages/batch-submitter/src/batch-submitter/tx-batch-submitter.ts
+++ b/packages/batch-submitter/src/batch-submitter/tx-batch-submitter.ts
@@ -8,6 +8,8 @@ import {
   getContractInterface,
   getContractFactory,
 } from '@eth-optimism/contracts'
+import { OptimismProvider } from '@eth-optimism/provider'
+import { Logger } from '@eth-optimism/core-utils'
 
 /* Internal Imports */
 import {
@@ -38,6 +40,33 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
   protected l2ChainId: number
   protected syncing: boolean
   protected lastL1BlockNumber: number
+  private disableQueueBatchAppend: boolean
+
+  constructor(
+    signer: Signer,
+    l2Provider: OptimismProvider,
+    minTxSize: number,
+    maxTxSize: number,
+    maxBatchSize: number,
+    numConfirmations: number,
+    finalityConfirmations: number,
+    pullFromAddressManager: boolean,
+    log: Logger,
+    disableQueueBatchAppend: boolean
+  ) {
+    super(
+      signer,
+      l2Provider,
+      minTxSize,
+      maxTxSize,
+      maxBatchSize,
+      numConfirmations,
+      finalityConfirmations,
+      pullFromAddressManager,
+      log
+    )
+    this.disableQueueBatchAppend = disableQueueBatchAppend
+  }
 
   /*****************************
    * Batch Submitter Overrides *
@@ -84,11 +113,14 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
       this.log.info(
         `Syncing mode enabled! Skipping batch submission and clearing ${pendingQueueElements} queue elements`
       )
-      // Empty the queue with a huge `appendQueueBatch(..)` call
-      return this._submitAndLogTx(
-        this.chainContract.appendQueueBatch(99999999),
-        'Cleared queue!'
-      )
+
+      if (this.disableQueueBatchAppend) {
+        // Empty the queue with a huge `appendQueueBatch(..)` call
+        return this._submitAndLogTx(
+          this.chainContract.appendQueueBatch(99999999),
+          'Cleared queue!'
+        )
+      }
     }
     this.log.info('Syncing mode enabled but queue is empty. Skipping...')
     return

--- a/packages/batch-submitter/src/exec/run-batch-submitter.ts
+++ b/packages/batch-submitter/src/exec/run-batch-submitter.ts
@@ -50,6 +50,7 @@ const requiredEnvVars: RequiredEnvVars = {
 }
 /* Optional Env Vars
  * FRAUD_SUBMISSION_ADDRESS
+ * DISABLE_QUEUE_BATCH_APPEND
  */
 
 export const run = async () => {
@@ -83,7 +84,8 @@ export const run = async () => {
     parseInt(requiredEnvVars.NUM_CONFIRMATIONS, 10),
     parseInt(requiredEnvVars.NUM_CONFIRMATIONS, 10),
     true,
-    getLogger(TX_BATCH_SUBMITTER_LOG_TAG)
+    getLogger(TX_BATCH_SUBMITTER_LOG_TAG),
+    !!process.env.DISABLE_QUEUE_BATCH_APPEND
   )
 
   const stateBatchSubmitter = new StateBatchSubmitter(

--- a/packages/batch-submitter/test/batch-submitter/transaction-batch-submitter.spec.ts
+++ b/packages/batch-submitter/test/batch-submitter/transaction-batch-submitter.spec.ts
@@ -153,7 +153,8 @@ describe('TransactionBatchSubmitter', () => {
         1,
         1,
         false,
-        getLogger(TX_BATCH_SUBMITTER_LOG_TAG)
+        getLogger(TX_BATCH_SUBMITTER_LOG_TAG),
+        false
       )
     })
 


### PR DESCRIPTION
## Description

Adds a config option to disable queue batch append transactions

## Metadata
### Fixes
- Fixes # [Link to Issue]

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
