### PR TITLE
Fix batch submitter monotonicity

### DIFF
--- a/packages/batch-submitter/src/batch-submitter/tx-batch-submitter.ts
+++ b/packages/batch-submitter/src/batch-submitter/tx-batch-submitter.ts
@@ -225,8 +225,13 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
       lastBlockNumber = block.blockNumber
     }
     for (const groupedBlock of groupedBlocks) {
-      if (groupedBlock.sequenced.length === 0 && groupedBlock.queued.length === 0) {
-        throw new Error('Attempted to generate batch context with 0 queued and 0 sequenced txs!')
+      if (
+        groupedBlock.sequenced.length === 0 &&
+        groupedBlock.queued.length === 0
+      ) {
+        throw new Error(
+          'Attempted to generate batch context with 0 queued and 0 sequenced txs!'
+        )
       }
       contexts.push({
         numSequencedTransactions: groupedBlock.sequenced.length,

--- a/packages/batch-submitter/src/batch-submitter/tx-batch-submitter.ts
+++ b/packages/batch-submitter/src/batch-submitter/tx-batch-submitter.ts
@@ -225,17 +225,20 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
       lastBlockNumber = block.blockNumber
     }
     for (const groupedBlock of groupedBlocks) {
+      if (groupedBlock.sequenced.length === 0 && groupedBlock.queued.length === 0) {
+        throw new Error('Attempted to generate batch context with 0 queued and 0 sequenced txs!')
+      }
       contexts.push({
         numSequencedTransactions: groupedBlock.sequenced.length,
         numSubsequentQueueTransactions: groupedBlock.queued.length,
         timestamp:
           groupedBlock.sequenced.length > 0
             ? groupedBlock.sequenced[0].timestamp
-            : 0,
+            : groupedBlock.queued[0].timestamp,
         blockNumber:
           groupedBlock.sequenced.length > 0
             ? groupedBlock.sequenced[0].blockNumber
-            : 0,
+            : groupedBlock.queued[0].blockNumber,
       })
     }
 

--- a/packages/batch-submitter/src/batch-submitter/tx-batch-submitter.ts
+++ b/packages/batch-submitter/src/batch-submitter/tx-batch-submitter.ts
@@ -228,7 +228,6 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
       if (groupedBlock.sequenced.length === 0 && groupedBlock.queued.length === 0) {
         throw new Error('Attempted to generate batch context with 0 queued and 0 sequenced txs!')
       }
-      console.log('pushing context!')
       contexts.push({
         numSequencedTransactions: groupedBlock.sequenced.length,
         numSubsequentQueueTransactions: groupedBlock.queued.length,

--- a/packages/batch-submitter/src/batch-submitter/tx-batch-submitter.ts
+++ b/packages/batch-submitter/src/batch-submitter/tx-batch-submitter.ts
@@ -228,6 +228,7 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
       if (groupedBlock.sequenced.length === 0 && groupedBlock.queued.length === 0) {
         throw new Error('Attempted to generate batch context with 0 queued and 0 sequenced txs!')
       }
+      console.log('pushing context!')
       contexts.push({
         numSequencedTransactions: groupedBlock.sequenced.length,
         numSubsequentQueueTransactions: groupedBlock.queued.length,


### PR DESCRIPTION
## Description
Fixes batch submitter monotonicity for contexts that have 0 sequencer txs, but >0 queued txs. This PR sets these contexts' block number and timestamp to the block number and timestamp of the first subsequent queued tx in the context
## Questions
- 
-
-

## Metadata
### Fixes
- Fixes # [Link to Issue]

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [ ] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
