### PR TITLE
Add rawTransaction to transaction output

### DIFF
--- a/packages/provider/src/app/provider.ts
+++ b/packages/provider/src/app/provider.ts
@@ -82,6 +82,7 @@ export class OptimismProvider extends JsonRpcProvider {
       const tx = formatTxResponse(transaction) as any
       tx.txType = transaction.txType
       tx.queueOrigin = transaction.queueOrigin
+      tx.rawTransaction = transaction.rawTransaction
       tx.l1BlockNumber = transaction.l1BlockNumber
       if (tx.l1BlockNumber != null) {
         tx.l1BlockNumber = parseInt(tx.l1BlockNumber, 16)


### PR DESCRIPTION
## Description
We should be operating on the raw transaction information. In order to do this we need to not filter out the `rawTransaction` field on the `getTransaction` response in Geth.

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](https://github.com/ethereum-optimism/optimism-monorepo/blob/master/.github/CONTRIBUTING.md) and am following those guidelines in this pull request.
