### PR TITLE
fix: core-utils signature

### DIFF
--- a/packages/core-utils/package.json
+++ b/packages/core-utils/package.json
@@ -1,11 +1,12 @@
 {
   "name": "@eth-optimism/core-utils",
-  "version": "0.1.1",
+  "version": "0.1.4",
   "description": "Optimism Core Utils",
-  "main": "build/index.js",
-  "types": "build/index.d.ts",
+  "main": "build/src/index.js",
+  "types": "build/src/index.d.ts",
   "files": [
-    "build/**/*.js"
+    "build/src/*",
+    "build/src/**/*"
   ],
   "scripts": {
     "all": "yarn clean && yarn build && yarn test && yarn lint:fix && yarn lint",

--- a/packages/core-utils/src/coders/ecdsa-coder.ts
+++ b/packages/core-utils/src/coders/ecdsa-coder.ts
@@ -1,5 +1,5 @@
 /* Internal Imports */
-import { remove0x, toVerifiedBytes, encodeHex, getLen } from '../utils'
+import { add0x, remove0x, toVerifiedBytes, encodeHex, getLen } from '../utils'
 import {
   Coder,
   Signature,
@@ -149,15 +149,15 @@ class DefaultEcdsaTxCoder implements Coder {
 
     return {
       sig: {
-        r: sliceBytes(pos.sig.r),
-        s: sliceBytes(pos.sig.s),
-        v: sliceBytes(pos.sig.v),
+        r: add0x(sliceBytes(pos.sig.r)),
+        s: add0x(sliceBytes(pos.sig.s)),
+        v: parseInt(sliceBytes(pos.sig.v), 16),
       },
       gasLimit: parseInt(sliceBytes(pos.gasLimit), 16),
       gasPrice: parseInt(sliceBytes(pos.gasPrice), 16),
       nonce: parseInt(sliceBytes(pos.nonce), 16),
-      target: sliceBytes(pos.target),
-      data: txData.slice(pos.data.start * 2),
+      target: add0x(sliceBytes(pos.target)),
+      data: add0x(txData.slice(pos.data.start * 2)),
     }
   }
 }

--- a/packages/core-utils/src/coders/types.ts
+++ b/packages/core-utils/src/coders/types.ts
@@ -1,7 +1,7 @@
 export interface Signature {
   r: string
   s: string
-  v: string
+  v: number
 }
 export type Bytes32 = string
 export type Uint16 = number

--- a/packages/core-utils/test/batch-encoder.spec.ts
+++ b/packages/core-utils/test/batch-encoder.spec.ts
@@ -13,15 +13,15 @@ describe('BatchEncoder', () => {
     it('should encode & then decode to the correct value', () => {
       const eip155TxData = {
         sig: {
-          v: '01',
-          r: '11'.repeat(32),
-          s: '22'.repeat(32),
+          v: 1,
+          r: '0x' + '11'.repeat(32),
+          s: '0x' + '22'.repeat(32),
         },
         gasLimit: 500,
         gasPrice: 100,
         nonce: 100,
-        target: '12'.repeat(20),
-        data: '99'.repeat(10),
+        target: '0x' + '12'.repeat(20),
+        data: '0x' + '99'.repeat(10),
       }
       const encoded = ctcCoder.eip155TxData.encode(eip155TxData)
       const decoded = ctcCoder.eip155TxData.decode(encoded)


### PR DESCRIPTION
## Description

Adds `0x` prefixes where they are missing as well as decodes the `v` value in the signature as an integer to follow how ethers does it.

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
