### PR TITLE
added "from" in allowedTransactionKeys list

### DIFF
--- a/packages/provider/src/app/utils.ts
+++ b/packages/provider/src/app/utils.ts
@@ -70,6 +70,7 @@ export const allowedTransactionKeys: { [key: string]: boolean } = {
   nonce: true,
   to: true,
   value: true,
+  from: true,
 }
 
 export function serializeEthSignTransaction(transaction): Bytes {


### PR DESCRIPTION
## Description

It looks like the `from` key is missing in the `allowedTransactionKeys` list, which means a signer (with a "from" address) cannot use `call(transaction)`. Only providers can call this function, which I think is an issue as many dApps are using signers and not providers to interact with the read only functions in smart contracts.

Here is the error:

```
Error: invalid transaction key: from (argument="transaction", value={"data":"[DATA]","to":"[CONTRACT ADDRESS]","from":"[SIGNER ADDRESS]"}, code=INVALID_ARGUMENT, version=)
```

